### PR TITLE
[#384] [CLEANUP] Prépare le passage à Ember 2.12

### DIFF
--- a/live/app/components/comparison-window.js
+++ b/live/app/components/comparison-window.js
@@ -69,5 +69,11 @@ export default Ember.Component.extend({
       resultItem = contentReference[answerStatus];
     }
     return resultItem;
-  })
+  }),
+
+  actions: {
+    saveFeedback(feedback) {
+      return feedback.save();
+    }
+  }
 });

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -71,8 +71,8 @@ export default Ember.Component.extend({
         assessment,
         challenge
       });
-
-      feedback.save().then(() => this.set('_status', FORM_SUBMITTED));
+      this.get('save')(feedback)
+        .then(() => this.set('_status', FORM_SUBMITTED));
     },
 
     cancelFeedback() {

--- a/live/app/components/follower-form.js
+++ b/live/app/components/follower-form.js
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
 
       const store = this.get('store');
       const follower = store.createRecord('follower', {email: email});
-      follower.save()
+      this.get('save')(follower)
         .then(() => {
           this.set('status', 'success');
           hideMessageDiv(this);

--- a/live/app/routes/index.js
+++ b/live/app/routes/index.js
@@ -13,6 +13,10 @@ export default Ember.Route.extend({
   actions: {
     startCourse(course) {
       this.transitionTo('courses.create-assessment', course);
+    },
+
+    saveFollower(follower) {
+      return follower.save();
     }
   }
 

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -81,7 +81,7 @@
 
     <div class="routable-modal--footer">
       <div class="comparison-window__feedback-panel">
-        {{feedback-panel assessment=answer.assessment challenge=challenge default_status='FORM_OPENED'}}
+        {{feedback-panel assessment=answer.assessment challenge=challenge default_status='FORM_OPENED' save=(action "saveFeedback")}}
       </div>
     </div>
   </div>

--- a/live/app/templates/index.hbs
+++ b/live/app/templates/index.hbs
@@ -38,7 +38,7 @@
     <h2 class="index-page-community__title">Rejoindre la communauté</h2>
     <p class="index-page-community__description">Vous souhaitez devenir béta‑testeur<br>ou être informé(e) du développement de Pix ?</p>
     <div class="index-page-community__form">
-      {{follower-form}}
+      {{follower-form save="saveFollower"}}
     </div>
   </section>
 

--- a/live/tests/test-helper.js
+++ b/live/tests/test-helper.js
@@ -1,4 +1,12 @@
 import resolver from './helpers/resolver';
-import { setResolver } from 'ember-mocha';
+import {
+  setResolver
+} from 'ember-mocha';
+import { mocha } from 'mocha';
+
+mocha.setup({
+  timeout: 2000,
+  slow: 500,
+});
 
 setResolver(resolver);

--- a/live/tests/unit/routes/assessments/get-challenge-test.js
+++ b/live/tests/unit/routes/assessments/get-challenge-test.js
@@ -4,7 +4,9 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | Assessments.ChallengeRoute', function () {
 
-  setupTest('route:assessments.get-challenge', {});
+  setupTest('route:assessments.get-challenge', {
+    needs: ['service:assessment']
+  });
 
   it('exists', function () {
     const route = this.subject();

--- a/live/tests/unit/routes/competences-test.js
+++ b/live/tests/unit/routes/competences-test.js
@@ -5,8 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Route | competences', function() {
 
   setupTest('route:competences', {
-    // Specify the other units that are required for this test.
-    // needs: ['controller:foo']
+    needs: ['service:panelActions']
   });
 
   it('exists', function() {

--- a/live/tests/unit/routes/placement-tests-test.js
+++ b/live/tests/unit/routes/placement-tests-test.js
@@ -4,7 +4,9 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | placement-tests', function() {
 
-  setupTest('route:placement-tests', {});
+  setupTest('route:placement-tests', {
+    needs: ['service:delay']
+  });
 
   it('exists', function() {
     const route = this.subject();


### PR DESCRIPTION
Cette PR effectue les nettoyages nécessaires au passage à Ember 2.12. Comme ça l'upgrade effective se passera comme sur des roulettes.

Au menu :

- **On déclare explicitement les services dont on a besoin dans les tests unitaires**. Allez savoir pourquoi, ça passe dans Ember <= 2.11 – mais clairement ça ne devrait pas.
- **On vire les stubs du store Ember Data dans les tests.** Pour stubber le service, on ré-enregistrait un `service:store` avec notre stub. Ember 2.12 n'aime pas ça du tout, et pète une erreur _"Holà, t'as déjà un service avec ce nom, tu vas pas l'écraser comme ça non plus."_.

  À la place de ce stub moche, j'ai déporté les `model.save()` des composants en question : ce sont maintenant des actions, gérées par le niveau du dessus. Ce qui fait qu'on peut facilement stubber ces actions dans les tests, et renvoyer la bonne promesse.

  Comme refactoring, c'est assez léger : ça ne rend pas les composants en question _beaucoup_ plus propres, mais ça ne change pas trop de code. En revanche les tests sont clairement plus élégants. Ça me semble un bon compromis avec _"tout ré-écrire muahaha"_.

Ça se relit assez bien commit-par-commit, si le cœur vous en dit.

Dans la prochaine PR on passera effectivement à Ember 2.12 :)