### PR TITLE
Remove link on Pix logo

### DIFF
--- a/app/templates/components/app-header.hbs
+++ b/app/templates/components/app-header.hbs
@@ -8,9 +8,9 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">
+            <div class="navbar-brand">
                 <img src="/images/pix-logo.png" alt="Logo PIX">
-            </a>
+            </div>
         </div>
       {{#if session.isIdentified }}
           <div class="profile nav navbar-nav navbar-right">


### PR DESCRIPTION
Some users have clicked on it and exited the test.

We don't need it to be a link.

Fix #52 
