### PR TITLE
Fix fetch empty courses

### DIFF
--- a/app/adapters/course.js
+++ b/app/adapters/course.js
@@ -2,6 +2,10 @@ import AirtableAdapter from "./airtable";
 
 export default AirtableAdapter.extend({
 
-  pathForType: () => 'Tests'
+  pathForType: () => 'Tests',
 
+  urlForFindAll() {
+    const url = this._super(...arguments);
+    return `${url}?view=${encodeURIComponent('PIX view')}`;
+  }
 });

--- a/app/index.html
+++ b/app/index.html
@@ -19,6 +19,8 @@
 
     <script src="assets/vendor.js"></script>
     <script src="assets/pix-live.js"></script>
+    <script src="https://cdn.ravenjs.com/3.7.0/ember/raven.min.js"></script>
+    <script>Raven.config('https://4b60c9f39a844832956f840b9d0d1359@sentry.io/99479').install();</script>
 
     {{content-for "body-footer"}}
   </body>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,5 +1,9 @@
 export default function () {
   this.passthrough('https://api.airtable.com/**');
+
+  this.post('https://sentry.io/**', () => {
+    return 200;
+  });
 }
 
 export function testConfig() {


### PR DESCRIPTION
Use an Airtable view to fetch the courses. In this view, we filter by `{Nb d'épreuves} > 0` and sorte by `{Ordre d'affichage}`
