### PR TITLE
[#401] [BUGFIX] Possibilité de signaler une épreuve depuis l'épreuve en question (US-483)

### DIFF
--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -99,7 +99,8 @@ const ChallengeItemGeneric = Ember.Component.extend({
       this.toggleProperty('hasUserConfirmWarning');
       this.toggleProperty('hasChallengeTimer');
       this.set('_hasUserAknowledgedTimingWarning', true);
-    }
+    },
+
   }
 
 });

--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -99,8 +99,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
       this.toggleProperty('hasUserConfirmWarning');
       this.toggleProperty('hasChallengeTimer');
       this.set('_hasUserAknowledgedTimingWarning', true);
-    },
-
+    }
   }
 
 });

--- a/live/app/components/comparison-window.js
+++ b/live/app/components/comparison-window.js
@@ -69,11 +69,5 @@ export default Ember.Component.extend({
       resultItem = contentReference[answerStatus];
     }
     return resultItem;
-  }),
-
-  actions: {
-    saveFeedback(feedback) {
-      return feedback.save();
-    }
-  }
+  })
 });

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
         assessment,
         challenge
       });
-      this.get('save')(feedback)
+      feedback.save()
         .then(() => this.set('_status', FORM_SUBMITTED));
     },
 

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -26,17 +26,17 @@ export default Ember.Component.extend({
 
   didReceiveAttrs() {
     this._super(...arguments);
-    this.reset();
+    this._reset();
   },
 
-  reset() {
+  _reset() {
     this.set('_email', null);
     this.set('_content', null);
     this.set('_error', null);
     this.set('_status', this._getDefaultStatus());
   },
 
-  closeForm(){
+  _closeForm(){
     this.set('_status', FORM_CLOSED);
     this.set('_error', null);
   },
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
     },
 
     cancelFeedback() {
-      this.closeForm();
+      this._closeForm();
     },
 
     sendFeedback() {

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -13,17 +13,16 @@ export default Ember.Component.extend({
 
   assessment: null,
   challenge: null,
-  default_status: FORM_CLOSED,
+  collapsible: true,
 
   _status: null,
   _email: null,
   _content: null,
   _error: null,
 
-  isFormClosedByDefault: Ember.computed.equal('default_status', FORM_CLOSED),
-
   isFormClosed: Ember.computed.equal('_status', FORM_CLOSED),
   isFormOpened: Ember.computed.equal('_status', FORM_OPENED),
+  isFormSubmitted: Ember.computed.equal('_status', FORM_SUBMITTED),
 
   didReceiveAttrs() {
     this._super(...arguments);
@@ -31,11 +30,10 @@ export default Ember.Component.extend({
   },
 
   reset() {
-    const default_status = this.get('default_status');
     this.set('_email', null);
     this.set('_content', null);
     this.set('_error', null);
-    this.set('_status', default_status);
+    this.set('_status', this._getDefaultStatus());
   },
 
   closeForm(){
@@ -43,10 +41,18 @@ export default Ember.Component.extend({
     this.set('_error', null);
   },
 
+  _getDefaultStatus() {
+    return this.get('collapsible') ? FORM_CLOSED : FORM_OPENED;
+  },
+
   actions: {
 
     openFeedbackForm() {
       this.set('_status', FORM_OPENED);
+    },
+
+    cancelFeedback() {
+      this.closeForm();
     },
 
     sendFeedback() {
@@ -56,7 +62,8 @@ export default Ember.Component.extend({
         return;
       }
 
-      if (Ember.isEmpty(this.get('_content').trim())) {
+      const content = this.get('_content');
+      if (Ember.isEmpty(content) || Ember.isEmpty(content.trim())) {
         this.set('_error', 'Vous devez saisir un message.');
         return;
       }
@@ -73,10 +80,6 @@ export default Ember.Component.extend({
       });
       feedback.save()
         .then(() => this.set('_status', FORM_SUBMITTED));
-    },
-
-    cancelFeedback() {
-      this.closeForm();
     }
   }
 });

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -81,7 +81,7 @@
 
     <div class="routable-modal--footer">
       <div class="comparison-window__feedback-panel">
-        {{feedback-panel assessment=answer.assessment challenge=challenge default_status='FORM_OPENED' save=(action "saveFeedback")}}
+        {{feedback-panel assessment=answer.assessment challenge=challenge default_status='FORM_OPENED'}}
       </div>
     </div>
   </div>

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -81,7 +81,7 @@
 
     <div class="routable-modal--footer">
       <div class="comparison-window__feedback-panel">
-        {{feedback-panel assessment=answer.assessment challenge=challenge default_status='FORM_OPENED'}}
+        {{feedback-panel assessment=answer.assessment challenge=challenge collapsible=false}}
       </div>
     </div>
   </div>

--- a/live/app/templates/components/feedback-panel.hbs
+++ b/live/app/templates/components/feedback-panel.hbs
@@ -2,26 +2,24 @@
   <div class="feedback-panel__view feedback-panel__view--link">
     <a class="feedback-panel__open-link" {{action "openFeedbackForm"}}>Signaler un problème</a>
   </div>
+{{/if}}
 
-{{else if isFormOpened}}
+{{#if isFormOpened}}
   <div class="feedback-panel__view feedback-panel__view--form">
     <h3 class="feedback-panel__form-title">Signaler un problème</h3>
 
     <div class="feedback-panel__form-description">
       <p>PIX est à l’écoute de vos remarques pour améliorer les épreuves proposées #personnenestparfait.</p>
-      <p>Vous pouvez nous laisser votre adresse mail si vous le souhaitez. Vos coordonnées ne feront l’objet d’aucune
-        transmission à des tiers.</p>
+      <p>Vous pouvez nous laisser votre adresse mail si vous le souhaitez. Vos coordonnées ne feront l’objet d’aucune transmission à des tiers.</p>
     </div>
 
     <div class="feedback-panel__form-wrapper">
       <form class="feedback-panel__form">
         <div class="feedback-panel__group">
-          {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=_email
-                  placeholder="Votre email (optionnel)"}}
+          {{input class="feedback-panel__field feedback-panel__field--email" type="text" value=_email placeholder="Votre email (optionnel)"}}
         </div>
         <div class="feedback-panel__group">
-          {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content
-                     placeholder="Votre message" rows=6}}
+          {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
         </div>
 
         {{#if _error}}
@@ -30,14 +28,16 @@
           </div>
         {{/if}}
         <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
-        {{#if isFormClosedByDefault}}
-          <button class="feedback-panel__button feedback-panel__button--cancel" {{action "cancelFeedback"}}>Annuler</button>
+        {{#if collapsible}}
+          <button class="feedback-panel__button feedback-panel__button--cancel" {{action "cancelFeedback"}}>Annuler
+          </button>
         {{/if}}
       </form>
     </div>
   </div>
+{{/if}}
 
-{{else }}
+{{#if isFormSubmitted}}
   <div class="feedback-panel__view feedback-panel__view--mercix">
     <p>Votre commentaire a bien été transmis à l’équipe du projet PIX.</p>
     <p>Mercix !</p>

--- a/live/package.json
+++ b/live/package.json
@@ -44,7 +44,6 @@
     "ember-cli-uglify": "1.2.0",
     "ember-collapsible-panel": "^2.0.1",
     "ember-data": "2.11.1",
-    "ember-exam": "0.6.0",
     "ember-export-application-global": "1.1.1",
     "ember-load-initializers": "0.6.3",
     "ember-lodash": "^4.17.2",

--- a/live/tests/integration/components/feedback-panel-test.js
+++ b/live/tests/integration/components/feedback-panel-test.js
@@ -73,25 +73,42 @@ describe('Integration | Component | feedback-panel', function () {
   });
 
   describe('Form view', function () {
-    let didReceiveSaveAction = false;
-    let feedbackToSave = null;
+
+    let isSaveMethodCalled = false;
+    let saveMethodBody = null;
+    let saveMethodUrl = null;
+
+    const storeStub = Ember.Service.extend({
+      createRecord() {
+        const createRecordArgs = arguments;
+        return Object.create({
+          save() {
+            isSaveMethodCalled = true;
+            saveMethodUrl = createRecordArgs[0];
+            saveMethodBody = createRecordArgs[1];
+            return Ember.RSVP.resolve();
+          }
+        });
+      }
+    });
 
     beforeEach(function () {
       // configure answer & cie. model object
       const assessment = Ember.Object.extend({ id: 'assessment_id' }).create();
       const challenge = Ember.Object.extend({ id: 'challenge_id' }).create();
 
-      // define actions
-      this.set('stubSaveFeedback', (feedback) => {
-        didReceiveSaveAction = true;
-        feedbackToSave = feedback;
-        return Ember.RSVP.resolve();
-      });
-
       // render component
       this.set('assessment', assessment);
       this.set('challenge', challenge);
-      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge default_status='FORM_OPENED' save=(action stubSaveFeedback)}}`);
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge default_status='FORM_OPENED'}}`);
+
+      // stub store service
+      this.register('service:store', storeStub);
+      this.inject.service('store', { as: 'store' });
+
+      isSaveMethodCalled = false;
+      saveMethodBody = null;
+      saveMethodUrl = null;
     });
 
     it('should display only the "form" view', function () {
@@ -132,12 +149,13 @@ describe('Integration | Component | feedback-panel', function () {
 
       // then
       return wait().then(() => {
-        expect(didReceiveSaveAction).to.be.true;
-        expect(_.isObject(feedbackToSave)).to.equal(true);
-        expect(feedbackToSave.get('assessement')).to.exists;
-        expect(feedbackToSave.get('challenge')).to.exists;
-        expect(feedbackToSave.get('content')).to.equal(CONTENT_VALUE);
-        expect(feedbackToSave.get('email')).to.equal(EMAIL_VALUE);
+        expect(isSaveMethodCalled).to.be.true;
+        expect(saveMethodUrl).to.equal('feedback');
+        expect(_.isObject(saveMethodBody)).to.equal(true);
+        expect(saveMethodBody.assessement).to.exists;
+        expect(saveMethodBody.challenge).to.exists;
+        expect(saveMethodBody.content).to.equal(CONTENT_VALUE);
+        expect(saveMethodBody.email).to.equal(EMAIL_VALUE);
         expectMercixViewToBeVisible(this);
       });
     });

--- a/live/tests/integration/components/feedback-panel-test.js
+++ b/live/tests/integration/components/feedback-panel-test.js
@@ -14,21 +14,33 @@ const BUTTON_SEND = '.feedback-panel__button--send';
 const BUTTON_CANCEL = '.feedback-panel__button--cancel';
 
 function expectLinkViewToBeVisible(component) {
-  expect(component.$(LINK_VIEW)).to.have.length(1);
-  expect(component.$(FORM_VIEW)).to.have.length(0);
-  expect(component.$(MERCIX_VIEW)).to.have.length(0);
+  expect(component.$(LINK_VIEW)).to.have.lengthOf(1);
+  expect(component.$(FORM_VIEW)).to.have.lengthOf(0);
+  expect(component.$(MERCIX_VIEW)).to.have.lengthOf(0);
 }
 
 function expectFormViewToBeVisible(component) {
-  expect(component.$(LINK_VIEW)).to.have.length(0);
-  expect(component.$(FORM_VIEW)).to.have.length(1);
-  expect(component.$(MERCIX_VIEW)).to.have.length(0);
+  expect(component.$(LINK_VIEW)).to.have.lengthOf(0);
+  expect(component.$(FORM_VIEW)).to.have.lengthOf(1);
+  expect(component.$(MERCIX_VIEW)).to.have.lengthOf(0);
 }
 
 function expectMercixViewToBeVisible(component) {
-  expect(component.$(LINK_VIEW)).to.have.length(0);
-  expect(component.$(FORM_VIEW)).to.have.length(0);
-  expect(component.$(MERCIX_VIEW)).to.have.length(1);
+  expect(component.$(LINK_VIEW)).to.have.lengthOf(0);
+  expect(component.$(FORM_VIEW)).to.have.lengthOf(0);
+  expect(component.$(MERCIX_VIEW)).to.have.lengthOf(1);
+}
+
+function setEmail(component, email) {
+  const $email = component.$('.feedback-panel__field--email');
+  $email.val(email);
+  $email.change();
+}
+
+function setContent(component, content) {
+  const $content = component.$('.feedback-panel__field--content');
+  $content.val(content);
+  $content.change();
 }
 
 describe('Integration | Component | feedback-panel', function () {
@@ -43,7 +55,7 @@ describe('Integration | Component | feedback-panel', function () {
       // when
       this.render(hbs`{{feedback-panel}}`);
       // then
-      expect(this.$()).to.have.length(1);
+      expect(this.$()).to.have.lengthOf(1);
       expectLinkViewToBeVisible(this);
     });
 
@@ -74,10 +86,6 @@ describe('Integration | Component | feedback-panel', function () {
 
   describe('Form view', function () {
 
-    let isSaveMethodCalled;
-    let saveMethodBody;
-    let saveMethodUrl;
-
     const storeStub = Ember.Service.extend({
       createRecord() {
         const createRecordArgs = arguments;
@@ -91,6 +99,10 @@ describe('Integration | Component | feedback-panel', function () {
         });
       }
     });
+
+    let isSaveMethodCalled;
+    let saveMethodBody;
+    let saveMethodUrl;
 
     beforeEach(function () {
       // configure answer & cie. model object
@@ -109,7 +121,7 @@ describe('Integration | Component | feedback-panel', function () {
       this.register('service:store', storeStub);
       this.inject.service('store', { as: 'store' });
 
-      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge default_status='FORM_OPENED'}}`);
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=false}}`);
     });
 
     it('should display only the "form" view', function () {
@@ -118,32 +130,29 @@ describe('Integration | Component | feedback-panel', function () {
 
     it('should contain email input field', function () {
       const $email = this.$('input.feedback-panel__field--email');
-      expect($email).to.have.length(1);
+      expect($email).to.have.lengthOf(1);
       expect($email.attr('placeholder')).to.equal('Votre email (optionnel)');
     });
 
     it('should contain content textarea field', function () {
       const $password = this.$('textarea.feedback-panel__field--content');
-      expect($password).to.have.length(1);
+      expect($password).to.have.lengthOf(1);
       expect($password.attr('placeholder')).to.equal('Votre message');
     });
 
     it('should contain "send" button with label "Envoyer" and placeholder "Votre email (optionnel)"', function () {
       const $buttonSend = this.$(BUTTON_SEND);
-      expect($buttonSend).to.have.length(1);
+      expect($buttonSend).to.have.lengthOf(1);
       expect($buttonSend.text()).to.equal('Envoyer');
     });
 
     it('clicking on "send" button should save the feedback into the store / API and display the "mercix" view', function () {
       // given
+      const EMAIL_VALUE = 'frere-jacques@gai-mail.com';
+      setEmail(this, EMAIL_VALUE);
+
       const CONTENT_VALUE = 'Prêtes-moi ta plume, pour écrire un mot';
-      const EMAIL_VALUE = 'myemail@gemail.com';
-      const $content = this.$('.feedback-panel__field--content');
-      const $email = this.$('.feedback-panel__field--email');
-      $content.val(CONTENT_VALUE);
-      $email.val(EMAIL_VALUE);
-      $content.change();
-      $email.change();
+      setContent(this, CONTENT_VALUE);
 
       // when
       this.$(BUTTON_SEND).click();
@@ -164,11 +173,11 @@ describe('Integration | Component | feedback-panel', function () {
     it('should not contain "cancel" button if the feedback form is opened by default', function () {
       // then
       const $buttonCancel = this.$(BUTTON_CANCEL);
-      expect($buttonCancel).to.have.length(0);
+      expect($buttonCancel).to.have.lengthOf(0);
     });
   });
 
-  describe('#Cancel Button available only if the feedback panel is closed by default', function () {
+  describe('#Cancel Button management', function () {
 
     beforeEach(function () {
       // configure answer & cie. model object
@@ -178,85 +187,128 @@ describe('Integration | Component | feedback-panel', function () {
       // render component
       this.set('assessment', assessment);
       this.set('challenge', challenge);
+    });
 
+    it('should not be visible if feedback-panel is not collapsible', function() {
+      // when
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=false}}`);
+
+      // then
+      expect(this.$(BUTTON_CANCEL)).to.have.lengthOf(0);
+    });
+
+    it('should not be visible if status is not FORM_OPENED', function() {
+      // when
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=true _status="FORM_CLOSED"}}`);
+
+      // then
+      expect(this.$(BUTTON_CANCEL)).to.have.lengthOf(0);
+    });
+
+    it('should be visible only if component is collapsible and form is opened', async function() {
+      // given
       this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
+
+      // when
+      this.$(OPEN_LINK).click();
+
+      // then
+      expect(this.$(BUTTON_CANCEL)).to.have.lengthOf(1);
     });
 
     it('should contain "cancel" button with label "Annuler" and placeholder "Votre message"', function () {
+      // given
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
+
       //when
       this.$(OPEN_LINK).click();
 
       //then
       const $buttonCancel = this.$(BUTTON_CANCEL);
-      expect($buttonCancel).to.have.length(1);
-      expect($buttonCancel.text()).to.equal('Annuler');
+      expect($buttonCancel).to.have.lengthOf(1);
+      expect($buttonCancel.text().trim()).to.equal('Annuler');
     });
 
     it('clicking on "cancel" button should close the "form" view and and display the "link" view', function () {
+      // given
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
+
       // when
       this.$(BUTTON_CANCEL).click();
+
       // then
       expectLinkViewToBeVisible(this);
     });
 
   });
 
-  describe('Mercix view', function () {
-
-    beforeEach(function () {
-      this.render(hbs`{{feedback-panel default_status='FORM_SUBMITTED'}}`);
-    });
-
-    it('should display only the "mercix" view', function () {
-      expectMercixViewToBeVisible(this);
-    });
-  });
-
   describe('Error management', function () {
 
-    it('should display error if "content" is blank', function () {
+    it('should display error if "content" is empty', function () {
       // given
-      this.render(hbs`{{feedback-panel default_status='FORM_OPENED'}}`);
-      this.$('.feedback-panel__field--content').val('   ');
-      this.$('.feedback-panel__field--content').change();
+      this.render(hbs`{{feedback-panel collapsible=false}}`);
 
       // when
       this.$(BUTTON_SEND).click();
 
       // then
-      expect(this.$('.alert')).to.have.length(1);
+      expect(this.$('.alert')).to.have.lengthOf(1);
+      expectFormViewToBeVisible(this);
+    });
+
+    it('should display error if "content" is blank', function () {
+      // given
+      this.render(hbs`{{feedback-panel collapsible=false}}`);
+      setContent(this, '');
+
+      // when
+      this.$(BUTTON_SEND).click();
+
+      // then
+      expect(this.$('.alert')).to.have.lengthOf(1);
       expectFormViewToBeVisible(this);
     });
 
     it('should display error if "email" is set but invalid', function () {
       // given
-      this.render(hbs`{{feedback-panel default_status='FORM_OPENED' _content='Lorem ipsum dolor sit amet'}}`);
-      this.$('.feedback-panel__field--email').val('wrong_email');
-      this.$('.feedback-panel__field--email').change();
+      this.render(hbs`{{feedback-panel collapsible=false}}`);
+      setEmail(this, 'wrong_email');
+      setContent(this, 'Valid content');
 
       // when
       this.$(BUTTON_SEND).click();
 
-      expect(this.$('.alert')).to.have.length(1);
+      expect(this.$('.alert')).to.have.lengthOf(1);
       expectFormViewToBeVisible(this);
     });
 
     it('should not display error if "form" view (with error) was closed and re-opened', function () {
       // given
       this.render(hbs`{{feedback-panel}}`);
+
       this.$(OPEN_LINK).click();
-      this.$('.feedback-panel__field--content').val('   ');
-      this.$('.feedback-panel__field--content').change();
+      setContent(this, '   ');
+
       this.$(BUTTON_SEND).click();
-      expect(this.$('.alert')).to.have.length(1);
+      expect(this.$('.alert')).to.have.lengthOf(1);
 
       // when
       this.$(BUTTON_CANCEL).click();
       this.$(OPEN_LINK).click();
 
       // then
-      expect(this.$('.alert')).to.have.length(0);
+      expect(this.$('.alert')).to.have.lengthOf(0);
     });
 
+    it('should display an error even if the user did not focus on email or content', function() {
+      // given
+      this.render(hbs`{{feedback-panel collapsible=false}}`);
+
+      // when
+      this.$(BUTTON_SEND).click();
+
+      // then
+      expect(this.$('.alert')).to.have.lengthOf(1);
+    });
   });
 });

--- a/live/tests/integration/components/feedback-panel-test.js
+++ b/live/tests/integration/components/feedback-panel-test.js
@@ -74,9 +74,9 @@ describe('Integration | Component | feedback-panel', function () {
 
   describe('Form view', function () {
 
-    let isSaveMethodCalled = false;
-    let saveMethodBody = null;
-    let saveMethodUrl = null;
+    let isSaveMethodCalled;
+    let saveMethodBody;
+    let saveMethodUrl;
 
     const storeStub = Ember.Service.extend({
       createRecord() {
@@ -100,15 +100,16 @@ describe('Integration | Component | feedback-panel', function () {
       // render component
       this.set('assessment', assessment);
       this.set('challenge', challenge);
-      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge default_status='FORM_OPENED'}}`);
+
+      isSaveMethodCalled = false;
+      saveMethodBody = null;
+      saveMethodUrl = null;
 
       // stub store service
       this.register('service:store', storeStub);
       this.inject.service('store', { as: 'store' });
 
-      isSaveMethodCalled = false;
-      saveMethodBody = null;
-      saveMethodUrl = null;
+      this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge default_status='FORM_OPENED'}}`);
     });
 
     it('should display only the "form" view', function () {
@@ -177,6 +178,7 @@ describe('Integration | Component | feedback-panel', function () {
       // render component
       this.set('assessment', assessment);
       this.set('challenge', challenge);
+
       this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
     });
 

--- a/live/tests/integration/components/follower-form-test.js
+++ b/live/tests/integration/components/follower-form-test.js
@@ -42,9 +42,10 @@ describe('Integration | Component | follower form', function() {
   */
 
   describe('Form view', function () {
-    let isSaveMethodCalled = false;
-    let saveMethodBody = null;
-    let saveMethodUrl = null;
+
+    let isSaveMethodCalled;
+    let saveMethodBody;
+    let saveMethodUrl;
 
     const storeStub = Ember.Service.extend({
       createRecord() {
@@ -82,8 +83,6 @@ describe('Integration | Component | follower form', function() {
 
 
     beforeEach(function () {
-      this.render(hbs`{{follower-form}}`);
-
       isSaveMethodCalled = false;
       saveMethodBody = null;
       saveMethodUrl = null;
@@ -94,6 +93,8 @@ describe('Integration | Component | follower form', function() {
       // stub store service
       this.register('service:store', storeStub);
       this.inject.service('store', { as: 'store' });
+
+      this.render(hbs`{{follower-form}}`);
 
       const EMAIL_VALUE = 'myemail@gemail.com';
       const $email = this.$(INPUT_EMAIL);
@@ -116,6 +117,8 @@ describe('Integration | Component | follower form', function() {
     it('clicking on "send" button should not save the email of the follower cause its already saved', function () {
       // given
       this.register('service:store', storeStubRejection);
+
+      this.render(hbs`{{follower-form}}`);
 
       const EMAIL_VALUE = 'myemail@gemail.com';
       const $email = this.$(INPUT_EMAIL);

--- a/live/tests/unit/components/feedback-panel-test.js
+++ b/live/tests/unit/components/feedback-panel-test.js
@@ -72,7 +72,7 @@ describe('Unit | Component | feedback-panel', function () {
 
   });
 
-  describe('#reset', function () {
+  describe('#_reset', function () {
 
     it('should return empty mail, text, error and back to the default status', function () {
       // given
@@ -84,7 +84,7 @@ describe('Unit | Component | feedback-panel', function () {
       component.set('_status', 'FORM_CLOSED');
 
       // when
-      component.reset();
+      component._reset();
 
       // then
       expect(component.get('_email')).to.be.null;
@@ -94,7 +94,7 @@ describe('Unit | Component | feedback-panel', function () {
     });
   });
 
-  describe('#closeForm', function () {
+  describe('#_closeForm', function () {
 
     it('should set status to CLOSED and set errors to null', function () {
       // given
@@ -103,7 +103,7 @@ describe('Unit | Component | feedback-panel', function () {
       component.set('_status', 'FORM_OPENED');
 
       // when
-      component.closeForm();
+      component._closeForm();
 
       // then
       expect(component.get('_error')).to.be.null;

--- a/live/tests/unit/components/feedback-panel-test.js
+++ b/live/tests/unit/components/feedback-panel-test.js
@@ -42,7 +42,6 @@ describe('Unit | Component | feedback-panel', function () {
       // then
       expect(isFormClosed).to.be.false;
     });
-
   });
 
   describe('#isFormOpened', function () {
@@ -73,38 +72,12 @@ describe('Unit | Component | feedback-panel', function () {
 
   });
 
-  describe('#isFormClosedByDefault', function () {
-
-    it('should return true if no specification', function () {
-      // given
-      const component = this.subject();
-
-      // when
-      const isFormClosedByDefault = component.get('isFormClosedByDefault');
-
-      // then
-      expect(isFormClosedByDefault).to.be.true;
-    });
-
-    it('should return false if we specified FORM_OPENED', function () {
-      // given
-      const component = this.subject();
-      component.set('default_status', 'FORM_OPENED');
-
-      // when
-      const isFormClosedByDefault = component.get('isFormClosedByDefault');
-
-      // then
-      expect(isFormClosedByDefault).to.be.false;
-    });
-  });
-
   describe('#reset', function () {
 
     it('should return empty mail, text, error and back to the default status', function () {
       // given
       const component = this.subject();
-      component.set('default_status', 'FORM_OPENED');
+      component.set('collapsible', false);
       component.set('_email', 'un@email.com');
       component.set('_content', 'un contenu');
       component.set('_error', 'une erreur');
@@ -117,7 +90,7 @@ describe('Unit | Component | feedback-panel', function () {
       expect(component.get('_email')).to.be.null;
       expect(component.get('_content')).to.be.null;
       expect(component.get('_error')).to.be.null;
-      expect(component.get('_status')).to.be.equal(component.get('default_status'));
+      expect(component.get('_status')).to.be.equal('FORM_OPENED');
     });
   });
 
@@ -138,4 +111,30 @@ describe('Unit | Component | feedback-panel', function () {
     });
   });
 
+  describe('#_getDefaultStatus', function () {
+
+    it('should return FORM_CLOSED if has property collapsible at "true"', function() {
+      // given
+      const component = this.subject();
+      component.set('collapsible', true);
+
+      // when
+      const defaultStatus =  component._getDefaultStatus();
+
+      // then
+      expect(defaultStatus).to.equal('FORM_CLOSED');
+    });
+
+    it('should return FORM_OPENED if has property collapsible at "false"', function() {
+      // given
+      const component = this.subject();
+      component.set('collapsible', false);
+
+      // when
+      const defaultStatus = component._getDefaultStatus();
+
+      // then
+      expect(defaultStatus).to.equal('FORM_OPENED');
+    });
+  });
 });


### PR DESCRIPTION
L'objet de cette PR est de fixer plusieurs bugs relatifs au signalement d'épreuve (composant `feedback-panel`) : 

- la soumission du feedback n'est pas pris en compte, quand on le fait depuis une épreuve (mais c'est ok depuis la page de résultat d'un test)
- l'erreur indiquant que le champs "content" est requis n'apparaît pas comme attendu quand on clique directement sur "Envoyer", sans avoir mis le focus sur le champs content

Par ailleurs, elle contient les changements suivants : 

- la propriété `default_status` (String / Enum) a été remplacée par la propriété `collapsible` (Boolean) afin de simplifier le code et améliorer la facilité d'intégration et de test du composant
- les méthodes internes (privées) sont préfixées par un '_'
- suppression de la dépendance à `ember-addon` (ça n'a rien à voir avec le sujet, mais ça fait toujours un warning et quelques Mo à télécharger en moins ^^)
- dans les tests, remplacement de la méthode d'assertion `to.have.length`par `to.have.lengthOf`, tel que préconisé par la doc de Chai ([cf. deprecation notice de la méthode #length](http://chaijs.com/api/bdd/#method_length))
- les tests ont été améliorés pour permettre la montée de version vers Ember 2.12

> A ce propos, il est tout à fait possible, de conserver le composant `feedback-panel` indépendant, tel qu'il a été conçu à la base. La chose à savoir est quand pour tester en intégration ce type de composant, faisant notamment intervenir le `store`, il faut que, dans le test, tout service déclaré au registre, le soit fait **avant** le rendering du composant.

