### PR TITLE
[#353] [BUGFIX] Correction du rendu de la route /placement-tests (US-425).

### DIFF
--- a/live/app/components/course-item.js
+++ b/live/app/components/course-item.js
@@ -9,7 +9,7 @@ const CourseItem = Ember.Component.extend({
 
   imageUrl: Ember.computed('course', function () {
     const imageUrl = this.get('course.imageUrl');
-    return imageUrl ? imageUrl : '/assets/images/course-default-image.png';
+    return imageUrl ? imageUrl : '/images/course-default-image.png';
   }),
 
   actions: {

--- a/live/app/routes/placement-tests.js
+++ b/live/app/routes/placement-tests.js
@@ -6,5 +6,12 @@ export default Ember.Route.extend({
 
   model() {
     return this.store.query('course', { isAdaptive: true });
+  },
+
+  actions: {
+    startCourse(course) {
+      this.transitionTo('courses.create-assessment', course);
+    }
   }
+
 });

--- a/live/app/templates/placement-tests.hbs
+++ b/live/app/templates/placement-tests.hbs
@@ -1,3 +1,3 @@
-<div class="page placement-tests-page">
+<div class="placement-tests-page-courses__course-list">
   {{course-list courses=model startCourse='startCourse'}}
 </div>

--- a/live/app/templates/placement-tests.hbs
+++ b/live/app/templates/placement-tests.hbs
@@ -1,33 +1,3 @@
 <div class="page placement-tests-page">
-  <div class="container">
-    <ul class="row courses">
-
-      {{#each model as |course|}}
-        <li class="col-md-4 course-item animated fadeIn">
-          <div class="rounded-panel course" data-id="{{ course.id }}">
-            {{#if course.imageUrl}}
-              <img class="course-picture" src="{{ course.imageUrl }}" alt="Illustration du test">
-            {{else}}
-              <img class="course-picture" src="{{rootURM}}images/course-default-image.png" alt="Illustration du test">
-            {{/if}}
-
-            <div class="course-content">
-              <h4 class="course-name">{{ course.name }}</h4>
-              <div class="course-description">
-                {{ course.description }}
-              </div>
-            </div>
-
-            <div class="course-actions">
-              {{#link-to "courses.create-assessment" course.id class="button button-primary start-button"}}
-                Démarrer le test
-              {{/link-to}}
-            </div>
-          </div>
-        </li>
-      {{/each}}
-
-    </ul>
-  </div>
-
+  {{course-list courses=model startCourse='startCourse'}}
 </div>

--- a/live/tests/acceptance/a5-voir-liste-tests-adaptatifs-test.js
+++ b/live/tests/acceptance/a5-voir-liste-tests-adaptatifs-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | a5 - voir la liste des tests adaptatifs', function () {
+describe('Acceptance | a5 - La page des tests adaptatifs', function () {
 
   let application;
 
@@ -16,34 +16,14 @@ describe('Acceptance | a5 - voir la liste des tests adaptatifs', function () {
     destroyApp(application);
   });
 
-  it('a5.1 on affiche autant de tests que remontés par l\'API', function () {
-    expect(findWithAssert('.course')).to.have.lengthOf(1);
+  it('a5.0 est accessible depuis "/placement-tests"', function () {
+    expect(currentURL()).to.equal('/placement-tests');
   });
 
-  describe('a5.2 pour un test donné avec toutes les informations', function () {
+  describe('a5.1 contient une section', function () {
 
-    let $course;
-
-    beforeEach(function () {
-      $course = findWithAssert('.course[data-id="ref_course_id"]');
+    it('a5.1.1 avec la liste des tests', function () {
+      findWithAssert('.placement-tests-page-courses__course-list');
     });
-
-    it('a5.2.1 on affiche son nom', function () {
-      expect($course.find('.course-name').text()).to.contains('First Course');
-    });
-
-    it('a5.2.2 on affiche sa description', function () {
-      expect($course.find('.course-description').text()).to.contains('Contient toutes sortes d\'epreuves avec différentes caractéristiques couvrant tous les cas d\'usage');
-    });
-
-    it('a5.2.3 on affiche son image', function () {
-      expect($course.find('img')[0].src).to.equal('http://fakeimg.pl/350x200/?text=First%20Course');
-    });
-
-    it('a5.2.4 on affiche un bouton "démarrer le test"', function () {
-      expect($course.find('.start-button').text()).to.contains('Démarrer le test');
-    });
-
   });
-
 });

--- a/live/tests/integration/components/course-item-test.js
+++ b/live/tests/integration/components/course-item-test.js
@@ -40,7 +40,7 @@ describe('Integration | Component | course item', function () {
 
       // then
       const $picture = this.$('.course-item__picture');
-      expect($picture.attr('src')).to.equal('/assets/images/course-default-image.png');
+      expect($picture.attr('src')).to.equal('/images/course-default-image.png');
     });
 
     it('should render course name', function () {

--- a/live/tests/unit/components/course-item-test.js
+++ b/live/tests/unit/components/course-item-test.js
@@ -43,7 +43,7 @@ describe('Unit | Component | CourseItemComponent', function () {
 
       // then
       expect(imageUrl).to.exists;
-      expect(imageUrl).to.equal('/assets/images/course-default-image.png');
+      expect(imageUrl).to.equal('/images/course-default-image.png');
     });
 
   });


### PR DESCRIPTION
Hai! Y avait `/assets/images` au lieu de `/images` pour `course-default-image.png` (image par défaut d'un test), j'ai vérifié et c'est pas normal.

Aussi j'ai dû ajouter l'action `startCourse` à `app/routes/placement-tests.js`. Peut-être que vous voudriez que le code de `app/routes/placement-tests.js` ressemble davantage à `app/routes/index.js` (il n'y a pas de RSVP par exemple) ?