### PR TITLE
Ember cli postcss

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,10 @@
+{
+    "extends": "stylelint-config-standard",
+    "rules": {
+        "at-rule-no-vendor-prefix": true,
+        "media-feature-name-no-vendor-prefix": true,
+        "property-no-vendor-prefix": true,
+        "selector-no-vendor-prefix": true,
+        "value-no-vendor-prefix": true
+    }
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -21,7 +21,7 @@
 
 body {
   font-family: 'Open Sans', sans-serif;
-  background-color: #f2f3f4;
+  background-color: var(--light-grey1);
 }
 
 .body {
@@ -37,7 +37,7 @@ body {
 .container .title {
   display: block;
   text-rendering: optimizeLegibility;
-  color: #484c58;
+  color: var(--dark-grey5);
   font-size: 30px;
   font-weight: 600;
   margin-bottom: 20px;

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -3,10 +3,12 @@
 @import url('globals/form.css');
 @import url('globals/groupped-input.css');
 @import url('globals/rounded-panel.css');
+
 /* components */
 @import url('components/app-header.css');
 @import url('components/identification-form.css');
 @import url('components/challenge-item.css');
+
 /* views */
 @import url('home.css');
 @import url('home-loading.css');

--- a/app/styles/components/app-header.css
+++ b/app/styles/components/app-header.css
@@ -1,3 +1,5 @@
+@import url('../globals/palette.css');
+
 #app-header .navbar {
   background-color: #fff;
   box-shadow: 0 1px 0 0 #dedfe2;
@@ -47,10 +49,10 @@
 
 #app-header a:hover,
 #app-header a:focus {
-  color: #2F70FB;
+  color: var(--pix-blue);
 }
 
 #app-header a:active {
-  color: #FDBD2C;
+  color: var(--pix-yellow);
 }
 

--- a/app/styles/components/app-header.css
+++ b/app/styles/components/app-header.css
@@ -1,58 +1,59 @@
 @import url('../globals/palette.css');
 
-#app-header .navbar {
-  background-color: #fff;
-  box-shadow: 0 1px 0 0 #dedfe2;
-  border-radius: 0;
-  border: none;
-  min-height: 80px;
-  margin-top: 0;
-  overflow: visible;
-  z-index: 4;
-}
+#app-header {
 
-#app-header .navbar-brand {
-  padding: 0 10px;
-  line-height: 80px;
-}
+  & .navbar {
+    background-color: #fff;
+    box-shadow: 0 1px 0 0 var(--light-grey4);
+    border-radius: 0;
+    border: none;
+    min-height: 80px;
+    margin-top: 0;
+    overflow: visible;
+    z-index: 4;
+  }
 
-#app-header .navbar-brand > img {
-  max-height: 80px;
-  padding-bottom: 8px;
-  padding-top: 2px;
-}
+  & .navbar-brand {
+    padding: 0 10px;
+    line-height: 80px;
 
-#app-header .navbar-form {
-  margin-top: 23px;
-}
+    & > img {
+      max-height: 80px;
+      padding-bottom: 8px;
+      padding-top: 2px;
+    }
+  }
 
-#app-header .navbar-nav > li > a {
-  padding-top: 30px;
-  padding-bottom: 30px;
-}
+  & .navbar-form {
+    margin-top: 23px;
+  }
 
-#app-header a {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-smoothing: antialiased;
-  font-weight: 700;
-  font-size: 13px;
-  text-transform: uppercase;
-  letter-spacing: .025em;
-  display: inline-block;
-  padding: 22px 20px 18px;
-  color: #3E4149;
-  text-decoration: none;
-  background-color: #fff;
-  width: 100%;
-}
+  & .navbar-nav > li > a {
+    padding-top: 30px;
+    padding-bottom: 30px;
+  }
 
-#app-header a:hover,
-#app-header a:focus {
-  color: var(--pix-blue);
-}
+  & a {
+    font-smoothing: antialiased;
+    font-weight: 700;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .025em;
+    display: inline-block;
+    padding: 22px 20px 18px;
+    color: #3E4149;
+    text-decoration: none;
+    background-color: #fff;
+    width: 100%;
 
-#app-header a:active {
-  color: var(--pix-yellow);
+    &:hover,
+    &:focus {
+       color: var(--pix-blue);
+    }
+
+    &:active {
+       color: var(--pix-yellow);
+    }
+  }
 }
 

--- a/app/styles/components/challenge-item.css
+++ b/app/styles/components/challenge-item.css
@@ -1,7 +1,10 @@
-.challenge-item .challenge-instruction {
-  font-size: 20px;
-}
 
-.challenge-item .challenge-proposal label {
-  font-weight: 400;
+.challenge-item {
+  & .challenge-instruction {
+    font-size: 20px;
+  }
+
+  & .challenge-proposal label {
+    font-weight: 400;
+  }
 }

--- a/app/styles/components/identification-form.css
+++ b/app/styles/components/identification-form.css
@@ -1,3 +1,6 @@
+@import url('../globals/palette.css');
+
+
 #identification-form {
   background-color: #fff;
   border-radius: 5px;
@@ -7,11 +10,11 @@
 }
 
 #identification-form .identification-form-actions button[disabled] {
-  background-color: rgba(120,193,130,0.50);
+  background-color: var(--green-dark);
 }
 
 #identification-form .identification-form-actions.has-error button[disabled] {
-  background-color: rgba(201,48,44,0.50);
-  border-color: #ac2925;
+  background-color: var(--red-dark);
+  border-color: var(--red);
 }
 

--- a/app/styles/components/identification-form.css
+++ b/app/styles/components/identification-form.css
@@ -1,20 +1,20 @@
 @import url('../globals/palette.css');
 
-
 #identification-form {
   background-color: #fff;
   border-radius: 5px;
   width: 460px;
   margin: 0 auto;
   padding: 24px 40px 59px;
-}
+  
+  & .identification-form-actions {
+    & button[disabled] {
+      background-color: var(--green-dark);
+    }
 
-#identification-form .identification-form-actions button[disabled] {
-  background-color: var(--green-dark);
+    & .has-error button[disabled] {
+      background-color: var(--red-dark);
+      border-color: var(--red);
+    }
+  }
 }
-
-#identification-form .identification-form-actions.has-error button[disabled] {
-  background-color: var(--red-dark);
-  border-color: var(--red);
-}
-

--- a/app/styles/courses/get-preview.css
+++ b/app/styles/courses/get-preview.css
@@ -1,6 +1,9 @@
+@import url('../globals/palette.css');
+
+
 #course-preview {}
 
 #course-preview strong {
-  color: #2F70FB;
+  color: var(--pix-blue);
   font-weight: 600;
 }

--- a/app/styles/courses/get-preview.css
+++ b/app/styles/courses/get-preview.css
@@ -1,9 +1,8 @@
 @import url('../globals/palette.css');
 
-
-#course-preview {}
-
-#course-preview strong {
-  color: var(--pix-blue);
-  font-weight: 600;
+#course-preview {
+  & strong {
+    color: var(--pix-blue);
+    font-weight: 600;
+  }
 }

--- a/app/styles/globals/buttons.css
+++ b/app/styles/globals/buttons.css
@@ -38,16 +38,17 @@
   display: inline-block;
   border-bottom: 1px solid var(--captrain-green1);
   box-shadow: 0px 1px 1px -1px var(--grey3);
+
+  &:hover,
+  &:focus {
+    color: #fff;
+    background-color: var(--captrain-green2);
+    border-color: var(--captrain-green2);
+    border-bottom-color: var(--captrain-green3);
+    text-decoration: none;
+  }
 }
 
-.button-primary:hover,
-.button-primary:focus {
-  color: #fff;
-  background-color: var(--captrain-green2);
-  border-color: var(--captrain-green2);
-  border-bottom-color: var(--captrain-green3);
-  text-decoration: none;
-}
 
 
 .button-secondary {
@@ -67,12 +68,13 @@
   display: inline-block;
   border-bottom: 1px solid var(--dark-grey1);
   box-shadow: 0 1px 1px -1px var(--grey3);
-}
-.button-secondary:hover,
-.button-secondary:focus {
-  color: #fff;
-  background-color: var(--grey2);
-  border-color: var(--grey2);
-  border-bottom-color: var(--dark-grey2);
-  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: #fff;
+    background-color: var(--grey2);
+    border-color: var(--grey2);
+    border-bottom-color: var(--dark-grey2);
+    text-decoration: none;
+  }
 }

--- a/app/styles/globals/buttons.css
+++ b/app/styles/globals/buttons.css
@@ -1,3 +1,5 @@
+@import url('./palette.css');
+
 .button {
   color: #fff;
   font-size: 0.9em;
@@ -6,14 +8,14 @@
   text-transform: uppercase;
   outline: none;
   border-radius: 0.3125em;
-  border: 1px solid #78C182;
+  border: 1px solid var(--captrain-green);
   padding: 12px 22px;
   text-align: center;
-  background-color: #78C182;
+  background-color: var(--captrain-green);
   background-image: none;
   text-decoration: none;
   display: inline-block;
-  border-bottom: 1px solid #55b162;
+  border-bottom: 1px solid var(--captrain-green1);
   box-shadow: 0 1px 1px -1px #909297;
   -webkit-appearance: button;
   cursor: pointer;
@@ -27,23 +29,23 @@
   text-transform: uppercase;
   outline: none;
   border-radius: 0.3125em;
-  border: 1px solid #78C182;
+  border: 1px solid var(--captrain-green);
   padding: 12px 22px;
   text-align: center;
-  background-color: #78C182;
+  background-color: var(--captrain-green);
   background-image: none;
   text-decoration: none;
   display: inline-block;
-  border-bottom: 1px solid #55b162;
+  border-bottom: 1px solid var(--captrain-green1);
   box-shadow: 0px 1px 1px -1px #909297;
 }
 
 .button-primary:hover,
 .button-primary:focus {
   color: #fff;
-  background-color: #67b972;
-  border-color: #67b972;
-  border-bottom-color: #4aa256;
+  background-color: var(--captrain-green2);
+  border-color: var(--captrain-green2);
+  border-bottom-color: var(--captrain-green3);
   text-decoration: none;
 }
 
@@ -56,21 +58,21 @@
   text-transform: uppercase;
   outline: none;
   border-radius: 0.3125em;
-  border: 1px solid #a5a7ab;
+  border: 1px solid var(--grey1);
   padding: 12px 22px;
   text-align: center;
-  background-color: #a5a7ab;
+  background-color: var(--grey1);
   background-image: none;
   text-decoration: none;
   display: inline-block;
-  border-bottom: 1px solid #8b8d92;
-  box-shadow: 0 1px 1px -1px #909297;
+  border-bottom: 1px solid var(--dark-grey1);
+  box-shadow: 0 1px 1px -1px var(--grey3);
 }
 .button-secondary:hover,
 .button-secondary:focus {
   color: #fff;
-  background-color: #989a9e;
-  border-color: #989a9e;
-  border-bottom-color: #7e8086;
+  background-color: var(--grey2);
+  border-color: var(--grey2);
+  border-bottom-color: var(--dark-grey2);
   text-decoration: none;
 }

--- a/app/styles/globals/buttons.css
+++ b/app/styles/globals/buttons.css
@@ -16,7 +16,7 @@
   text-decoration: none;
   display: inline-block;
   border-bottom: 1px solid var(--captrain-green1);
-  box-shadow: 0 1px 1px -1px #909297;
+  box-shadow: 0 1px 1px -1px var(--grey3);
   -webkit-appearance: button;
   cursor: pointer;
 }
@@ -37,7 +37,7 @@
   text-decoration: none;
   display: inline-block;
   border-bottom: 1px solid var(--captrain-green1);
-  box-shadow: 0px 1px 1px -1px #909297;
+  box-shadow: 0px 1px 1px -1px var(--grey3);
 }
 
 .button-primary:hover,

--- a/app/styles/globals/groupped-input.css
+++ b/app/styles/globals/groupped-input.css
@@ -4,7 +4,7 @@
   line-height: 20px;
   background-repeat: no-repeat;
   background-position: 11px center;
-  border: 1px solid #D0D1D5;
+  border: 1px solid var(--light-grey5);
   border-radius: 5px;
   outline: none;
 }
@@ -14,7 +14,7 @@
 }
 
 .groupped-input.focus {
-  border: 1px solid #2F70FB;
+  border: 1px solid var(--pix-blue);
   box-shadow: none;
   opacity: 1;
 }

--- a/app/styles/globals/groupped-input.css
+++ b/app/styles/globals/groupped-input.css
@@ -7,16 +7,22 @@
   border: 1px solid var(--light-grey5);
   border-radius: 5px;
   outline: none;
+
+  & .focus {
+    border: 1px solid var(--pix-blue);
+    box-shadow: none;
+    opacity: 1;
+  }
+
+  & input {
+    border: none;
+    outline: none;
+    width: 100%;
+  }
 }
 
 .groupped-input-with-icon {
   padding-left: 35px;
-}
-
-.groupped-input.focus {
-  border: 1px solid var(--pix-blue);
-  box-shadow: none;
-  opacity: 1;
 }
 
 .groupped-input-top {
@@ -36,8 +42,3 @@
   border-top-right-radius: 0;
 }
 
-.groupped-input input {
-  border: none;
-  outline: none;
-  width: 100%;
-}

--- a/app/styles/globals/palette.css
+++ b/app/styles/globals/palette.css
@@ -10,6 +10,7 @@
   --grey3:        #909297;
   --dark-grey1:   #8b8d92;
   --dark-grey2:   #7e8086;
+  --dark-grey3:   #6f7177;
   --dark-grey5:   #484c58;
 
   --pix-blue:     #2F70FB;

--- a/app/styles/globals/palette.css
+++ b/app/styles/globals/palette.css
@@ -1,8 +1,29 @@
-.palette {
-  color: #f2f3f4; /* light grey for <html/> background */
-  color: #2F70FB; /* PIX blue */
-  color: #FDBD2C; /* PIX yellow */
-  color: #f3f3f3; /* light grey for <hr/> */
-  color: #78C182; /* green captain train */
+:root {
+  --light-grey1:  #f2f3f4; /* html background */
+  --light-grey2:  #f3f3f3; /* hr */
+  --light-grey3:  #efefef;
+  --light-grey4:  #dedfe2;
+  --light-grey5:  #D0D1D5;
+  --light-grey6:  #CCC;
+  --grey1:        #a5a7ab;
+  --grey2:        #989a9e;
+  --grey3:        #909297;
+  --dark-grey1:   #8b8d92;
+  --dark-grey2:   #7e8086;
+  --dark-grey5:   #484c58;
+
+  --pix-blue:     #2F70FB;
+  --pix-yellow:   #FDBD2C;
+  --pix-orange:   #e97f2a;
+
+  --captrain-green:  #78C182;
+  --captrain-green1: #55b162; /* border-color */
+  --captrain-green2: #67b972;
+  --captrain-green3: #4aa256;
+
+  --green-dark: rgba(120,193,130,0.50);
+
+  --red-dark: rgba(201,48,44,0.50);
+  --red: #ac2925;
 }
 

--- a/app/styles/globals/rounded-panel.css
+++ b/app/styles/globals/rounded-panel.css
@@ -10,14 +10,14 @@
   padding: 20px;
   margin-bottom: 50px;
   overflow: hidden;
-}
 
-.rounded-panel > hr {
-  height: 1px;
-  border: none;
-  background: var(--light-grey5);
-  margin: 20px -29px;
-  box-sizing: content-box;
+  & > hr {
+    height: 1px;
+    border: none;
+    background: var(--light-grey5);
+    margin: 20px -29px;
+    box-sizing: content-box;
+  }
 }
 
 .rounded-panel-title {

--- a/app/styles/globals/rounded-panel.css
+++ b/app/styles/globals/rounded-panel.css
@@ -1,10 +1,12 @@
+@import url('./palette.css');
+
 .rounded-panel {
   background-color: #fff;
   border-radius: 0.3125em;
-  border-left: 1px solid #dedfe2;
-  border-right: 1px solid #dedfe2;
-  border-bottom: 1px solid #D0D1D5;
-  box-shadow: 0 1px 0 0 #dedfe2;
+  border-left: 1px solid var(--light-grey4);
+  border-right: 1px solid var(--light-grey4);
+  border-bottom: 1px solid var(--light-grey5);
+  box-shadow: 0 1px 0 0 var(--light-grey4);
   padding: 20px;
   margin-bottom: 50px;
   overflow: hidden;
@@ -13,7 +15,7 @@
 .rounded-panel > hr {
   height: 1px;
   border: none;
-  background: #E4E5E9;
+  background: var(--light-grey5);
   margin: 20px -29px;
   box-sizing: content-box;
 }
@@ -25,10 +27,10 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-smoothing: antialiased;
-  color: #2F70FB;
+  color: var(--pix-blue);
 }
 
 .rounded-panel-notice {
-  color: #e97f2a;
-  color: #FDBD2C;
+  /*color: var(--pix-orange);*/
+  color: var(--pix-yellow);
 }

--- a/app/styles/home-loading.css
+++ b/app/styles/home-loading.css
@@ -1,15 +1,16 @@
-#home-loading .loader-container {
-  width: 1em;
-  height: 3em;
-  margin: 0 auto;
-  padding-top: 180px;
-}
+#home-loading {
+  & .loader-container {
+    width: 1em;
+    height: 3em;
+    margin: 0 auto;
+    padding-top: 180px;
+  }
 
-#home-loading .ball-zig-zag-deflect > div:nth-child(2) {
-  background-color: var(--pix-blue);
-}
+  & .ball-zig-zag-deflect > div:nth-child(2) {
+    background-color: var(--pix-blue);
+  }
 
-#home-loading .ball-zig-zag-deflect > div:nth-child(1) {
-  background-color: var(--pix-yellow);
+  & .ball-zig-zag-deflect > div:nth-child(1) {
+    background-color: var(--pix-yellow);
+  }
 }
-

--- a/app/styles/home-loading.css
+++ b/app/styles/home-loading.css
@@ -6,10 +6,10 @@
 }
 
 #home-loading .ball-zig-zag-deflect > div:nth-child(2) {
-  background-color: #2F70FB;
+  background-color: var(--pix-blue);
 }
 
 #home-loading .ball-zig-zag-deflect > div:nth-child(1) {
-  background-color: #FDBD2C;
+  background-color: var(--pix-yellow);
 }
 

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -1,71 +1,75 @@
-#home .courses {
-  list-style-type: none;
-  padding: 0;
-}
+#home {
+  & .courses {
+    list-style-type: none;
+    padding: 0;
+  }
 
-#home .course {
-  margin: 0 0 15px 15px;
-  padding: 15px;
-  width: 285px;
-  float: left;
-  display: inline-block;
-  position: relative;
-  background-color: white;
-  border-radius: 0.3125em;
-  border-left: 1px solid var(--light-grey4);
-  border-right: 1px solid var(--light-grey4);
-  border-bottom: 1px solid var(--light-grey5);
-  box-shadow: 0 1px 0 0 var(--light-grey4);
-}
+  & .course {
+    margin: 0 0 15px 15px;
+    padding: 15px;
+    width: 285px;
+    float: left;
+    display: inline-block;
+    position: relative;
+    background-color: white;
+    border-radius: 0.3125em;
+    border-left: 1px solid var(--light-grey4);
+    border-right: 1px solid var(--light-grey4);
+    border-bottom: 1px solid var(--light-grey5);
+    box-shadow: 0 1px 0 0 var(--light-grey4);
+  }
 
-#home .course-picture {
-  width: 244px;
-  height: 170px;
-  text-align: center;
-  margin: 0 auto;
-  display: block;
-}
+  & .course-picture {
+    width: 244px;
+    height: 170px;
+    text-align: center;
+    margin: 0 auto;
+    display: block;
+  }
 
-#home .course-wrapper h3 {
-  color: var(--pix-blue);
-}
+  & .course-description {
+    height: 140px;
+    overflow: hidden;
+  }
 
-#home .course-description {
-  height: 140px;
-  overflow: hidden;
-}
+  & .course-wrapper h3 {
+    color: var(--pix-blue);
 
-#home .course-actions {
-  text-align: center;
-}
+    & .disabled {
+      &::after {
+        content: ' ';
+        position: absolute;
+        top:0;
+        left:0;
+        width: 100%;
+        height:100%;
+        background-color: var(--light-grey3);
+        opacity: 0.5;
+      }
 
-#home .course-actions > a {
-  background-color: var(--pix-blue);
-  border: none;
-}
+      & h3 {
+        color: inherit;
+      }
 
-#home .course-actions > a:hover,
-#home .course-actions > a:active {
-  background-color: var(--pix-yellow);
-}
+      & .course-actions > a {
+        background-color: transparent;
+        border: 1px solid var(--light-grey6);
+        color: inherit;
+      }
+    }
+  }
 
-#home .course-wrapper.disabled::after {
-  content: ' ';
-  position: absolute;
-  top:0;
-  left:0;
-  width: 100%;
-  height:100%;
-  background-color: var(--light-grey3);
-  opacity: 0.5;
-}
+  & .course-actions {
+    text-align: center;
 
-#home .course-wrapper.disabled h3 {
-  color: inherit;
-}
+    & > a {
+      background-color: var(--pix-blue);
+      border: none;
 
-#home .course-wrapper.disabled .course-actions > a {
-  background-color: transparent;
-  border: 1px solid var(--light-grey6);
-  color: inherit;
+      &:hover,
+      &:active {
+        background-color: var(--pix-yellow);
+      }
+    }
+  }
 }

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -12,10 +12,10 @@
   position: relative;
   background-color: white;
   border-radius: 0.3125em;
-  border-left: 1px solid #dedfe2;
-  border-right: 1px solid #dedfe2;
-  border-bottom: 1px solid #D0D1D5;
-  box-shadow: 0 1px 0 0 #dedfe2;
+  border-left: 1px solid var(--light-grey4);
+  border-right: 1px solid var(--light-grey4);
+  border-bottom: 1px solid var(--light-grey5);
+  box-shadow: 0 1px 0 0 var(--light-grey4);
 }
 
 #home .course-picture {
@@ -27,7 +27,7 @@
 }
 
 #home .course-wrapper h3 {
-  color: #2F70FB;
+  color: var(--pix-blue);
 }
 
 #home .course-description {
@@ -40,13 +40,13 @@
 }
 
 #home .course-actions > a {
-  background-color: #2F70FB;
+  background-color: var(--pix-blue);
   border: none;
 }
 
 #home .course-actions > a:hover,
 #home .course-actions > a:active {
-  background-color: #FDBD2C;
+  background-color: var(--pix-yellow);
 }
 
 #home .course-wrapper.disabled::after {
@@ -56,7 +56,7 @@
   left:0;
   width: 100%;
   height:100%;
-  background-color: #efefef;
+  background-color: var(--light-grey3);
   opacity: 0.5;
 }
 
@@ -66,6 +66,6 @@
 
 #home .course-wrapper.disabled .course-actions > a {
   background-color: transparent;
-  border: 1px solid #CCC;
+  border: 1px solid var(--light-grey6);
   color: inherit;
 }

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -25,7 +25,7 @@
   text-align: center;
   padding-top: 30px;
   padding-bottom: 30px;
-  color: #2F70FB;
+  color: var(--pix-blue);
   color: #FFF;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -1,45 +1,45 @@
+#index {
+  & .cover {
+    background-image: url('/images/stock-photo-113728127.jpg');
+    height: 100%;
+    background-size: cover;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    content: ' ';
 
-#index .cover {
-  background-image: url('/images/stock-photo-113728127.jpg');
-  height: 100%;
-  background-size: cover;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  content: ' ';
-}
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      content: '';
+      bottom: 10%;
+      background: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent);
+    }
+  }
 
-#index .cover::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  content: '';
-  bottom: 10%;
-  background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0.5), transparent);
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent);
-}
+  & .presentation {
+    text-align: center;
+    padding-top: 30px;
+    padding-bottom: 30px;
+    color: var(--pix-blue);
+    color: #FFF;
+    font-smoothing: antialiased;
+    text-shadow: 0px 0px 1px rgba(48, 50, 58, 0.6), 0px 1px 1px rgba(48, 50, 58, 0.6);
+    margin: 0.3em 0;
 
-#index .presentation {
-  text-align: center;
-  padding-top: 30px;
-  padding-bottom: 30px;
-  color: var(--pix-blue);
-  color: #FFF;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-smoothing: antialiased;
-  text-shadow: 0px 0px 1px rgba(48, 50, 58, 0.6), 0px 1px 1px rgba(48, 50, 58, 0.6);
-  margin: 0.3em 0;
-}
-#index .presentation h1 {
-  font-weight: 600;
-  font-size: 40px;
-}
-#index .presentation h2 {
-  font-weight: 400;
-  font-size: 21px;
-  color: #fff;
+    & h1 {
+      font-weight: 600;
+      font-size: 40px;
+    }
+
+    & h2 {
+      font-weight: 400;
+      font-size: 21px;
+      color: #fff;
+    }
+  }
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -24,13 +24,21 @@ module.exports = function (defaults) {
           {
             module: cssnext,
             options: {
-              browsers: ['last 2 version']
+              browsers: ['last 2 version'],
+              calc: true,
+              colorFunction: true,
+              colorGray: true,
+              nesting: true,
+              pseudoClassMatches: true,
+              pseudoClassAnyLink: true,
+              pseudoClassNot: true,
+
             }
           },
           // linters
           { module: colorGuard },
           // reporters at the end
-          { module: browserReporter },
+          //{ module: browserReporter },
           { module: reporter }
         ]
       },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,9 +40,9 @@ module.exports = function (defaults) {
             }
           },
           // linters
-          { module: colorGuard },
+          //{ module: colorGuard }, FIXME: there are issues reported that need a fix
           // reporters at the end
-          //{ module: browserReporter },
+          { module: browserReporter },
           { module: reporter }
         ]
       },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,9 +2,40 @@
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-module.exports = function(defaults) {
+/* postcss plugins */
+var postcssImport = require('postcss-import');
+var cssnext = require('postcss-cssnext');
+var colorGuard = require('colorguard');
+var browserReporter = require('postcss-browser-reporter');
+var reporter = require('postcss-reporter');
+
+module.exports = function (defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    postcssOptions: {
+      compile: {
+        enabled: true,
+        plugins: [
+          // multiple-file transformation first (eg: imports)
+          {
+            module: postcssImport,
+            options: {}
+          },
+          // single-file transformations (eg: variables, nesting, etc.)
+          {
+            module: cssnext,
+            options: {
+              browsers: ['last 2 version']
+            }
+          },
+          // linters
+          { module: colorGuard },
+          // reporters at the end
+          { module: browserReporter },
+          { module: reporter }
+        ]
+      },
+      filter: { enabled: false }
+    }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 var postcssImport = require('postcss-import');
 var cssnext = require('postcss-cssnext');
 var colorGuard = require('colorguard');
+var stylelint = require("stylelint");
 var browserReporter = require('postcss-browser-reporter');
 var reporter = require('postcss-reporter');
 
@@ -15,7 +16,11 @@ module.exports = function (defaults) {
       compile: {
         enabled: true,
         plugins: [
-          // multiple-file transformation first (eg: imports)
+          // first linter
+          {
+            module: stylelint
+          },
+          // multiple-file transformation (eg: imports)
           {
             module: postcssImport,
             options: {}
@@ -31,8 +36,7 @@ module.exports = function (defaults) {
               nesting: true,
               pseudoClassMatches: true,
               pseudoClassAnyLink: true,
-              pseudoClassNot: true,
-
+              pseudoClassNot: true
             }
           },
           // linters

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "postcss-import": "^8.1.2",
     "postcss-nesting": "^2.3.1",
     "postcss-reporter": "^1.4.1",
+    "stylelint": "^7.2.0",
+    "stylelint-config-standard": "^13.0.0",
     "tap-xunit": "^1.4.0",
     "urljs": "^2.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "broccoli-asset-rev": "^2.4.6",
     "chai": "^3.5.0",
     "codeclimate-test-reporter": "^0.3.3",
+    "colorguard": "^1.2.0",
     "coveralls": "^2.11.12",
     "ember-airtable": "0.0.2",
     "ember-ajax": "^2.5.1",
@@ -52,6 +53,7 @@
     "ember-cli-mirage": "0.2.1",
     "ember-cli-mocha": "^0.10.4",
     "ember-cli-mocha-reporter": "0.0.2",
+    "ember-cli-postcss": "3.0.4",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "1.1.0",
@@ -66,6 +68,10 @@
     "eslint": "^3.3.1",
     "loader.js": "^4.0.11",
     "mocha": "^3.0.0",
+    "postcss-browser-reporter": "^0.5.0",
+    "postcss-cssnext": "^2.7.0",
+    "postcss-import": "^8.1.2",
+    "postcss-reporter": "^1.4.1",
     "tap-xunit": "^1.4.0",
     "urljs": "^2.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "postcss-browser-reporter": "^0.5.0",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^8.1.2",
+    "postcss-nesting": "^2.3.1",
     "postcss-reporter": "^1.4.1",
     "tap-xunit": "^1.4.0",
     "urljs": "^2.3.1"


### PR DESCRIPTION
Changes:
- add postcss
- add a style linter
- enable variables, nesting, and css-next pseudo classes (`::not()`, `::matches()`, `:any-link`)
- convert code for variable colors
- convert code for nesting

A word on the css-next nesting syntax: it's a bit more cumbersome (the `&` is mandatory), but it is also more powerful: the `&` is not necessarly at first which enable things like `a + b > & > c` which can be handy !

The style linter is fully customizable, we can extend this one with [our rules](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md) or [take a community one](https://www.npmjs.com/browse/keyword/stylelint-config) (sorry, no airbnb config).
