### PR TITLE
BSR : replace baseURL by rootURL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-BUILDPACK_URL=https://github.com/tonycoco/heroku-buildpack-ember-cli
-EMBER_ENV=development

--- a/app/index.html
+++ b/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/pix-live.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/pix-live.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/pix-live.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/pix-live.js"></script>
     <script src="https://cdn.ravenjs.com/3.7.0/ember/raven.min.js"></script>
     <script>Raven.config('https://4b60c9f39a844832956f840b9d0d1359@sentry.io/99479').install();</script>
 

--- a/app/router.js
+++ b/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function () {

--- a/app/templates/components/app-header.hbs
+++ b/app/templates/components/app-header.hbs
@@ -9,7 +9,7 @@
                 <span class="icon-bar"></span>
             </button>
             <div class="navbar-brand">
-                <img src="/images/pix-logo.png" alt="Logo PIX">
+                <img src="{{rootURL}}images/pix-logo.png" alt="Logo PIX">
             </div>
         </div>
       {{#if session.isIdentified }}

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,18 @@
 {
   "name": "pix-live",
   "dependencies": {
-    "ember": "~2.7.0",
-    "ember-cli-shims": "~0.1.3",
-    "pretender": "~1.1.0",
-    "Faker": "~3.1.0",
-    "bootstrap": "~3.3.6",
-    "animate.css": "^3.5.2",
-    "loaders.css": "^0.1.2",
-    "markdown-it": "^7.0.1"
+    "ember": "2.7.3",
+    "ember-cli-shims": "0.1.3",
+    "pretender": "1.1.0",
+    "Faker": "3.1.0",
+    "bootstrap": "3.3.7",
+    "animate.css": "3.5.2",
+    "loaders.css": "0.1.2",
+    "markdown-it": "7.0.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "~2.5.3",
-    "ember-mocha-adapter": "~0.3.1"
+    "chai": "3.5.0",
+    "mocha": "2.5.3",
+    "ember-mocha-adapter": "0.3.1"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'pix-live',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       // XXX because of a deprecation notice in the console
@@ -48,7 +48,6 @@ module.exports = function(environment) {
     ENV.EmberENV.useDelay = false;
 
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "ember-lodash": "0.0.10",
     "ember-markdown-it": "0.0.4",
     "ember-resolver": "^2.0.3",
-    "ember-welcome-page": "^1.0.1",
     "eslint": "^3.3.1",
     "loader.js": "^4.0.11",
     "markdown-it": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.4.tgz",


### PR DESCRIPTION
> The baseURL configuration option and the accompanying <base> tag in Ember CLI applications are often and tragically misunderstood. There have been at least 67 issues opened for Ember CLI referencing baseURL, making it one of the most common points of discussion. As a result, in Ember CLI's canary channel, we have deprecated baseURL and removed the default <base> inside of index.html. The intent is that this change will be released with Ember CLI 2.7 stable in roughly 10 weeks.

cf. http://emberjs.com/blog/2016/04/28/baseURL.html
