### PR TITLE
[#362] [INFRA] Stope Pretender explicitement à la fin de chaque test

### DIFF
--- a/live/tests/helpers/destroy-app.js
+++ b/live/tests/helpers/destroy-app.js
@@ -2,4 +2,5 @@ import Ember from 'ember';
 
 export default function destroyApp(application) {
   Ember.run(application, 'destroy');
+  server.shutdown();
 }


### PR DESCRIPTION
This fixes several warnings during acceptance tests:

>You created a second Pretender instance while there was already one running.

See https://github.com/samselikoff/ember-cli-mirage/issues/915