### PR TITLE
[#382] [INFRA] Correction du dernier avertissement dans les tests : "unsafe CSS bindings"

### DIFF
--- a/live/package.json
+++ b/live/package.json
@@ -50,7 +50,7 @@
     "ember-math-helpers": "2.0.5",
     "ember-metrics": "0.8.1",
     "ember-resolver": "2.1.1",
-    "ember-routable-modal": "0.2.1",
+    "ember-routable-modal": "dbbk/ember-routable-modal#a5b7a0bb",
     "ember-route-action-helper": "2.0.2",
     "ember-source": "2.11.2",
     "eslint": "3.16.0",


### PR DESCRIPTION
This fixes a CSS-bindings warning during tests (cd. #366)

The latest version of this module is currently broken – so we pin to the specific commit that fixes the warning.