### PR TITLE
[#366] [INFRA] Correction d'avertissements dans les tests : "unsafe CSS bindings"

### DIFF
--- a/live/app/components/progress-bar.js
+++ b/live/app/components/progress-bar.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  classNames: ['progress', 'pix-progress-bar']
+  classNames: ['progress', 'pix-progress-bar'],
+
+  barStyle: Ember.computed('progress.stepPercentage', function() {
+    return Ember.String.htmlSafe(`width: ${this.get('progress.stepPercentage')}%`);
+  })
 });

--- a/live/app/components/timeout-jauge.js
+++ b/live/app/components/timeout-jauge.js
@@ -48,6 +48,10 @@ export default Ember.Component.extend({
     return 100 - (get(this, 'remainingSeconds') / actualAllotedTime) * 100;
   }),
 
+  jaugeWidthStyle: computed('percentageOfTimeout', function() {
+    return Ember.String.htmlSafe(`width: ${this.get('percentageOfTimeout')}%`);
+  }),
+
   hasFinished: computed('remainingSeconds', function() {
     return get(this, 'remainingSeconds') <= 0;
   }),

--- a/live/app/templates/components/progress-bar.hbs
+++ b/live/app/templates/components/progress-bar.hbs
@@ -1,8 +1,8 @@
 <div class="progress-bar progress-bar-info"
      role="progressbar"
-     aria-valuenow="{{progress.currentStep}}"
+     aria-valuenow={{progress.currentStep}}
      aria-valuemin="0"
      aria-valuemax="100"
-     style="width:{{progress.stepPercentage}}%">
+     style={{barStyle}}>
   {{progress.currentStep}} / {{progress.maxStep}}
 </div>

--- a/live/app/templates/components/timeout-jauge.hbs
+++ b/live/app/templates/components/timeout-jauge.hbs
@@ -11,7 +11,7 @@
         {{remainingTime}}
       </div>
     </div>
-    <div class="timeout-jauge-progress" style="width:{{percentageOfTimeout}}%">
+    <div class="timeout-jauge-progress" style={{jaugeWidthStyle}}>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Ember déconseille de binder directement une variable `style` à une chaîne de caractères lambda : si la chaîne de caractère contient des données contrôlées par l'utilisateur, cela peut mener à une injection de CSS.

C'est la raison pour laquelle Ember affiche un warning pendant plusieurs des tests :

> WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes

Cette PR corrige la plupart de ces warnings, en appliquant le refactoring recommandé par la doc sur :

- `components/progress-bar`
- `components/timeout-jauge`

Le dernier de ces warnings est dû à une dépendance externe, `ember-routable-modal`. J'ai ouvert une PR pour corriger le warning upstream : https://github.com/dbbk/ember-routable-modal/pull/3

