### PR TITLE
[#388] [BUGFIX] Problème d'affichage de la modale de correction pour un QROCm-ind.

### DIFF
--- a/live/app/utils/solution-as-object.js
+++ b/live/app/utils/solution-as-object.js
@@ -2,8 +2,8 @@
 import _ from 'lodash';
 
 function transformSolutionsToString(solutionsAsObject) {
-  _.each(solutionsAsObject, function (potentialSolution) {
-    potentialSolution.forEach(function (value, index) {
+  _.each(solutionsAsObject, (potentialSolution) => {
+    potentialSolution.forEach((value, index) => {
       potentialSolution[index] = potentialSolution[index].toString();
     });
   });

--- a/live/package.json
+++ b/live/package.json
@@ -47,6 +47,7 @@
     "ember-exam": "0.6.0",
     "ember-export-application-global": "1.1.1",
     "ember-load-initializers": "0.6.3",
+    "ember-lodash": "^4.17.2",
     "ember-math-helpers": "2.0.5",
     "ember-metrics": "0.8.1",
     "ember-resolver": "2.1.1",


### PR DESCRIPTION
Le problème apparaît seulement en production. Tout fonctionne en local, sur les RA et en staging.

Cela est dû au fait qu'en production l'application Ember est buildée avec le mode `--environment=production`.

En creusant, on s'est rendu compte que l'erreur est liée au fichier `live/app/components/qrocm-ind-solution-panel.js`.

Et en creusant davantage, le problème est dû aux 2 imports suivants : 
- [l. 2] import _ from 'lodash';
- [l. 4] import solutionsAsObject from 'pix-live/utils/solution-as-object'; (qui lui-même importe lodash)

La root cause est qu'on utilise lodash côté Ember sans l'avoir importé dans l'application. Au moment de la concaténation/minification/uglification/optimisation par Babel pour la transpilation en mode "production", il y a une collision dans la gestion de nos (sous-)dépendances avec lodash.

La solution est simple : importer `ember-lodash`.

Pour info : pour arriver à traquer ce bug subtil, nous avons lancé l'application en local, en mode "production" et en nous connectant à l'API de staging.

Pour ce faire, il faut :
1. modifier la propriété Ember.APP.API_HOST dans le fichier `live/config/environment.js` pour spécifier en valeur "staging.pix.beta.gouv.fr" (ATTENTION ! à ne pas le commiter)
2. lancer le front avec la commande : `ember s --proxy --environment=production`



