### PR TITLE
US-216 : ETQ usager, JV que les liens dans la consigne d'une épreuve s'ouvre dans un nouvel onglet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ serve:   serve-api   serve-live
 start:   start-api   start-live
 ci-test: ci-test-api ci-test-live
 
-deploy-development: deploy-live-development deploy-api-development
+deploy-integration: deploy-live-integration deploy-api-integration
 deploy-staging: 	  deploy-live-staging 	  deploy-api-staging
 deploy-production:  deploy-live-production  deploy-api-production
 
@@ -37,16 +37,16 @@ ci-test-api: test-api
 ci-test-live:
 	cd live && npm run ci:test
 
-deploy-live-development:
-	cd live && npm run deploy:development
+deploy-live-integration:
+	cd live && npm run deploy:integration
 	./live/scripts/signal_deploy_to_pr.sh
 deploy-live-staging:
 	cd live && npm run deploy:staging
 deploy-live-production:
 	cd live && npm run deploy:production
 
-deploy-api-development:
-	(cd api && npm run deploy:development)
+deploy-api-integration:
+	(cd api && npm run deploy:integration)
 deploy-api-staging:
 	(cd api && npm run deploy:staging)
 deploy-api-production:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deploy-live-development:
 deploy-live-staging:
 	cd live && npm run deploy:staging
 deploy-live-production:
-	cd live && npm run deploy:prod
+	cd live && npm run deploy:production
 
 deploy-api-development:
 	(cd api && npm run deploy:development)

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -14,6 +14,20 @@ module.exports = {
     useNullAsDefault: true
   },
 
+  integration: {
+    client: 'sqlite3',
+    connection: {
+      filename: `${__dirname}/integration.sqlite3`
+    },
+    migrations: {
+      directory: './migrations'
+    },
+    seeds: {
+      directory: './seeds'
+    },
+    useNullAsDefault: true
+  },
+
   staging: {
     client: 'postgresql',
     connection: process.env.DATABASE_URL,

--- a/api/package.json
+++ b/api/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/sgmap/pix-api/issues"
   },
   "engines": {
-    "node": "6.9.0"
+    "node": ">=6.9.0"
   },
   "homepage": "https://github.com/sgmap/pix-api#readme",
   "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "db:seed": "npm run knex seed:run",
     "coverage": "NODE_ENV=test ./node_modules/.bin/istanbul cover _mocha -- -r tests/setup --recursive tests",
     "lint": "./node_modules/.bin/eslint app/**/*.js",
-    "deploy:development": "./scripts/deploy.sh development",
+    "deploy:integration": "./scripts/deploy.sh integration",
     "deploy:staging": "./scripts/deploy.sh staging",
     "deploy:production": "./scripts/deploy.sh production"
   },

--- a/api/scripts/deploy.sh
+++ b/api/scripts/deploy.sh
@@ -11,7 +11,7 @@ GIT_CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD | tr -d "\n"`
 }
 
 case $BUILD_ENV in
-  "development")
+  "integration")
     # if no <BUILD_OUTPUT> argument is given, use the branch name
     APP=$GIT_CURRENT_BRANCH
   ;;

--- a/circle.yml
+++ b/circle.yml
@@ -19,12 +19,12 @@ deployment:
       - git config --global user.name 'Thomas Wickham'
       - make deploy-staging
 
-  development:
+  integration:
     branch: /.*/
     commands:
       - git config --global user.email 'mackwic@gmail.com'
       - git config --global user.name 'Thomas Wickham'
-      - make deploy-development
+      - make deploy-integration
 
 general:
   branches:

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ deployment:
     commands:
       - git config --global user.email 'mackwic@gmail.com'
       - git config --global user.name 'Thomas Wickham'
-      - make deploy-branch
+      - make deploy-development
 
 general:
   branches:

--- a/live/app/initializers/configure-pix-api-host.js
+++ b/live/app/initializers/configure-pix-api-host.js
@@ -10,12 +10,12 @@ export function configurePixApiHost(locationObject) {
     return 'http://api-staging.pix-app.ovh';
   }
 
-  if (/localhost/.test(locationObject.hostname)) {
-    return 'http://localhost:3000';
+  if (ENV.environment === 'integration') {
+    const matches = /^(.*).pix.beta.gouv.fr/.exec(locationObject.hostname);
+    return `http://${matches[1]}.pix-app.ovh`;
   }
 
-  const matches = /^(.*).pix.beta.gouv.fr/.exec(locationObject.hostname);
-  return `http://${matches[1]}.pix-app.ovh`;
+  return 'http://localhost:3000';
 }
 
 export function initialize() {

--- a/live/app/routes/assessments/get-challenge.js
+++ b/live/app/routes/assessments/get-challenge.js
@@ -17,10 +17,6 @@ export default Ember.Route.extend({
     });
   },
 
-  afterModel(model) {
-    Ember.debug('model = ' + JSON.stringify(model));
-  },
-
   actions : {
 
     saveAnswerAndNavigate: function (currentChallenge, assessment, answerValue) {

--- a/live/app/templates/components/challenge-item.hbs
+++ b/live/app/templates/components/challenge-item.hbs
@@ -1,7 +1,7 @@
 <div class="rounded-panel challenge-statement">
 
   {{#if challenge.instruction}}
-      <div class="challenge-instruction">{{ markdown-render challenge.instruction }}</div>
+      <div class="challenge-instruction">{{ markdown-to-html extensions='targetBlank' markdown=challenge.instruction }}</div>
   {{/if}}
 
   {{#if hasIllustration}}

--- a/live/bower.json
+++ b/live/bower.json
@@ -8,7 +8,8 @@
     "bootstrap": "~3.3.7",
     "animate.css": "^3.5.2",
     "loaders.css": "^0.1.2",
-    "markdown-it": "^8.0.0"
+    "showdown": "1.4.3",
+    "showdown-target-blank": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/live/config/environment.js
+++ b/live/config/environment.js
@@ -61,6 +61,9 @@ module.exports = function (environment) {
     ENV.googleFonts = [];
   }
 
+  if (environment === 'integration') {
+  }
+
   if (environment === 'staging') {
   }
 

--- a/live/ember-cli-build.js
+++ b/live/ember-cli-build.js
@@ -64,6 +64,8 @@ module.exports = function (defaults) {
   // along with the exports of each module as its value.
 
   app.import('bower_components/bootstrap/dist/js/bootstrap.js');
+  app.import('bower_components/showdown/dist/showdown.js');
+  app.import('bower_components/showdown-target-blank/dist/showdown-target-blank.js');
 
   if (app.env !== 'test') {
     // css animations

--- a/live/mirage/data/challenges/qcu-challenge-with-links-in-instruction.js
+++ b/live/mirage/data/challenges/qcu-challenge-with-links-in-instruction.js
@@ -1,0 +1,18 @@
+export default  {
+  data: {
+    type: 'challenges',
+    id: 'qcu_challenge_id_with_links_in_instruction',
+    attributes: {
+      type: 'QCU',
+      instruction: "" +
+      "Une consigne avec plusieurs liens : \n" +
+      "- [Lien #1](http://lien.1.url)\n" +
+      "- [Lien #2](http://lien.2.url)\n" +
+      "- [Lien #3](http://lien.3.url)",
+      proposals: "" +
+      "- Choix #1\n " +
+      "- Choix #2\n " +
+      "- Choix #3"
+    }
+  }
+};

--- a/live/mirage/data/challenges/qcu-challenge.js
+++ b/live/mirage/data/challenges/qcu-challenge.js
@@ -4,7 +4,7 @@ export default  {
     id: 'qcu_challenge_id',
     attributes: {
       type: 'QCU',
-      instruction: "Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?",
+      instruction: "Julie a déposé un document dans un espace de [stockage](https://fr.wikipedia.org/wiki/Stockage) partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?",
       proposals: "" +
       "- J’ai déposé le document ici : P: > Equipe > Communication > Textes > intro.odt\n " +
       "- Ci-joint le document que j’ai déposé dans l’espace partagé\n " +

--- a/live/mirage/routes/get-challenge.js
+++ b/live/mirage/routes/get-challenge.js
@@ -1,9 +1,11 @@
 import qcuChallengeWithImage from '../data/challenges/qcu-challenge-with-image';
 import qcuChallengeWithAttachment from '../data/challenges/qcu-challenge-with-attachment';
+import qcuChallengeWithLinksInInstruction from '../data/challenges/qcu-challenge-with-links-in-instruction';
 import qcuChallenge from '../data/challenges/qcu-challenge';
 import qcmChallenge from '../data/challenges/qcm-challenge';
 import qrocmChallenge from '../data/challenges/qrocm-challenge';
 
+// eslint-disable-next-line complexity
 export default function (schema, request) {
 
   switch (request.params.id) {
@@ -18,6 +20,8 @@ export default function (schema, request) {
       return qcuChallengeWithImage;
     case qcuChallengeWithAttachment.data.id:
       return qcuChallengeWithAttachment;
+    case qcuChallengeWithLinksInInstruction.data.id:
+      return qcuChallengeWithLinksInInstruction;
     default:
       return qcuChallenge;
   }

--- a/live/package.json
+++ b/live/package.json
@@ -25,7 +25,7 @@
   },
   "repository": "",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.9.0"
   },
   "author": "",
   "license": "MIT",
@@ -54,6 +54,7 @@
     "ember-cli-mocha-reporter": "0.0.2",
     "ember-cli-postcss": "3.0.4",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-showdown": "2.8.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -61,11 +62,10 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-lodash": "0.0.10",
-    "ember-markdown-it": "0.0.4",
+    "ember-radio-buttons": "^4.0.1",
     "ember-resolver": "^2.0.3",
     "eslint": "^3.3.1",
     "loader.js": "^4.0.11",
-    "markdown-it": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.4.tgz",
     "mocha": "^3.0.0",
     "postcss-browser-reporter": "^0.5.0",
     "postcss-cssnext": "^2.7.0",
@@ -75,8 +75,5 @@
     "stylelint": "^7.2.0",
     "stylelint-config-standard": "^13.0.0",
     "tap-xunit": "^1.4.0"
-  },
-  "dependencies": {
-    "ember-radio-buttons": "^4.0.1"
   }
 }

--- a/live/package.json
+++ b/live/package.json
@@ -19,7 +19,7 @@
     "test:watch": "ember test --serve",
     "ci:test": "npm run build && ./scripts/ci-test.sh && npm run ci:coverage",
     "ci:coverage": "COVERALLS_REPO_TOKEN=4N0uyZhpJrg7ta7KAR3rz54qeOoHOmXqL ./node_modules/.bin/coveralls < coverage/lcov.info ; CODECLIMATE_REPO_TOKEN=4be8413753f290bf2f907800f8fe4da302d6e8c35c3d969f5c1ee39e003a14eb codeclimate-test-reporter < coverage/lcov.info ; rm -rf coverage/",
-    "deploy:development": "./scripts/deploy.sh development",
+    "deploy:integration": "./scripts/deploy.sh integration",
     "deploy:staging": "./scripts/deploy.sh staging",
     "deploy:production": "./scripts/deploy.sh production"
   },

--- a/live/scripts/deploy.sh
+++ b/live/scripts/deploy.sh
@@ -11,7 +11,7 @@ GIT_CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD | tr -d "\n"`
 }
 
 case $BUILD_ENV in
-  "development")
+  "integration")
     # if no <BUILD_OUTPUT> argument is given, use the branch name
     BUILD_OUTPUT=$GIT_CURRENT_BRANCH
   ;;

--- a/live/tests/acceptance/14-creer-une-epreuve-qroc-test.js
+++ b/live/tests/acceptance/14-creer-une-epreuve-qroc-test.js
@@ -8,7 +8,6 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import RSVP from 'rsvp';
 
 describe("Acceptance | 14 - Créer une épreuve de type QROC | ", function () {
 

--- a/live/tests/acceptance/216-gestion-des-liens-dans-l-ennonce-test.js
+++ b/live/tests/acceptance/216-gestion-des-liens-dans-l-ennonce-test.js
@@ -1,0 +1,42 @@
+import {
+  describe,
+  it,
+  before,
+  after
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+describe("Acceptance | 216 - Gestion des liens dans l'énoncé d'une épreuve |", function () {
+
+  let application;
+  let $links;
+
+  before(function () {
+    application = startApp();
+  });
+
+  after(function () {
+    destroyApp(application);
+  });
+
+  before(function (done) {
+    visit('/challenges/qcu_challenge_id_with_links_in_instruction/preview');
+    andThen(() => {
+      $links = findWithAssert('.challenge-instruction a');
+      done();
+    });
+  });
+
+  it("Le contenu de type [foo](bar) doit être converti sous forme de lien", function() {
+    expect($links.length).to.equal(3);
+  });
+
+  it("Les liens doivent s'ouvrir dans un nouvel onglet", function() {
+    for (let i = 0 ; i < $links.length ; i++) {
+      expect($links[i].getAttribute('target')).to.equal('_blank');
+    }
+  });
+
+});

--- a/live/tests/acceptance/32-creer-une-epreuve-qcu-test.js
+++ b/live/tests/acceptance/32-creer-une-epreuve-qcu-test.js
@@ -7,7 +7,6 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import markdownit from 'markdown-it';
 
 describe('Acceptance | 32 - Créer une épreuve de type QCU | ', function () {
 
@@ -44,7 +43,7 @@ describe('Acceptance | 32 - Créer une épreuve de type QCU | ', function () {
       });
 
       it('32.2 la consigne de l\'épreuve', function () {
-        expect($challenge.find('.challenge-instruction').html()).to.equal('<p>Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?</p>\n');
+        expect($challenge.find('.challenge-instruction').html()).to.contain('<p>Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?</p>');
       });
     });
   });

--- a/live/tests/acceptance/32-creer-une-epreuve-qcu-test.js
+++ b/live/tests/acceptance/32-creer-une-epreuve-qcu-test.js
@@ -43,8 +43,13 @@ describe('Acceptance | 32 - Créer une épreuve de type QCU | ', function () {
       });
 
       it('32.2 la consigne de l\'épreuve', function () {
-        expect($challenge.find('.challenge-instruction').html()).to.contain('<p>Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?</p>');
+        expect($challenge.find('.challenge-instruction').text()).to.contain('Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?');
       });
+
+      it('32.3 les liens dans la consigne de l\'épreuve qui seront ouvert dans un nouvel onglet', function () {
+        expect($challenge.find('.challenge-instruction').html()).to.contain('<a target="_blank" href="https://fr.wikipedia.org/wiki/Stockage">stockage</a> ');
+      });
+
     });
   });
 });

--- a/live/tests/acceptance/37-prévisualiser-un-test.js
+++ b/live/tests/acceptance/37-prévisualiser-un-test.js
@@ -7,15 +7,11 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import markdownit from 'markdown-it';
 
 describe('Acceptance | 37 - Prévisualiser un test |', function () {
 
   let challenges;
   let course;
-  let courseId;
-  let firstChallengeId;
-  let secondChallengeId;
   let lastChallengeId;
 
   let application;
@@ -81,8 +77,7 @@ describe('Acceptance | 37 - Prévisualiser un test |', function () {
       });
 
       it("37.6. la consigne de l'épreuve", function () {
-        const expectedMarkdown = markdownit().render("Que peut-on dire des œufs de catégorie A ?");
-        expect($challenge.find('.challenge-instruction').html()).to.equal(expectedMarkdown);
+        expect($challenge.find('.challenge-instruction').html()).to.contain("Que peut-on dire des œufs de catégorie A ?");
       });
 
       it("37.7. un bouton pour accéder à l'épreuve suivante", function () {

--- a/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
+++ b/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
@@ -7,7 +7,6 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import markdownit from 'markdown-it';
 
 describe('Acceptance | 4 - Démarrer une épreuve |', function() {
 
@@ -35,9 +34,8 @@ describe('Acceptance | 4 - Démarrer une épreuve |', function() {
   describe('Les informations visibles pour une épreuve de type QCU sont :', function () {
 
     it('4.2. la consigne de l\'épreuve', function () {
-      const expectedMarkdown = markdownit().render("Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?");
       const $instruction = findWithAssert('.challenge-instruction');
-      expect($instruction.html()).to.equal(expectedMarkdown);
+      expect($instruction.html()).to.contain("Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?");
     });
 
     it('4.3. les propositions de l\'épreuve', function () {

--- a/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
+++ b/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
@@ -35,7 +35,7 @@ describe('Acceptance | 4 - Démarrer une épreuve |', function() {
 
     it('4.2. la consigne de l\'épreuve', function () {
       const $instruction = findWithAssert('.challenge-instruction');
-      expect($instruction.html()).to.contain("Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?");
+      expect($instruction.html()).to.contain('Julie a déposé un document dans un espace de <a target="_blank" href="https://fr.wikipedia.org/wiki/Stockage">stockage</a> partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?');
     });
 
     it('4.3. les propositions de l\'épreuve', function () {

--- a/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
+++ b/live/tests/acceptance/4-demarrer-une-epreuve-qcu-test.js
@@ -35,7 +35,7 @@ describe('Acceptance | 4 - Démarrer une épreuve |', function() {
 
     it('4.2. la consigne de l\'épreuve', function () {
       const $instruction = findWithAssert('.challenge-instruction');
-      expect($instruction.html()).to.contain('Julie a déposé un document dans un espace de <a target="_blank" href="https://fr.wikipedia.org/wiki/Stockage">stockage</a> partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?');
+      expect($instruction.text()).to.contain('Julie a déposé un document dans un espace de stockage partagé avec Pierre. Elle lui envoie un mail pour l’en informer. Quel est le meilleur message ?');
     });
 
     it('4.3. les propositions de l\'épreuve', function () {

--- a/live/tests/unit/initializers/configure-pix-api-host-test.js
+++ b/live/tests/unit/initializers/configure-pix-api-host-test.js
@@ -33,17 +33,6 @@ describe('ConfigurePixApiHostInitializer', function () {
 
   describe('configurePixApiHost', function () {
 
-    it('should detect localhost', function () {
-      // given
-      const location = { hostname: 'localhost:4200' };
-
-      // when
-      const pixApiHost = configurePixApiHost(location);
-
-      // then
-      expect(pixApiHost).to.equal(`http://localhost:3000`);
-    });
-
     it('should detect Pix production', function () {
       // given
       ENV.environment = 'production';
@@ -66,8 +55,9 @@ describe('ConfigurePixApiHostInitializer', function () {
       expect(pixApiHost).to.equal('http://api-staging.pix-app.ovh')
     });
 
-    it('should detect feature branches environment', function () {
+    it('should detect Pix integration', function () {
       // given
+      ENV.environment = 'integration';
       const location = { hostname: '123-user-stories-are-magic.pix.beta.gouv.fr' };
 
       // when
@@ -76,5 +66,17 @@ describe('ConfigurePixApiHostInitializer', function () {
       // then
       expect(pixApiHost).to.equal(`http://123-user-stories-are-magic.pix-app.ovh`)
     });
+
+    it('should detect localhost', function () {
+      // given
+      const location = { hostname: 'localhost:4200' };
+
+      // when
+      const pixApiHost = configurePixApiHost(location);
+
+      // then
+      expect(pixApiHost).to.equal(`http://localhost:3000`);
+    });
+
   });
 });


### PR DESCRIPTION
Cette story s'est révélé plus compliquée que prévu.

J'ai dû changer le parser de Markdown que nous utilisions : je suis passé de [Markdown-it](https://github.com/markdown-it/markdown-it) à [Showdown](https://github.com/showdownjs/showdown).

Outre que Showdown possède plus de stars sur GitHub avec une communauté plus active, l'extension qui m'intéressait – [showdown-target-blank](https://github.com/cybercase/showdown-target-blank) – était fonctionnelle avec Bower quand celle de markdown-it – [markdown-it-link-attributes](https://github.com/crookedneighbor/markdown-it-link-attributes) – n'était pas disponible lors du `bower install`.

Par ailleurs, j'ai passé du temps à approfondir ma compréhension du fonctionnement des [initializers Ember](https://guides.emberjs.com/v2.8.0/applications/initializers/). En particulier, il n'est pas possible de faire un `import Shodown from 'shodown'` depuis un initializer. Le cas échéant, une erreur est levée indiquant dans la console : `could not find module shodown required in <pix-live/app/initializers/my_initializer>"`.

En revanche, il m'a été possible d'accéder directement à l'objet / variable glovale `showdown` : 

``` javascript
// pix-live/app/initializers/my_initializer.js

shodown.extension('targetBlank', function() {
  // code dupliqué depuis le repository de l'extension 
  // https://github.com/cybercase/showdown-target-blank/blob/master/src/target_blank.js
  return [
    {
      type:   'output',
      regex: '<a(.*?)>',
      replace: function (match, content) {
        return content.indexOf('mailto:') !== -1 ? '<a' + content + '>' : '<a target="_blank"' + content + '>';
      }
    }
  ];
})
```

Finalement, j'ai opté pour l'approche [Bower](https://guides.emberjs.com/v2.8.0/addons-and-dependencies/managing-dependencies/#toc_bower).

Si j'ai bien tout compris, il y a 2 façons d'intégrer une lib : 
- via un addon ember qui se charge de l'intégration ; le problème c'est que la montée de version de la lib et la configuration (ou l'ajout de plugins sous-jacents) dépend du plugin Ember faisant la glue
- via Bower, auquel cas il faut penser à déclarer l'import dans Ember-CLI

En passant par Bower, il suffit d'ajouter les 2 dépendances (Shodown + extension target-blank) dans le `bower.json` et de déclarer les imports dans le fichier `ember-cli-build.js`. Et voilà !

Dernière chose : d'après le code source du module showdown-target-blank, si le module showdown est préalablement chargé, alors l'extension est rajoutée automatiquement, sans qu'il n'y ait quoique ce soit à faire. C'est pour ça que l'on peut l'utiliser directement dans nos fichiers de template, ex : 

``` handlebars
<!-- pix-live/app/templates/components/challenge-item.hbs -->
{{ markdown-to-html extensions='targetBlank' markdown=challenge.instruction }}
```
