### PR TITLE
[#397] [FEATURE] Améliorer l'ergonomie de l'éditeur d'épreuve pour configurer les traitements de la validation automatique (US-409).

### DIFF
--- a/api/lib/infrastructure/serializers/airtable/solution-serializer.js
+++ b/api/lib/infrastructure/serializers/airtable/solution-serializer.js
@@ -2,6 +2,16 @@ const _ = require('../../utils/lodash-utils');
 const Solution = require('../../../domain/models/referential/solution');
 const AirtableSerializer = require('./airtable-serializer');
 
+function isTreatmentDisable(fields, fieldName) {
+  return (fields[fieldName]) && (fields[fieldName] === 'Désactivé');
+}
+
+function checkTreatmentIsEnableAndRemoveItIfNot(fields, fieldName, enabledTreatments, treatment) {
+  if (isTreatmentDisable(fields, fieldName)) {
+    _.pull(enabledTreatments, treatment);
+  }
+}
+
 class SolutionSerializer extends AirtableSerializer {
 
   deserialize(airtableRecord) {
@@ -16,22 +26,17 @@ class SolutionSerializer extends AirtableSerializer {
 
       solution.type = fields['Type d\'épreuve'];
       solution.value = fields['Bonnes réponses'];
+
       solution.enabledTreatments = ['t1', 't2', 't3'];
-      if (fields['désactiver T1']) {
-        _.pull(solution.enabledTreatments, 't1');
-      }
-      if (fields['désactiver T2']) {
-        _.pull(solution.enabledTreatments, 't2');
-      }
-      if (fields['désactiver T3']) {
-        _.pull(solution.enabledTreatments, 't3');
-      }
+      checkTreatmentIsEnableAndRemoveItIfNot(fields, 'T1 - Espaces, casses & accents', solution.enabledTreatments, 't1');
+      checkTreatmentIsEnableAndRemoveItIfNot(fields, 'T2 - Ponctuation', solution.enabledTreatments, 't2');
+      checkTreatmentIsEnableAndRemoveItIfNot(fields, 'T3 - Distance d\'édition', solution.enabledTreatments, 't3');
 
       // TODO to be removed before code review
       solution.deactivations = {};
-      solution.deactivations.t1 = fields['désactiver T1'];
-      solution.deactivations.t2 = fields['désactiver T2'];
-      solution.deactivations.t3 = fields['désactiver T3'];
+      solution.deactivations.t1 = isTreatmentDisable(fields, 'T1 - Espaces, casses & accents');
+      solution.deactivations.t2 = isTreatmentDisable(fields, 'T2 - Ponctuation');
+      solution.deactivations.t3 = isTreatmentDisable(fields, 'T3 - Distance d\'édition');
 
       solution.scoring = _.ensureString(fields['Scoring']).replace(/@/g, ''); // XXX YAML ne supporte pas @
     }

--- a/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
@@ -1,11 +1,11 @@
 const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/solution-serializer');
 
-describe('Unit | Serializer | solution-serializer', function () {
+describe('Unit | Serializer | solution-serializer', () => {
 
-  describe('#deserialize', function () {
+  describe('#deserialize', () => {
 
-    it('should convert record "id" into "id" property', function () {
+    it('should convert record "id" into "id" property', () => {
       // given
       const airtableRecord = { id: 'rec123', fields: {} };
 
@@ -22,7 +22,7 @@ describe('Unit | Serializer | solution-serializer', function () {
 
     ].forEach(({ airtableField, modelProperty }) => {
 
-      it(`Should convert record '${airtableField}' field into '${modelProperty}' property`, function () {
+      it(`Should convert record '${airtableField}' field into '${modelProperty}' property`, () => {
         // given
         const fields = [];
         fields[airtableField] = `${modelProperty}_value`;
@@ -37,9 +37,9 @@ describe('Unit | Serializer | solution-serializer', function () {
 
     });
 
-    describe('Treatments options management', function () {
+    describe('Treatments options management', () => {
 
-      it('should return [t1, t2, t3] when treatments deactivations are not defined in Airtable', function () {
+      it('should return [t1, t2, t3] when validation treatments are not defined in Airtable', () => {
         // given
         const fields = [];
         const airtableRecord = { fields };
@@ -49,11 +49,11 @@ describe('Unit | Serializer | solution-serializer', function () {
         expect(solution.enabledTreatments).to.deep.equal(['t1', 't2', 't3']);
       });
 
-      it('should return [t2, t3] when T1 is deactivated in Airtable', function () {
+      it('should return [t2, t3] when T1 is deactivated in Airtable', () => {
         // given
         const airtableRecord = {
           fields: {
-            'désactiver T1': true
+            'T1 - Espaces, casses & accents': 'Désactivé'
           }
         };
         // when
@@ -62,11 +62,11 @@ describe('Unit | Serializer | solution-serializer', function () {
         expect(solution.enabledTreatments).to.deep.equal(['t2', 't3']);
       });
 
-      it('should return [t1, t3] when T2 is deactivated in Airtable', function () {
+      it('should return [t1, t3] when T2 is deactivated in Airtable', () => {
         // given
         const airtableRecord = {
           fields: {
-            'désactiver T2': true
+            'T2 - Ponctuation': 'Désactivé'
           }
         };
         // when
@@ -75,11 +75,11 @@ describe('Unit | Serializer | solution-serializer', function () {
         expect(solution.enabledTreatments).to.deep.equal(['t1', 't3']);
       });
 
-      it('should return [t1, t2] when T1 is deactivated in Airtable', function () {
+      it('should return [t1, t2] when T1 is deactivated in Airtable', () => {
         // given
         const airtableRecord = {
           fields: {
-            'désactiver T3': true
+            'T3 - Distance d\'édition': 'Désactivé'
           }
         };
         // when
@@ -88,13 +88,13 @@ describe('Unit | Serializer | solution-serializer', function () {
         expect(solution.enabledTreatments).to.deep.equal(['t1', 't2']);
       });
 
-      it('should return [] when T1, T2 and T3 are deactivated in Airtable', function () {
+      it('should return [] when T1, T2 and T3 are deactivated in Airtable', () => {
         // given
         const airtableRecord = {
           fields: {
-            'désactiver T1': true,
-            'désactiver T2': true,
-            'désactiver T3': true
+            'T1 - Espaces, casses & accents': 'Désactivé',
+            'T2 - Ponctuation': 'Désactivé',
+            'T3 - Distance d\'édition': 'Désactivé'
           }
         };
         // when
@@ -102,6 +102,22 @@ describe('Unit | Serializer | solution-serializer', function () {
         // then
         expect(solution.enabledTreatments).to.deep.equal([]);
       });
+
+      it('should take into account 3 values: _blank_, "Activé", "Désactivé"', () => {
+        // given
+        const airtableRecord = {
+          fields: {
+            'T2 - Ponctuation': 'Activé',
+            'T3 - Distance d\'édition': 'Désactivé'
+          }
+        };
+        // when
+        const solution = serializer.deserialize(airtableRecord);
+        // then
+        expect(solution.enabledTreatments).to.deep.equal(['t1', 't2']);
+      });
+
+
 
     });
   });


### PR DESCRIPTION
[Trello](https://trello.com/c/f8ocukUa/409-rendre-plus-lisible-activation-desactivation-t1-t2-et-t3)

Les producteurs d'épreuves s'emmêlent les pinceaux lorsqu'ils doivent configurer dans Airtable les traitements à appliquer pour une épreuve donnée.

Cette PR a pour objet de modifier le type et les intitulés des colonnes dans Airtable.

Ce qui a été fait : 
- pour assurer le coup, j'ai dupliqué les 3 colonnes T* le temps de passer cette story en production
- j'ai nommé les colonnes de façon plus explicite et tournées de façon positive ; désormais on ne désactive plus un traitement, on le déclare "Activé" ou "Désactivé"
- cette PR tient aussi compte du fait qu'aucun valeur n'est précisée, le cas échéant on considère le traitement correspondant "Activé"
- j'ai mis à jour les tests en conséquence et ai rajouté 1 test pour tenir compte de la nouvelle option "Activé"

**REMARQUE : il faudra bien penser à supprimer les anciennes colonnes dès que la story sera passée en production.**