### PR TITLE
US-14 (FIX): Treat QROCM as QROC + introduce placeholders as requested

### DIFF
--- a/app/components/challenge-item.js
+++ b/app/components/challenge-item.js
@@ -1,25 +1,29 @@
 import Ember from 'ember';
 
+const { computed, inject } = Ember;
+
 const ChallengeItem = Ember.Component.extend({
 
   tagName: 'article',
   classNames: ['challenge-item'],
   attributeBindings: ['challenge.id:data-challenge-id'],
 
-  assessmentService: Ember.inject.service('assessment'),
+  assessmentService: inject.service('assessment'),
 
   challenge: null,
   assessment: null,
   selectedProposal: null,
   error: null,
 
-  hasIllustration: Ember.computed.notEmpty('challenge.illustrationUrl'),
-  isChallengePreviewMode: Ember.computed.empty('assessment'),
-  hasError: Ember.computed.notEmpty('error'),
+  hasIllustration: computed.notEmpty('challenge.illustrationUrl'),
+  isChallengePreviewMode: computed.empty('assessment'),
+  hasError: computed.notEmpty('error'),
 
-  challengeIsTypeQROC: Ember.computed.equal('challenge.type', 'QROC'),
-  challengeIsTypeQCM: Ember.computed.equal('challenge.type', 'QCM'),
-  challengeIsTypeQCU: Ember.computed.equal('challenge.type', 'QCU'),
+  challengeIsTypeQROC: computed('challenge.type', function () {
+    return this.get('challenge.type') === 'QROC' || this.get('challenge.type') === 'QROCM';
+  }),
+  challengeIsTypeQCM: computed.equal('challenge.type', 'QCM'),
+  challengeIsTypeQCU: computed.equal('challenge.type', 'QCU'),
 
   onSelectedProposalChanged: Ember.observer('selectedProposal', function () {
     this.set('error', null);

--- a/app/models/challenge/proposals-as-blocks-mixin.js
+++ b/app/models/challenge/proposals-as-blocks-mixin.js
@@ -24,6 +24,10 @@ function parseInput(lastIsOpening, input) {
   return { lastIsOpening, block };
 }
 
+function stringHasPlaceholder(input) {
+  return 1 <= input.indexOf('#');
+}
+
 export default Ember.Mixin.create({
 
   _proposalsAsBlocks: Ember.computed('proposals', function () {
@@ -42,11 +46,11 @@ export default Ember.Mixin.create({
         continue;
       }
 
-      if (block.input && 1 <= block.input.indexOf('#')) {
+      if (block.input && stringHasPlaceholder(block.input)) {
 
-        const tmp_parts = block.input.split('#');
-        const variable = tmp_parts[0];
-        const placeholder = tmp_parts[1];
+        const inputParts = block.input.split('#');
+        const variable = inputParts[0];
+        const placeholder = inputParts[1];
 
         block.input = variable;
         block.placeholder = placeholder;

--- a/app/models/challenge/proposals-as-blocks-mixin.js
+++ b/app/models/challenge/proposals-as-blocks-mixin.js
@@ -38,9 +38,21 @@ export default Ember.Mixin.create({
 
     for (let index = 0; index < parts.length; index += 1) {
       let { lastIsOpening, block } = parseInput((lastIsOpening || false), parts[index]);
-      if (block) {
-        result.push(block);
+      if (!block) {
+        continue;
       }
+
+      if (block.input && 1 <= block.input.indexOf('#')) {
+
+        const tmp_parts = block.input.split('#');
+        const variable = tmp_parts[0];
+        const placeholder = tmp_parts[1];
+
+        block.input = variable;
+        block.placeholder = placeholder;
+      }
+
+      result.push(block);
     }
 
     return result;

--- a/app/templates/components/challenge-item.hbs
+++ b/app/templates/components/challenge-item.hbs
@@ -17,7 +17,7 @@
           {{/if}}
 
           {{#if block.input}}
-            {{input type="text" placeholder=block.input}}
+            {{input type="text" placeholder=block.placeholder}}
           {{/if}}
 
         {{/each}}

--- a/tests/unit/models/challenge/proposals-as-blocks-mixin-test.js
+++ b/tests/unit/models/challenge/proposals-as-blocks-mixin-test.js
@@ -18,7 +18,8 @@ describe('Unit | Model | Challenge/Proposal As Blocks Mixin', function () {
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [{ input: 'plop' }, { text: ',' }, { input: 'plop' }, { input: 'plop' }]
-    }
+    },
+    { data: '${plop#var}', expected: [{ input: 'plop', placeholder: 'var' }] }
   ];
 
   const Challenge = Ember.Object.extend(ProposalsAsBlocksMixin, {});


### PR DESCRIPTION
by default, no placeholders. Use a placeholder only if `${variable#placeholder}` is used
