### PR TITLE
US-7 (FIX): skip null the error + some refactor + fixes

### DIFF
--- a/app/components/challenge-item.js
+++ b/app/components/challenge-item.js
@@ -34,9 +34,9 @@ const ChallengeItem = Ember.Component.extend({
     validate(challenge, assessment) {
       if (Ember.isEmpty(this.get('selectedProposal'))) {
 
-        const errorMsg = 'Vous devez sélectionner une réponse.';
-        this.set('error', errorMsg);
-        this.sendAction('onError', errorMsg);
+        const errorMessage = 'Vous devez sélectionner une réponse.';
+        this.set('error', errorMessage);
+        this.sendAction('onError', errorMessage);
         return;
       }
       const value = this._adaptSelectedProposalValueToBackendValue(this.get('selectedProposal'));

--- a/app/components/challenge-item.js
+++ b/app/components/challenge-item.js
@@ -33,13 +33,17 @@ const ChallengeItem = Ember.Component.extend({
   actions: {
     validate(challenge, assessment) {
       if (Ember.isEmpty(this.get('selectedProposal'))) {
-        this.set('error', 'Vous devez sélectionner une réponse.');
+
+        const errorMsg = 'Vous devez sélectionner une réponse.';
+        this.set('error', errorMsg);
+        this.sendAction('onError', errorMsg);
         return;
       }
       const value = this._adaptSelectedProposalValueToBackendValue(this.get('selectedProposal'));
       this.sendAction('onValidated', challenge, assessment, value);
     },
     skip() {
+      this.set('error', null);
       this.sendAction('onValidated', this.get('challenge'), this.get('assessment'), '#ABAND#')
     }
   },

--- a/tests/integration/components/challenge-item-test.js
+++ b/tests/integration/components/challenge-item-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import RSVP from 'rsvp';
 
-function renderChallengeItem(challengeAttributes = {}, validateHandler = null) {
+function renderChallengeItem(challengeAttributes = {}, validateHandler = null, errorHandler = null) {
 
   const challenge = Ember.Object.create(challengeAttributes);
   this.set('challenge', challenge);
@@ -13,8 +13,9 @@ function renderChallengeItem(challengeAttributes = {}, validateHandler = null) {
   const assessment = Ember.Object.create({});
   this.set('assessment', assessment);
   this.set('validateHandler', (validateHandler || (() => null)));
+  this.set('errorHandler', (errorHandler || (() => null)));
 
-  this.render(hbs`{{challenge-item challenge assessment onValidated=(action validateHandler)}}`);
+  this.render(hbs`{{challenge-item challenge assessment onValidated=(action validateHandler) onError=(action errorHandler)}}`);
 }
 
 function renderChallengeItem_challengePreview(challengeAttributes = {}) {
@@ -134,7 +135,7 @@ describeComponent(
         renderChallengeItem.call(this, {
           type: 'QCU',
           _proposalsAsArray: ['Xi', 'Fu', 'Mi']
-        }, (challenge, assessment, answerValue) => {
+        }, (_challenge, _assessment, answerValue) => {
 
           // then
           expect(answerValue).to.equal("1");
@@ -164,23 +165,27 @@ describeComponent(
 
     describe('Error alert box', function () {
 
-      it("should be hidden by default", function () {
+      it("should be hidden by default", function (done) {
         // when
-        renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, () => done());
+        renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] });
 
         // then
-        expect(this.$('.alert-error')).to.have.lengthOf(0);
+        Ember.run.next(() => {
+          expect(this.$('.alert-error')).to.have.lengthOf(0);
+          done();
+        })
       });
 
       describe('when validating a challenge without having selected a proposal', function () {
 
-        it("should be displayed", function () {
+        it("should be displayed", function (done) {
           // given
           renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, () => {
 
             // then
             const $alertError = this.$('.alert-error');
             expect($alertError).to.have.lengthOf(1);
+	    done();
           });
 
           // when
@@ -189,29 +194,15 @@ describeComponent(
 
         it('should contains "Vous devez saisir une réponse"', function () {
           // given
-          renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, () => {
-
+          renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, null, (errorMsg) => {
             // then
-            const $alertError = this.$('.alert-error');
-            expect($alertError.text()).to.contains("Vous devez saisir une réponse");
+            expect(errorMsg).to.contains('Vous devez saisir une réponse');
+            done();
           });
 
           // when
           validateChallenge.call(this);
         });
-
-      });
-
-      describe('when a proposal is selected', function () {
-
-        it("should be removed", function () {
-          // when
-          selectFirstProposal.call(this);
-
-          // then
-          assertAlertErrorToBeHidden.call(this);
-        });
-
       });
     });
 

--- a/tests/integration/components/challenge-item-test.js
+++ b/tests/integration/components/challenge-item-test.js
@@ -25,21 +25,8 @@ function renderChallengeItem_challengePreview(challengeAttributes = {}) {
   this.render(hbs`{{challenge-item challenge}}`);
 }
 
-function selectFirstProposal() {
-
-  return new RSVP.Promise(function (resolve) {
-    return this.$('.challenge-proposal:first input[type="radio"]').click(() => {
-      return resolve();
-    });
-  });
-}
-
 function validateChallenge() {
   this.$('.validate-button').click();
-}
-
-function assertAlertErrorToBeHidden() {
-  expect(this.$('.alert-error')).to.have.lengthOf(0);
 }
 
 describeComponent(
@@ -153,7 +140,7 @@ describeComponent(
 
       it('save #ABAND# as value when clicked', function (done) {
 
-        renderChallengeItem.call(this, { proposalsAsArray: ['1', '2', '3'] }, (_challenge, _assessment, answerValue) => {
+        renderChallengeItem.call(this, { _proposalsAsArray: ['1', '2', '3'] }, (_challenge, _assessment, answerValue) => {
 
           expect(answerValue).to.equal('#ABAND#');
           done()
@@ -167,11 +154,11 @@ describeComponent(
 
       it("should be hidden by default", function (done) {
         // when
-        renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] });
+        renderChallengeItem.call(this, { _proposalsAsArray: ['Xi', 'Fu', 'Mi'] });
 
         // then
         Ember.run.next(() => {
-          expect(this.$('.alert-error')).to.have.lengthOf(0);
+          expect(this.$('.alert')).to.have.lengthOf(0);
           done();
         })
       });
@@ -180,28 +167,17 @@ describeComponent(
 
         it("should be displayed", function (done) {
           // given
-          renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, () => {
+          renderChallengeItem.call(this, { _proposalsAsArray: ['Xi', 'Fu', 'Mi'] });
 
+          // when
+          validateChallenge.call(this);
+
+          Ember.run.next(() => {
             // then
-            const $alertError = this.$('.alert-error');
+            const $alertError = this.$('.alert');
             expect($alertError).to.have.lengthOf(1);
-	    done();
-          });
-
-          // when
-          validateChallenge.call(this);
-        });
-
-        it('should contains "Vous devez saisir une réponse"', function () {
-          // given
-          renderChallengeItem.call(this, { proposalsAsArray: ['Xi', 'Fu', 'Mi'] }, null, (errorMsg) => {
-            // then
-            expect(errorMsg).to.contains('Vous devez saisir une réponse');
             done();
-          });
-
-          // when
-          validateChallenge.call(this);
+          })
         });
       });
     });

--- a/tests/unit/components/challenge-item-test.js
+++ b/tests/unit/components/challenge-item-test.js
@@ -8,7 +8,7 @@ import { beforeEach } from "mocha";
 
 describeModule(
   'component:challenge-item',
-  'ChallengeItem',
+  'Unit | Component | ChallengeItem',
   {},
   function () {
 
@@ -29,9 +29,34 @@ describeModule(
 
         // then
         expect(challengeItem.get('error')).to.be.null;
-
       });
+    });
 
+    describe('#onError is called when an error is raised', function () {
+
+      it('is called when no proposal has been selected with the message “Vous devez sélectionner une réponse”', function (done) {
+        const challengeItem = this.subject();
+        challengeItem.set('onError', (message) => {
+          expect(message).to.contains('Vous devez sélectionner une réponse');
+          done();
+        });
+
+        challengeItem.actions.validate.call(challengeItem);
+      });
+    });
+
+    describe('#skip', function () {
+
+      it('should clear the error property', function (done) {
+        const challengeItem = this.subject();
+        challengeItem.set('error', 'an error');
+        challengeItem.set('onValidated', () => {
+          expect(challengeItem.get('error')).to.be.null;
+          done();
+        });
+
+        challengeItem.actions.skip.call(challengeItem);
+      });
     });
   }
 );


### PR DESCRIPTION
Changes: 
- skip null the error
- introduce `onError` event for testing purpose
- refactor tests to be unit tests (rather than integration)
- introduce `done` callbacks when necessary in integration testing
