### PR TITLE
[#385] [CLEANUP] Déplacement de la logique d'affichage pour décider quel composant challenge-item-* afficher depuis le modèle "challenge" vers la route "assessments/get-challenge".

### DIFF
--- a/live/app/helpers/get-challenge-component-class.js
+++ b/live/app/helpers/get-challenge-component-class.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import _ from 'pix-live/utils/lodash-custom';
+
+export function getChallengeComponentClass(params) {
+  let result;
+  const challenge = params[0];
+  const challengeType = challenge.get('type').toUpperCase();
+  if (_(challengeType).isAmongst(['QCUIMG', 'QCU', 'QRU'])) {
+    result = 'qcu';
+  } else if (_(challengeType).isAmongst(['QCMIMG', 'QCM'])) {
+    result = 'qcm';
+  } else if (_(challengeType).isAmongst(['QROC'])) {
+    result = 'qroc';
+  } else if (_(challengeType).isAmongst(['QROCM', 'QROCM-IND', 'QROCM-DEP'])) {
+    result = 'qrocm';
+  }
+  return 'challenge-item-' + result;
+}
+
+export default Ember.Helper.helper(getChallengeComponentClass);

--- a/live/app/models/challenge.js
+++ b/live/app/models/challenge.js
@@ -2,11 +2,10 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ProposalsAsArrayMixin from './challenge/proposals-as-array-mixin';
 import ProposalsAsBlocksMixin from './challenge/proposals-as-blocks-mixin';
-import _ from 'pix-live/utils/lodash-custom';
 
 const { Model, attr } = DS;
 
-const ChallengeModel = Model.extend(ProposalsAsArrayMixin, ProposalsAsBlocksMixin, {
+export default Model.extend(ProposalsAsArrayMixin, ProposalsAsBlocksMixin, {
 
   instruction: attr('string'),
   proposals: attr('string'),
@@ -19,25 +18,6 @@ const ChallengeModel = Model.extend(ProposalsAsArrayMixin, ProposalsAsBlocksMixi
   hasAttachment: Ember.computed.notEmpty('attachments'),
   hasSingleAttachment: Ember.computed.equal('attachments.length', 1),
   hasMultipleAttachments: Ember.computed.gt('attachments.length', 1),
-  hasTimer: Ember.computed.notEmpty('timer'),
-
-  challengeItemType: Ember.computed('type', function() {
-    let result;
-    const challengeType = this.get('type').toUpperCase();
-
-    if (_(challengeType).isAmongst(['QCUIMG', 'QCU', 'QRU'])) {
-      result = 'qcu';
-    } else if (_(challengeType).isAmongst(['QCMIMG', 'QCM'])) {
-      result = 'qcm';
-    } else if (_(challengeType).isAmongst(['QROC'])) {
-      result = 'qroc';
-    } else if (_(challengeType).isAmongst(['QROCM', 'QROCM-IND', 'QROCM-DEP'])) {
-      result = 'qrocm';
-    }
-
-    return 'challenge-item-' + result;
-  })
+  hasTimer: Ember.computed.notEmpty('timer')
 
 });
-
-export default ChallengeModel;

--- a/live/app/routes/assessments/get-challenge.js
+++ b/live/app/routes/assessments/get-challenge.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import RSVP from 'rsvp';
-import _ from 'pix-live/utils/lodash-custom';
 
 export default Ember.Route.extend({
 
@@ -31,26 +30,6 @@ export default Ember.Route.extend({
       assessment_id: model.assessment.id,
       challenge_id: model.challenge.id
     };
-  },
-
-  setupController(controller, model) {
-    this._super(controller, model);
-    controller.set('_challengeComponentClass', this._componentClassForChallenge(model.challenge));
-  },
-
-  _componentClassForChallenge(challenge) {
-    let result;
-    const challengeType = challenge.get('type').toUpperCase();
-    if (_(challengeType).isAmongst(['QCUIMG', 'QCU', 'QRU'])) {
-      result = 'qcu';
-    } else if (_(challengeType).isAmongst(['QCMIMG', 'QCM'])) {
-      result = 'qcm';
-    } else if (_(challengeType).isAmongst(['QROC'])) {
-      result = 'qroc';
-    } else if (_(challengeType).isAmongst(['QROCM', 'QROCM-IND', 'QROCM-DEP'])) {
-      result = 'qrocm';
-    }
-    return 'challenge-item-' + result;
   },
 
   _createAnswer(answerValue, answerTimeout, currentChallenge, assessment, answerElapsedTime) {

--- a/live/app/routes/assessments/get-challenge.js
+++ b/live/app/routes/assessments/get-challenge.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import RSVP from 'rsvp';
+import _ from 'pix-live/utils/lodash-custom';
 
 export default Ember.Route.extend({
 
@@ -30,6 +31,26 @@ export default Ember.Route.extend({
       assessment_id: model.assessment.id,
       challenge_id: model.challenge.id
     };
+  },
+
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.set('_challengeComponentClass', this._componentClassForChallenge(model.challenge));
+  },
+
+  _componentClassForChallenge(challenge) {
+    let result;
+    const challengeType = challenge.get('type').toUpperCase();
+    if (_(challengeType).isAmongst(['QCUIMG', 'QCU', 'QRU'])) {
+      result = 'qcu';
+    } else if (_(challengeType).isAmongst(['QCMIMG', 'QCM'])) {
+      result = 'qcm';
+    } else if (_(challengeType).isAmongst(['QROC'])) {
+      result = 'qroc';
+    } else if (_(challengeType).isAmongst(['QROCM', 'QROCM-IND', 'QROCM-DEP'])) {
+      result = 'qrocm';
+    }
+    return 'challenge-item-' + result;
   },
 
   _createAnswer(answerValue, answerTimeout, currentChallenge, assessment, answerElapsedTime) {

--- a/live/app/templates/assessments/get-challenge.hbs
+++ b/live/app/templates/assessments/get-challenge.hbs
@@ -11,7 +11,7 @@
       </div>
     {{/unless}}
 
-    {{component _challengeComponentClass
+    {{component (get-challenge-component-class model.challenge)
         challenge=model.challenge
         assessment=model.assessment
         answers=model.answers

--- a/live/app/templates/assessments/get-challenge.hbs
+++ b/live/app/templates/assessments/get-challenge.hbs
@@ -11,7 +11,7 @@
       </div>
     {{/unless}}
 
-    {{component model.challenge.challengeItemType
+    {{component _challengeComponentClass
         challenge=model.challenge
         assessment=model.assessment
         answers=model.answers

--- a/live/app/templates/challenges/get-preview.hbs
+++ b/live/app/templates/challenges/get-preview.hbs
@@ -1,5 +1,6 @@
 <div id="challenge-preview">
     <div class="container">
-      {{component challengeItemType challenge=model.challenge }}
+      {{component (get-challenge-component-class model.challenge)
+        challenge=model.challenge }}
     </div>
 </div>

--- a/live/app/templates/courses/get-challenge-preview.hbs
+++ b/live/app/templates/courses/get-challenge-preview.hbs
@@ -1,7 +1,7 @@
 <div id="challenge-preview" data-id="{{ model.challenge.id }}" class="challenge-preview">
   <div class="container">
 
-    {{component challengeItemType
+    {{component (get-challenge-component-class model.challenge)
         challenge=model.challenge
         assessment=model.assessment
         onValidated=(action navigate)}}

--- a/live/tests/unit/helpers/get-challenge-component-class-test.js
+++ b/live/tests/unit/helpers/get-challenge-component-class-test.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { getChallengeComponentClass } from 'pix-live/helpers/get-challenge-component-class';
+
+describe('Unit | Helper | get challenge component class', function () {
+
+  [
+    { challengeType: 'QCU', expectedClass: 'challenge-item-qcu' },
+    { challengeType: 'QCUIMG', expectedClass: 'challenge-item-qcu' },
+    { challengeType: 'QRU', expectedClass: 'challenge-item-qcu' },
+    { challengeType: 'QCM', expectedClass: 'challenge-item-qcm' },
+    { challengeType: 'QCMIMG', expectedClass: 'challenge-item-qcm' },
+    { challengeType: 'QROC', expectedClass: 'challenge-item-qroc' },
+    { challengeType: 'QROCm', expectedClass: 'challenge-item-qrocm' },
+    { challengeType: 'QROCm-ind', expectedClass: 'challenge-item-qrocm' },
+    { challengeType: 'QROCm-dep', expectedClass: 'challenge-item-qrocm' }
+  ].forEach((useCase) => {
+
+    it(`should return component class "${useCase.expectedClass}" when challenge type is "${useCase.challengeType}"`, function () {
+      // given
+      const challenge = Ember.Object.create({ type: useCase.challengeType });
+      const params = [challenge];
+
+      // when
+      const componentClass = getChallengeComponentClass(params);
+
+      // then
+      expect(componentClass).to.equal(useCase.expectedClass);
+    });
+  });
+});
+

--- a/live/tests/unit/routes/assessments/get-challenge-test.js
+++ b/live/tests/unit/routes/assessments/get-challenge-test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import Ember from 'ember';
 
 describe('Unit | Route | Assessments.ChallengeRoute', function () {
 
@@ -11,35 +10,5 @@ describe('Unit | Route | Assessments.ChallengeRoute', function () {
     const route = this.subject();
     expect(route).to.be.ok;
   });
-
-  describe('#_componentClassForChallenge', function () {
-
-    [
-      { challengeType: 'QCU', expectedClass: 'challenge-item-qcu' },
-      { challengeType: 'QCUIMG', expectedClass: 'challenge-item-qcu' },
-      { challengeType: 'QRU', expectedClass: 'challenge-item-qcu' },
-      { challengeType: 'QCM', expectedClass: 'challenge-item-qcm' },
-      { challengeType: 'QCMIMG', expectedClass: 'challenge-item-qcm' },
-      { challengeType: 'QROC', expectedClass: 'challenge-item-qroc' },
-      { challengeType: 'QROCm', expectedClass: 'challenge-item-qrocm' },
-      { challengeType: 'QROCm-ind', expectedClass: 'challenge-item-qrocm' },
-      { challengeType: 'QROCm-dep', expectedClass: 'challenge-item-qrocm' }
-    ].forEach((useCase) => {
-
-      it(`should return component class "${useCase.expectedClass}" when challenge type is "${useCase.challengeType}"`, function() {
-        // given
-        const route = this.subject();
-        const challenge = Ember.Object.create({ type: useCase.challengeType});
-
-        // when
-        const componentClass = route._componentClassForChallenge(challenge);
-
-        // then
-        expect(componentClass).to.equal(useCase.expectedClass);
-      });
-    });
-
-  });
-
 
 });

--- a/live/tests/unit/routes/assessments/get-challenge-test.js
+++ b/live/tests/unit/routes/assessments/get-challenge-test.js
@@ -1,14 +1,45 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import Ember from 'ember';
 
-describe('Unit | Route | Assessments.ChallengeRoute', function() {
+describe('Unit | Route | Assessments.ChallengeRoute', function () {
 
   setupTest('route:assessments.get-challenge', {});
 
-  it('exists', function() {
+  it('exists', function () {
     const route = this.subject();
     expect(route).to.be.ok;
   });
+
+  describe('#_componentClassForChallenge', function () {
+
+    [
+      { challengeType: 'QCU', expectedClass: 'challenge-item-qcu' },
+      { challengeType: 'QCUIMG', expectedClass: 'challenge-item-qcu' },
+      { challengeType: 'QRU', expectedClass: 'challenge-item-qcu' },
+      { challengeType: 'QCM', expectedClass: 'challenge-item-qcm' },
+      { challengeType: 'QCMIMG', expectedClass: 'challenge-item-qcm' },
+      { challengeType: 'QROC', expectedClass: 'challenge-item-qroc' },
+      { challengeType: 'QROCm', expectedClass: 'challenge-item-qrocm' },
+      { challengeType: 'QROCm-ind', expectedClass: 'challenge-item-qrocm' },
+      { challengeType: 'QROCm-dep', expectedClass: 'challenge-item-qrocm' }
+    ].forEach((useCase) => {
+
+      it(`should return component class "${useCase.expectedClass}" when challenge type is "${useCase.challengeType}"`, function() {
+        // given
+        const route = this.subject();
+        const challenge = Ember.Object.create({ type: useCase.challengeType});
+
+        // when
+        const componentClass = route._componentClassForChallenge(challenge);
+
+        // then
+        expect(componentClass).to.equal(useCase.expectedClass);
+      });
+    });
+
+  });
+
 
 });


### PR DESCRIPTION
Ce n'est pas une bonne idée de gérer de la logique d'affichage utile pour le Templating dans un objet Modèle métier.

Cette PR a pour objet de déplacer la logique de templating contenue dans la méthode  `challengeItemType ` de la classe Modèle `live/app/models/challenge` et d'en faire un helper `live/app/helpers/get-challenge-component-class`.

Au départ, nous avions prévu avec @kemenaran de simplement en faire une méthode privée appelée dans la route `live/app/routes/assessments/get-challenge`, mais comme la logique est répétée plusieurs fois (dans la preview d'une Epreuve seule et dans la preview d'un Test), il semble plus judicieux d'en faire un helper.

Au passage, j'ai ajouté des tests unitaires sur le bout de logique qui n'était pas du tout testé.