### PR TITLE
[#379] [FEATURE] Signaler une épreuve directement depuis l'épreuve en question (US-394).

### DIFF
--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -3,8 +3,6 @@ import callOnlyOnce from '../utils/call-only-once';
 import _ from 'pix-live/utils/lodash-custom';
 import ENV from 'pix-live/config/environment';
 
-let warningConfirmationSent = false;
-
 const ChallengeItemGeneric = Ember.Component.extend({
 
   tagName: 'article',
@@ -13,6 +11,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
 
   _elapsedTime: null,
   _timer: null,
+  _hasUserAknowledgedTimingWarning: false,
 
   init() {
     this._super(...arguments);
@@ -22,7 +21,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
   },
 
   didUpdateAttrs() {
-    if (!warningConfirmationSent) {
+    if (!this.get('_hasUserAknowledgedTimingWarning')) {
       this.set('hasUserConfirmWarning', false);
       this.set('hasChallengeTimer', this.hasTimerDefined());
     }
@@ -40,6 +39,10 @@ const ChallengeItemGeneric = Ember.Component.extend({
 
   hasChallengeTimer: Ember.computed('challenge', function () {
     return this.hasTimerDefined();
+  }),
+
+  canDisplayFeedbackPanel: Ember.computed('_hasUserAknowledgedTimingWarning', function () {
+    return !this.hasTimerDefined() || (this.hasTimerDefined() && this.get('_hasUserAknowledgedTimingWarning'));
   }),
 
   hasTimerDefined(){
@@ -81,20 +84,20 @@ const ChallengeItemGeneric = Ember.Component.extend({
       }
       const answerValue = this._getAnswerValue();
       this.sendAction('onValidated', this.get('challenge'), this.get('assessment'), answerValue, this._getTimeout(), this._getElapsedTime());
-      warningConfirmationSent = false;
+      this.set('_hasUserAknowledgedTimingWarning', false);
     }),
 
     skip: callOnlyOnce(function () {
       this.set('errorMessage', null);
       this.sendAction('onValidated', this.get('challenge'), this.get('assessment'), '#ABAND#', this._getTimeout(), this._getElapsedTime());
-      warningConfirmationSent = false;
+      this.set('_hasUserAknowledgedTimingWarning', false);
     }),
 
     setUserConfirmation() {
       this._start();
       this.toggleProperty('hasUserConfirmWarning');
       this.toggleProperty('hasChallengeTimer');
-      warningConfirmationSent = true;
+      this.set('_hasUserAknowledgedTimingWarning', true);
     }
   }
 

--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -21,6 +21,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
   },
 
   didUpdateAttrs() {
+    this._super(...arguments);
     if (!this.get('_hasUserAknowledgedTimingWarning')) {
       this.set('hasUserConfirmWarning', false);
       this.set('hasChallengeTimer', this.hasTimerDefined());

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -9,46 +9,52 @@ export default Ember.Component.extend({
 
   store: Ember.inject.service(),
 
-  answer: null,
-  email: '',
-  content: '',
-  error: null,
-  status: FORM_CLOSED,
-  isFormClosed: Ember.computed.equal('status', FORM_CLOSED),
-  isFormOpened: Ember.computed.equal('status', FORM_OPENED),
+  assessment: null,
+  challenge: null,
+
+  _email: '',
+  _content: '',
+  _error: null,
+  _status: FORM_CLOSED,
+
+  isFormClosed: Ember.computed.equal('_status', FORM_CLOSED),
+  isFormOpened: Ember.computed.equal('_status', FORM_OPENED),
 
   actions: {
+
     openFeedbackForm() {
-      this.set('status', FORM_OPENED);
+      this.set('_status', FORM_OPENED);
     },
 
     sendFeedback() {
-      if (!Ember.isEmpty(this.get('email')) && !isValid(this.get('email'))) {
-        this.set('error', 'Vous devez saisir une adresse mail valide.');
+      const email = this.get('_email');
+      if (!Ember.isEmpty(email) && !isValid(email)) {
+        this.set('_error', 'Vous devez saisir une adresse mail valide.');
         return;
       }
 
-      if (Ember.isEmpty(this.get('content').trim())) {
-        this.set('error', 'Vous devez saisir un message.');
+      if (Ember.isEmpty(this.get('_content').trim())) {
+        this.set('_error', 'Vous devez saisir un message.');
         return;
       }
 
       const store = this.get('store');
-      const answer = this.get('answer');
+      const assessment = this.get('assessment');
+      const challenge = this.get('challenge');
 
       const feedback = store.createRecord('feedback', {
-        email: this.get('email'),
-        content: this.get('content'),
-        assessment: answer.get('assessment'),
-        challenge: answer.get('challenge')
+        email: this.get('_email'),
+        content: this.get('_content'),
+        assessment,
+        challenge
       });
-      feedback.save()
-        .then(() => this.set('status', FORM_SUBMITTED));
+
+      feedback.save().then(() => this.set('_status', FORM_SUBMITTED));
     },
 
     cancelFeedback() {
-      this.set('error', null);
-      this.set('status', FORM_CLOSED);
+      this.set('_error', null);
+      this.set('_status', FORM_CLOSED);
     }
   }
 });

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -8,6 +8,7 @@ const FORM_SUBMITTED = 'FORM_SUBMITTED';
 export default Ember.Component.extend({
 
   store: Ember.inject.service(),
+  classNames: ['feedback-panel'],
 
   assessment: null,
   challenge: null,

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -8,18 +8,31 @@ const FORM_SUBMITTED = 'FORM_SUBMITTED';
 export default Ember.Component.extend({
 
   store: Ember.inject.service(),
+
   classNames: ['feedback-panel'],
 
   assessment: null,
   challenge: null,
 
-  _email: '',
-  _content: '',
-  _error: null,
   _status: FORM_CLOSED,
+  _email: null,
+  _content: null,
+  _error: null,
 
   isFormClosed: Ember.computed.equal('_status', FORM_CLOSED),
   isFormOpened: Ember.computed.equal('_status', FORM_OPENED),
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+    this.reset();
+  },
+
+  reset() {
+    this.set('_status', FORM_CLOSED);
+    this.set('_email', null);
+    this.set('_content', null);
+    this.set('_error', null);
+  },
 
   actions: {
 
@@ -54,8 +67,7 @@ export default Ember.Component.extend({
     },
 
     cancelFeedback() {
-      this.set('_error', null);
-      this.set('_status', FORM_CLOSED);
+      this.reset();
     }
   }
 });

--- a/live/app/styles/app.scss
+++ b/live/app/styles/app.scss
@@ -17,6 +17,7 @@
 @import 'components/app-footer';
 @import 'components/corner-ribbon';
 @import 'components/challenge-actions';
+@import 'components/challenge-item';
 @import 'components/challenge-response';
 @import 'components/challenge-statement';
 @import 'components/challenge-stay';

--- a/live/app/styles/components/_challenge-item.scss
+++ b/live/app/styles/components/_challenge-item.scss
@@ -1,0 +1,4 @@
+.challenge-item__feedback {
+  border-top: solid 1px #d8d8d8;
+  padding: 20px 0;
+}

--- a/live/app/styles/components/_comparison-window.scss
+++ b/live/app/styles/components/_comparison-window.scss
@@ -111,3 +111,10 @@
   border: solid 1.5px #d5d5d5;
   margin-left: 22px;
 }
+
+.comparison-window__feedback-panel {
+  background-color: $feedback-panel-background-color;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  padding: 20px 40px;
+}

--- a/live/app/styles/components/_feedback-panel.scss
+++ b/live/app/styles/components/_feedback-panel.scss
@@ -1,10 +1,6 @@
 .feedback-panel {
-  background-color: $feedback-panel-background-color;
   color: $charcoal-grey;
-  padding: 20px 40px;
   font-size: 15px;
-  border-bottom-left-radius: 5px;
-  border-bottom-right-radius: 5px;
 }
 
 /* "Link" view

--- a/live/app/styles/components/_feedback-panel.scss
+++ b/live/app/styles/components/_feedback-panel.scss
@@ -9,7 +9,9 @@
 .feedback-panel__open-link {
   cursor: pointer;
   color: inherit;
-  font-weight: 600;
+  font-weight: 900;
+  font-size: 15px;
+  line-height: 20px;
 }
 
 .feedback-panel__open-link:hover,
@@ -25,6 +27,7 @@
   font-size: 15px;
   font-weight: 900;
   margin: 0 0 20px;
+  line-height: 20px;
 }
 
 .feedback-panel__form-description {

--- a/live/app/templates/assessments/get-challenge.hbs
+++ b/live/app/templates/assessments/get-challenge.hbs
@@ -17,7 +17,4 @@
         answers=model.answers
         onValidated="saveAnswerAndNavigate"}}
   </div>
-
-  {{feedback-panel assessment=model.assessment challenge=model.challenge}}
-
 </div>

--- a/live/app/templates/assessments/get-challenge.hbs
+++ b/live/app/templates/assessments/get-challenge.hbs
@@ -17,4 +17,7 @@
         answers=model.answers
         onValidated="saveAnswerAndNavigate"}}
   </div>
+
+  {{feedback-panel assessment=model.assessment challenge=model.challenge}}
+
 </div>

--- a/live/app/templates/components/challenge-item-qcm.hbs
+++ b/live/app/templates/components/challenge-item-qcm.hbs
@@ -41,5 +41,7 @@
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}
-  {{feedback-panel assessment=assessment challenge=challenge}}
+  <div class="challenge-item__feedback">
+    {{feedback-panel assessment=assessment challenge=challenge}}
+  </div>
 {{/if}}

--- a/live/app/templates/components/challenge-item-qcm.hbs
+++ b/live/app/templates/components/challenge-item-qcm.hbs
@@ -39,3 +39,7 @@
   {{/if}}
 
 {{/unless}}
+
+{{#if canDisplayFeedbackPanel}}
+  {{feedback-panel assessment=assessment challenge=challenge}}
+{{/if}}

--- a/live/app/templates/components/challenge-item-qcu.hbs
+++ b/live/app/templates/components/challenge-item-qcu.hbs
@@ -40,5 +40,7 @@
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}
-  {{feedback-panel assessment=assessment challenge=challenge}}
+  <div class="challenge-item__feedback">
+    {{feedback-panel assessment=assessment challenge=challenge}}
+  </div>
 {{/if}}

--- a/live/app/templates/components/challenge-item-qcu.hbs
+++ b/live/app/templates/components/challenge-item-qcu.hbs
@@ -38,3 +38,7 @@
     {{challenge-actions skip="skip" validate="validate"}}
   {{/if}}
 {{/unless}}
+
+{{#if canDisplayFeedbackPanel}}
+  {{feedback-panel assessment=assessment challenge=challenge}}
+{{/if}}

--- a/live/app/templates/components/challenge-item-qroc.hbs
+++ b/live/app/templates/components/challenge-item-qroc.hbs
@@ -40,5 +40,7 @@
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}
-  {{feedback-panel assessment=assessment challenge=challenge}}
+  <div class="challenge-item__feedback">
+    {{feedback-panel assessment=assessment challenge=challenge}}
+  </div>
 {{/if}}

--- a/live/app/templates/components/challenge-item-qroc.hbs
+++ b/live/app/templates/components/challenge-item-qroc.hbs
@@ -38,3 +38,7 @@
     {{challenge-actions skip="skip" validate="validate"}}
   {{/if}}
 {{/unless}}
+
+{{#if canDisplayFeedbackPanel}}
+  {{feedback-panel assessment=assessment challenge=challenge}}
+{{/if}}

--- a/live/app/templates/components/challenge-item-qrocm.hbs
+++ b/live/app/templates/components/challenge-item-qrocm.hbs
@@ -39,3 +39,7 @@
     {{challenge-actions skip="skip" validate="validate"}}
   {{/if}}
 {{/unless}}
+
+{{#if canDisplayFeedbackPanel}}
+  {{feedback-panel assessment=assessment challenge=challenge}}
+{{/if}}

--- a/live/app/templates/components/challenge-item-qrocm.hbs
+++ b/live/app/templates/components/challenge-item-qrocm.hbs
@@ -34,12 +34,13 @@
     </div>
   {{/if}}
 
-
   {{#if assessment}}
     {{challenge-actions skip="skip" validate="validate"}}
   {{/if}}
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}
-  {{feedback-panel assessment=assessment challenge=challenge}}
+  <div class="challenge-item__feedback">
+    {{feedback-panel assessment=assessment challenge=challenge}}
+  </div>
 {{/if}}

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -72,7 +72,6 @@
         </div>
       {{/if}}
 
-
       {{#if isAssessmentChallengeTypeQrocmInd}}
         <div class="comparison-window__corrected-answers comparison-window__corrected-answers--qrocm">
           {{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -82,7 +82,7 @@
 
     <div class="routable-modal--footer">
       <div class="comparison-window__feedback-panel">
-        {{feedback-panel answer=answer}}
+        {{feedback-panel assessment=answer.assessment challenge=challenge}}
       </div>
     </div>
   </div>

--- a/live/app/templates/components/feedback-panel.hbs
+++ b/live/app/templates/components/feedback-panel.hbs
@@ -1,44 +1,40 @@
-<div class="feedback-panel">
+{{#if isFormClosed}}
+  <div class="feedback-panel__view feedback-panel__view--link">
+    <a class="feedback-panel__open-link" {{action "openFeedbackForm"}}>Signaler un problème</a>
+  </div>
 
-  {{#if isFormClosed}}
-    <div class="feedback-panel__view feedback-panel__view--link">
-      <a class="feedback-panel__open-link" {{action "openFeedbackForm"}}>Signaler un problème</a>
+{{else if isFormOpened}}
+  <div class="feedback-panel__view feedback-panel__view--form">
+    <h3 class="feedback-panel__form-title">Signaler un problème</h3>
+
+    <div class="feedback-panel__form-description">
+      <p>PIX est à l’écoute de vos remarques pour améliorer les épreuves proposées #personnenestparfait.</p>
+      <p>Vous pouvez nous laisser votre adresse mail si vous le souhaitez. Vos coordonnées ne feront l’objet d’aucune transmission à des tiers.</p>
     </div>
 
-  {{else if isFormOpened}}
-    <div class="feedback-panel__view feedback-panel__view--form">
-      <h3 class="feedback-panel__form-title">Signaler un problème</h3>
+    <div class="feedback-panel__form-wrapper">
+      <form class="feedback-panel__form">
+        <div class="feedback-panel__group">
+          {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=_email placeholder="Votre email (optionnel)"}}
+        </div>
+        <div class="feedback-panel__group">
+          {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
+        </div>
 
-      <div class="feedback-panel__form-description">
-        <p>PIX est à l’écoute de vos remarques pour améliorer les épreuves proposées #personnenestparfait.</p>
-        <p>Vous pouvez nous laisser votre adresse mail si vous le souhaitez. Vos coordonnées ne feront l’objet d’aucune transmission à des tiers.</p>
-      </div>
-
-      <div class="feedback-panel__form-wrapper">
-        <form class="feedback-panel__form">
-          <div class="feedback-panel__group">
-            {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=_email placeholder="Votre email (optionnel)"}}
+        {{#if _error}}
+          <div class="alert alert-danger" role="alert">
+            {{_error}}
           </div>
-          <div class="feedback-panel__group">
-            {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
-          </div>
-
-          {{#if _error}}
-            <div class="alert alert-danger" role="alert">
-              {{_error}}
-            </div>
-          {{/if}}
-          <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
-          <button class="feedback-panel__button feedback-panel__button--cancel" {{action "cancelFeedback"}}>Annuler</button>
-        </form>
-      </div>
+        {{/if}}
+        <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
+        <button class="feedback-panel__button feedback-panel__button--cancel" {{action "cancelFeedback"}}>Annuler</button>
+      </form>
     </div>
+  </div>
 
-  {{else }}
-    <div class="feedback-panel__view feedback-panel__view--mercix">
-      <p>Votre commentaire a bien été transmis à l’équipe du projet PIX.</p>
-      <p>Mercix !</p>
-    </div>
-  {{/if}}
-
-</div>
+{{else }}
+  <div class="feedback-panel__view feedback-panel__view--mercix">
+    <p>Votre commentaire a bien été transmis à l’équipe du projet PIX.</p>
+    <p>Mercix !</p>
+  </div>
+{{/if}}

--- a/live/app/templates/components/feedback-panel.hbs
+++ b/live/app/templates/components/feedback-panel.hbs
@@ -17,15 +17,15 @@
       <div class="feedback-panel__form-wrapper">
         <form class="feedback-panel__form">
           <div class="feedback-panel__group">
-            {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=email placeholder="Votre email (optionnel)"}}
+            {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=_email placeholder="Votre email (optionnel)"}}
           </div>
           <div class="feedback-panel__group">
-            {{textarea class="feedback-panel__field feedback-panel__field--content" value=content placeholder="Votre message" rows=6}}
+            {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
           </div>
 
-          {{#if error}}
+          {{#if _error}}
             <div class="alert alert-danger" role="alert">
-              {{error}}
+              {{_error}}
             </div>
           {{/if}}
           <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>

--- a/live/tests/acceptance/b7-epreuve-points-communs-test.js
+++ b/live/tests/acceptance/b7-epreuve-points-communs-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function () {
+describe.only('Acceptance | b7 - Points communs a toutes les épreuves | ', function () {
 
   let application;
 
@@ -57,5 +57,9 @@ describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function 
 
     // then
     andThen(() => expect(currentURL()).to.equal('/'));
+  });
+
+  it('b7.7 Il est possible de signaler l\'épreuve via le formulaire de Feedback', () => {
+    expect($('.feedback-panel')).to.have.lengthOf(1);
   });
 });

--- a/live/tests/acceptance/b7-epreuve-points-communs-test.js
+++ b/live/tests/acceptance/b7-epreuve-points-communs-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe.only('Acceptance | b7 - Points communs a toutes les épreuves | ', function () {
+describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function () {
 
   let application;
 
@@ -57,9 +57,5 @@ describe.only('Acceptance | b7 - Points communs a toutes les épreuves | ', func
 
     // then
     andThen(() => expect(currentURL()).to.equal('/'));
-  });
-
-  it('b7.7 Il est possible de signaler l\'épreuve via le formulaire de Feedback', () => {
-    expect($('.feedback-panel')).to.have.lengthOf(1);
   });
 });

--- a/live/tests/acceptance/b7-epreuve-points-communs-test.js
+++ b/live/tests/acceptance/b7-epreuve-points-communs-test.js
@@ -58,4 +58,8 @@ describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function 
     // then
     andThen(() => expect(currentURL()).to.equal('/'));
   });
+
+  it('b7.7 Il est possible de signaler l\'épreuve via le formulaire de Feedback', () => {
+    expect($('.feedback-panel')).to.have.lengthOf(1);
+  });
 });

--- a/live/tests/acceptance/h2-page-warning-timee-test.js
+++ b/live/tests/acceptance/h2-page-warning-timee-test.js
@@ -42,6 +42,10 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
       expect($('.timeout-jauge')).to.have.lengthOf(0);
     });
 
+    it('h2.4 le formulaire de signalement n\'est pas affiché pour une épreuve chronométrée tant que l\'usager n\'a pas confirmé être prêt pour l\'épreuve', () => {
+      expect($('.feedback-panel')).to.have.lengthOf(0);
+    });
+
   });
 
   describe('h2-Test comportement lorsque le bouton de confirmation est cliqué', function () {
@@ -63,6 +67,10 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
       expect($('.timeout-jauge')).to.have.lengthOf(1);
     });
 
+    it('h2.4 le formulaire de signalement est affiché', () => {
+      expect($('.feedback-panel')).to.have.lengthOf(1);
+    });
+
   });
 
   describe('h2-Affichage de la page warning pour 2 epreuves timées du même types (suite au bug US-424)', function () {
@@ -80,7 +88,8 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
 
       // then
       expect($('.challenge-item-warning')).to.have.lengthOf(1);
-
     });
   });
+
+
 });

--- a/live/tests/acceptance/l1-signaler-une-epreuve-test.js
+++ b/live/tests/acceptance/l1-signaler-une-epreuve-test.js
@@ -1,0 +1,67 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+const FEEDBACK_FORM = '.feedback-panel__form';
+
+describe('Acceptance | Signaler une épreuve', function() {
+
+  let application;
+
+  before(function() {
+    application = startApp();
+  });
+
+  after(function() {
+    destroyApp(application);
+  });
+
+  function assertThatFeedbackPanelExist() {
+    expect(find('.feedback-panel')).to.have.lengthOf(1);
+  }
+
+  function assertThatFeedbackFormIsClosed() {
+    expect(find('.feedback-panel__open-link')).to.have.lengthOf(1);
+    expect(find(FEEDBACK_FORM)).to.have.lengthOf(0);
+  }
+
+  function assertThatFeedbackFormIsOpen() {
+    expect(find('.feedback-panel__open-link')).to.have.lengthOf(0);
+    expect(find(FEEDBACK_FORM)).to.have.lengthOf(1);
+  }
+
+  it('l1.1 Je peux signaler une épreuve depuis la page de comparaison de mes réponses avec celles attendues pour une épreuve (page de résultat du test)', async () => {
+    await visit('/assessments/ref_assessment_id/results/compare/ref_answer_qcm_id/1');
+    assertThatFeedbackPanelExist();
+  });
+
+  it('l1.2 Je peux signaler une épreuve directement depuis l\'épreuve en question', async () => {
+    await visit('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
+    assertThatFeedbackPanelExist();
+  });
+
+  it('l1.3 Le formulaire de signalement d\'une épreuve est remis à zéro dès que je change d\'épreuve', async () => {
+    await visit('/assessments/ref_assessment_id/challenges/ref_qru_challenge_id');
+    assertThatFeedbackFormIsClosed();
+
+    await click('.feedback-panel__open-link');
+    assertThatFeedbackFormIsOpen();
+
+    await click('.challenge-actions__action-skip');
+    assertThatFeedbackFormIsClosed();
+  });
+
+  it('l1.4 Le formulaire de signalement est remis à zéro même quand les 2 épreuves qui s\'enchaînent utilisent le même composant challenge-item-* (ex : q1 est de type "QCU" et q2 "QRU" ; toutes deux utilisent le composant challenge-item-qcu)', async () => {
+    // In our Mirage data set, in the "ref course", the QCU challenge is followed by a QRU's one
+    await visit('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
+    assertThatFeedbackFormIsClosed();
+
+    await click('.feedback-panel__open-link');
+    assertThatFeedbackFormIsOpen();
+
+    await click('.challenge-actions__action-skip');
+    assertThatFeedbackFormIsClosed();
+  });
+
+});

--- a/live/tests/integration/components/feedback-panel-test.js
+++ b/live/tests/integration/components/feedback-panel-test.js
@@ -51,7 +51,7 @@ describe('Integration | Component | feedback-panel', function () {
   describe('Link view', function () {
 
     beforeEach(function () {
-      this.render(hbs`{{feedback-panel status='FORM_CLOSED'}}`);
+      this.render(hbs`{{feedback-panel _status='FORM_CLOSED'}}`);
     });
 
     it('should display only the "link" view', function () {
@@ -95,11 +95,11 @@ describe('Integration | Component | feedback-panel', function () {
       // configure answer & cie. model object
       const assessment = Ember.Object.extend({ id: 'assessment_id' }).create();
       const challenge = Ember.Object.extend({ id: 'challenge_id' }).create();
-      const answer = Ember.Object.extend({ id: 'answer_id', assessment, challenge }).create();
 
       // render component
-      this.set('answer', answer);
-      this.render(hbs`{{feedback-panel answer=answer status='FORM_OPENED'}}`);
+      this.set('assessment', assessment);
+      this.set('challenge', challenge);
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge _status='FORM_OPENED'}}`);
 
       // stub store service
       this.register('service:store', storeStub);
@@ -176,7 +176,7 @@ describe('Integration | Component | feedback-panel', function () {
   describe('Mercix view', function () {
 
     beforeEach(function () {
-      this.render(hbs`{{feedback-panel status='FORM_SUBMITTED'}}`);
+      this.render(hbs`{{feedback-panel _status='FORM_SUBMITTED'}}`);
     });
 
     it('should display only the "mercix" view', function () {
@@ -188,7 +188,7 @@ describe('Integration | Component | feedback-panel', function () {
 
     it('should display error if "content" is blank', function () {
       // given
-      this.render(hbs`{{feedback-panel status='FORM_OPENED' content='   '}}`);
+      this.render(hbs`{{feedback-panel _status='FORM_OPENED' _content='   '}}`);
 
       // when
       this.$(BUTTON_SEND).click();
@@ -200,7 +200,7 @@ describe('Integration | Component | feedback-panel', function () {
 
     it('should display error if "email" is set but invalid', function () {
       // given
-      this.render(hbs`{{feedback-panel status='FORM_OPENED' content='Lorem ipsum dolor sit amet' email='wrong_email'}}`);
+      this.render(hbs`{{feedback-panel _status='FORM_OPENED' _content='Lorem ipsum dolor sit amet' _email='wrong_email'}}`);
 
       // when
       this.$(BUTTON_SEND).click();
@@ -211,7 +211,7 @@ describe('Integration | Component | feedback-panel', function () {
 
     it('should not display error if "form" view (with error) was closed and re-opened', function () {
       // given
-      this.render(hbs`{{feedback-panel status='FORM_OPENED' content='   '}}`);
+      this.render(hbs`{{feedback-panel _status='FORM_OPENED' _content='   '}}`);
       this.$(BUTTON_SEND).click();
       expect(this.$('.alert')).to.have.length(1);
 

--- a/live/tests/unit/components/feedback-panel-test.js
+++ b/live/tests/unit/components/feedback-panel-test.js
@@ -22,7 +22,7 @@ describe('Unit | Component | feedback-panel', function () {
     it('should return true if status equals "FORM_CLOSED"', function () {
       // given
       const component = this.subject();
-      component.set('status', 'FORM_CLOSED');
+      component.set('_status', 'FORM_CLOSED');
 
       // when
       const isFormClosed = component.get('isFormClosed');
@@ -34,7 +34,7 @@ describe('Unit | Component | feedback-panel', function () {
     it('should return false if status is not equal to "FORM_CLOSED"', function () {
       // given
       const component = this.subject();
-      component.set('status', 'FORM_OPENED');
+      component.set('_status', 'FORM_OPENED');
 
       // when
       const isFormClosed = component.get('isFormClosed');
@@ -50,7 +50,7 @@ describe('Unit | Component | feedback-panel', function () {
     it('should return true if status equals "FORM_OPENED"', function () {
       // given
       const component = this.subject();
-      component.set('status', 'FORM_OPENED');
+      component.set('_status', 'FORM_OPENED');
 
       // when
       const isFormClosed = component.get('isFormOpened');
@@ -62,7 +62,7 @@ describe('Unit | Component | feedback-panel', function () {
     it('should return false if status is not equal to "FORM_OPENED"', function () {
       // given
       const component = this.subject();
-      component.set('status', 'FORM_CLOSED');
+      component.set('_status', 'FORM_CLOSED');
 
       // when
       const isFormClosed = component.get('isFormOpened');


### PR DESCRIPTION
**WHY**
Aujourd'hui il faut attendre d'être sur la page des résultats pour signaler une erreur ou un désaccord avec une épreuve. L'objet de cette PR est de permettre aux usagers de signaler une épreuve immédiatement, dans le contexte de l'épreuve, afin d'encourager la remontée de feedback, de meilleure qualité encore.

**HOW**
Je pensais aller hyper vite à sortir cette story, du fait qu'on a peaufiné le composant `feedback-panel` et que, en théorie, il suffit de le rajouter à la page `get-challenge`. Mais j'ai été freiné par le fait que les composants `challenge-item-* ` et `warning-page` ne respectent pas la _Ember Way_. C'était vraiment dur de comprendre le code existant et de détecter les bons endroits où mettre mon code. Je pense qu'il devient urgent de revoir la façon dont on prévient l'utilisateur que la prochaine épreuve est timée (et utiliser les [mécanismes de transition d'Ember](https://guides.emberjs.com/v2.12.0/routing/redirection/)).

Par ailleurs, il y avait un bug dans le composant feedback-panel, qui ne s'est jamais révélé jusqu'à présent car le cas n'est pas encore arrivé : quand on enchaîne 2 épreuves de même modalité, si le formulaire de feedback a été affiché ou soumis dans la 1ère épreuve, quand on passe à la suivante, alors le formulaire n'était pas remis à zéro. J'ai corrigé via une méthode `reset` que j'appelle dans le hook [`didUpdateAttrs`](https://guides.emberjs.com/v2.12.0/components/the-component-lifecycle/).

