### PR TITLE
[#410] [CLEANUP] Rajoute des règles ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,8 @@ rules:
     - { anonymous: never, named: never, asyncArrow: ignore }
   space-in-parens:
     - 2
+  eol-last:
+    - 2
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,8 @@ rules:
   no-unused-vars:
     - 2
     - { argsIgnorePattern: "_" }
+  space-before-blocks:
+    - 2
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,9 @@ rules:
     - { argsIgnorePattern: "_" }
   space-before-blocks:
     - 2
+  space-before-function-paren:
+    - 2
+    - { anonymous: never, named: never, asyncArrow: ignore }
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,9 @@ rules:
     - 2
   eol-last:
     - 2
+  no-multiple-empty-lines:
+    - 2
+    - { max: 1, maxEOF: 1 }
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,9 @@ rules:
     - 2
   no-var:
     - 2
+  no-unused-vars:
+    - 2
+    - { argsIgnorePattern: "_" }
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,8 @@ rules:
   space-before-function-paren:
     - 2
     - { anonymous: never, named: never, asyncArrow: ignore }
+  space-in-parens:
+    - 2
 parserOptions:
   ecmaVersion: 8
   sourceType: script

--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -1,6 +1,6 @@
 const AnswerController = require('./answer-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -1,6 +1,6 @@
 const AssessmentController = require('./assessment-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
 

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,6 +1,6 @@
 const ChallengeController = require('./challenge-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/courses/index.js
+++ b/api/lib/application/courses/index.js
@@ -1,6 +1,6 @@
 const CourseController = require('./course-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/feedbacks/index.js
+++ b/api/lib/application/feedbacks/index.js
@@ -1,6 +1,6 @@
 const FeedbackController = require('./feedback-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/followers/index.js
+++ b/api/lib/application/followers/index.js
@@ -1,6 +1,6 @@
 const FollowerController = require('./follower-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -10,6 +10,5 @@ module.exports = {
     });
   }
 
-
 };
 

--- a/api/lib/application/healthcheck/index.js
+++ b/api/lib/application/healthcheck/index.js
@@ -1,5 +1,5 @@
 const healthcheckController = require('./healthcheck-controller');
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,6 +1,6 @@
 const UserController = require('./user-controller');
 
-exports.register = function (server, options, next) {
+exports.register = function(server, options, next) {
 
   server.route([
     {

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -24,7 +24,6 @@ function _selectNextInAdaptiveMode(assessment) {
   });
 }
 
-
 function _selectNextInNormalMode(currentChallengeId, challenges) {
 
   /*
@@ -37,7 +36,6 @@ function _selectNextInNormalMode(currentChallengeId, challenges) {
   return _.defaultTo(nextChallengeId, null); // result MUST be null if not found
 
 }
-
 
 function _completeAssessmentWithScore(assessment, answers, knowledgeData) {
 
@@ -73,7 +71,6 @@ function selectNextChallengeId(course, currentChallengeId, assessment) {
     }
   });
 }
-
 
 function getScoredAssessment(assessmentId) {
   return new Promise((resolve, reject) => {

--- a/api/lib/domain/services/challenge-service.js
+++ b/api/lib/domain/services/challenge-service.js
@@ -1,7 +1,7 @@
 const _ = require('../../infrastructure/utils/lodash-utils');
 
 function _countResult(about, desiredResult) {
-  return _.reduce(about, function (sum, o) {
+  return _.reduce(about, function(sum, o) {
     return sum + (o.result === desiredResult ? 1 : 0);
   }, 0);
 }

--- a/api/lib/domain/services/deactivations-service.js
+++ b/api/lib/domain/services/deactivations-service.js
@@ -23,7 +23,7 @@ module.exports = {
   },
 
   hasOnlyT2T3(deactivations) {
-    if (deactivations && (!deactivations.t1) && deactivations.t2 && deactivations.t3 ) {
+    if (deactivations && (!deactivations.t1) && deactivations.t2 && deactivations.t3) {
       return true;
     }
     return false;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -20,7 +20,6 @@ function sendWelcomeEmail(email) {
   });
 }
 
-
 module.exports = {
   sendAccountCreationEmail,
   sendWelcomeEmail

--- a/api/lib/domain/services/scoring-service.js
+++ b/api/lib/domain/services/scoring-service.js
@@ -22,7 +22,6 @@ function propagateKnowledge(knowledgeList, startNode, direction) {
   return nodeList;
 }
 
-
 function _createPerformanceRecord(challenge, answer) {
   const knowledgeTags = challenge.knowledgeTags;
   const mainKnowledgeTag = knowledgeTags[0];

--- a/api/lib/domain/services/solution-service-qcm.js
+++ b/api/lib/domain/services/solution-service-qcm.js
@@ -2,7 +2,7 @@ const _ = require('../../infrastructure/utils/lodash-utils');
 
 module.exports = {
 
-  match (answer, solution) {
+  match(answer, solution) {
 
     if (_.areCSVequivalent(answer, solution)) {
       return 'ok';

--- a/api/lib/domain/services/solution-service-qcu.js
+++ b/api/lib/domain/services/solution-service-qcu.js
@@ -1,7 +1,7 @@
 
 module.exports = {
 
-  match (answer, solution) {
+  match(answer, solution) {
 
     if (answer === solution) {
       return 'ok';

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -95,7 +95,7 @@ function _formatResult(validations, deactivations) {
 
 module.exports = {
 
-  match (answer, solution, deactivations) {
+  match(answer, solution, deactivations) {
 
     // Input checking
     if (!_.isString(answer)

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -56,7 +56,7 @@ module.exports = {
   _compareAnswersAndSolutions,
   _formatResult,
 
-  match (yamlAnswer, yamlSolution, enabledTreatments) {
+  match(yamlAnswer, yamlSolution, enabledTreatments) {
 
     // Input checking
     if (!_.isString(yamlAnswer)

--- a/api/lib/domain/services/solution-service-qru.js
+++ b/api/lib/domain/services/solution-service-qru.js
@@ -1,6 +1,6 @@
 module.exports = {
 
-  match () {
+  match() {
     return 'unimplemented';
   }
 };

--- a/api/lib/infrastructure/bookshelf.js
+++ b/api/lib/infrastructure/bookshelf.js
@@ -5,7 +5,7 @@ const validator = require('validator');
 
 const _ = require('lodash');
 
-validator.isRequired = function (value) {
+validator.isRequired = function(value) {
   return !_.isNil(value);
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
@@ -11,7 +11,7 @@ function _buildError(field, message) {
 function serialize(validationErrors) {
   const errors = [];
 
-  Object.keys(validationErrors.data).forEach(function (field) {
+  Object.keys(validationErrors.data).forEach(function(field) {
     validationErrors.data[ field ].forEach((message) => {
       errors.push(_buildError(field, message));
     });

--- a/api/lib/infrastructure/utils/lodash-utils.js
+++ b/api/lib/infrastructure/utils/lodash-utils.js
@@ -60,13 +60,13 @@ _.mixin({
   'isBlank'(string) {
     return (_.isUndefined(string) || _.isNull(string) || string.trim().length === 0);
   },
-  isArrayOfString: function (x) {
+  isArrayOfString: function(x) {
     return _.isArray(x) && _.every(x, _.isString);
   },
-  isNotString: function (x) {
+  isNotString: function(x) {
     return !_.isString(x);
   },
-  isNotArrayOfString: function (x) {
+  isNotArrayOfString: function(x) {
     return !_.isArrayOfString(x);
   }
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -34,7 +34,6 @@ const plugins = [
   }
 ];
 
-
 if(process.env.NODE_ENV === 'test') {
   plugins.push(require('inject-then'));
 }

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-module.exports = (function () {
+module.exports = (function() {
 
   const config = {
 

--- a/api/package.json
+++ b/api/package.json
@@ -62,7 +62,7 @@
     "db:reset": "npm run db:delete && npm run db:migrate && npm run db:seed",
     "test": "NODE_ENV=test npm run db:migrate && NODE_ENV=test ./node_modules/.bin/mocha --recursive tests",
     "test:watch": "npm test -- --watch",
-    "lint": "./node_modules/.bin/eslint lib/** tests/**",
+    "lint": "./node_modules/.bin/eslint lib tests",
     "coverage:check": "NODE_ENV=test npm run db:migrate && NODE_ENV=test ./node_modules/.bin/istanbul cover --dir '../coverage' _mocha -- --recursive tests",
     "coverage:rename": "mv ../coverage/lcov.info ../coverage/api_lcov.info",
     "coverage": "npm run coverage:check && npm run coverage:rename",

--- a/api/package.json
+++ b/api/package.json
@@ -62,7 +62,7 @@
     "db:reset": "npm run db:delete && npm run db:migrate && npm run db:seed",
     "test": "NODE_ENV=test npm run db:migrate && NODE_ENV=test ./node_modules/.bin/mocha --recursive tests",
     "test:watch": "npm test -- --watch",
-    "lint": "./node_modules/.bin/eslint lib/**",
+    "lint": "./node_modules/.bin/eslint lib/** tests/**",
     "coverage:check": "NODE_ENV=test npm run db:migrate && NODE_ENV=test ./node_modules/.bin/istanbul cover --dir '../coverage' _mocha -- --recursive tests",
     "coverage:rename": "mv ../coverage/lcov.info ../coverage/api_lcov.info",
     "coverage": "npm run coverage:check && npm run coverage:rename",

--- a/api/tests/acceptance/application/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answer-controller-find_test.js
@@ -1,15 +1,15 @@
 const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | Controller | answer-controller', function () {
+describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
   /* Find
    –––––––––––––––––––––––––––––––––––––––––––––––––– */
-  describe('Find /api/answers?challengeId=Y&assessmentId=Z', function () {
+  describe('Find /api/answers?challengeId=Y&assessmentId=Z', function() {
 
     let inserted_answer_id = null;
 
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       assessmentId: '12345'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
@@ -31,20 +31,20 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('answers').delete().then(() => {
         done();
       });
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -52,7 +52,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should return required answer', function (done) {
+    it('should return required answer', function(done) {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         const answer = response.result.data;
 
@@ -66,7 +66,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should return 200 with "null" data if not found answer', function (done) {
+    it('should return 200 with "null" data if not found answer', function(done) {
       server.inject({
         method: 'GET',
         url: '/api/answers?challenge=nothing&assessment=nothing'

--- a/api/tests/acceptance/application/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answer-controller-get_test.js
@@ -1,13 +1,13 @@
 const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | Controller | answer-controller', function () {
+describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('Get /api/answers/:id', function () {
+  describe('Get /api/answers/:id', function() {
 
     let options;
     let inserted_answer_id;
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       assessmentId: '12345'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
@@ -29,20 +29,20 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('answers').delete().then(() => {
         done();
       });
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -50,7 +50,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should return required answer', function (done) {
+    it('should return required answer', function(done) {
       server.inject(options, (response) => {
         const answer = response.result.data;
 

--- a/api/tests/acceptance/application/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answer-controller-save_test.js
@@ -2,22 +2,22 @@ const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock }
 const server = require('../../../server');
 const Answer = require('../../../lib/domain/models/data/answer');
 
-describe('Acceptance | Controller | answer-controller', function () {
-  after(function (done) {
+describe('Acceptance | Controller | answer-controller', function() {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('POST /api/answers', function () {
+  describe('POST /api/answers', function() {
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('answers').delete().then(() => done());
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('answers').delete().then(() => done());
     });
 
-    before(function (done) {
+    before(function(done) {
       nock('https://api.airtable.com')
         .get('/v0/test-base/Epreuves/a_challenge_id')
         .query(true)
@@ -33,14 +33,14 @@ describe('Acceptance | Controller | answer-controller', function () {
       done();
     });
 
-    after(function (done) {
+    after(function(done) {
       nock.cleanAll();
       done();
     });
 
     let options;
 
-    beforeEach(function () {
+    beforeEach(function() {
       options = {
         method: 'POST',
         url: '/api/answers',
@@ -70,14 +70,14 @@ describe('Acceptance | Controller | answer-controller', function () {
       };
     });
 
-    it('should return 201 HTTP status code', function (done) {
+    it('should return 201 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(201);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -85,16 +85,16 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should add a new answer into the database', function (done) {
+    it('should add a new answer into the database', function(done) {
       server.inject(options, () => {
-        Answer.count().then(function (afterAnswersNumber) {
+        Answer.count().then(function(afterAnswersNumber) {
           expect(afterAnswersNumber).to.equal(1);
           done();
         });
       });
     });
 
-    it('should return persisted answer', function (done) {
+    it('should return persisted answer', function(done) {
       // when
       server.inject(options, (response) => {
         const answer = response.result.data;
@@ -102,7 +102,7 @@ describe('Acceptance | Controller | answer-controller', function () {
         // then
         new Answer()
           .fetch()
-          .then(function (model) {
+          .then(function(model) {
             expect(model.id).to.be.a('number');
             expect(model.get('value')).to.equal(options.payload.data.attributes.value);
             expect(model.get('result')).to.equal('ok');
@@ -123,7 +123,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should persist long text for column "answers.value"', function (done) {
+    it('should persist long text for column "answers.value"', function(done) {
       // given
       options.payload.data.attributes.value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?';
 
@@ -131,20 +131,20 @@ describe('Acceptance | Controller | answer-controller', function () {
       server.inject(options, () => {
 
         // then
-        Answer.count().then(function (afterAnswersNumber) {
+        Answer.count().then(function(afterAnswersNumber) {
           expect(afterAnswersNumber).to.equal(1);
           done();
         });
       });
     });
 
-    it('should return persisted answer with elapsedTime', function (done) {
+    it('should return persisted answer with elapsedTime', function(done) {
       // when
       server.inject(options, () => {
         // then
         new Answer()
           .fetch()
-          .then(function (model) {
+          .then(function(model) {
             expect(model.get('elapsedTime')).to.equal(options.payload.data.attributes['elapsed-time']);
             done();
           });

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -2,13 +2,13 @@ const {describe, it, before, after, beforeEach, afterEach, expect, knex, nock} =
 const server = require('../../../server');
 const Answer = require('../../../lib/domain/models/data/answer');
 
-describe('Acceptance | Controller | answer-controller', function () {
+describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('POST /api/answers (update)', function () {
+  describe('POST /api/answers (update)', function() {
 
     const options = {
       method: 'POST', url: '/api/answers', payload: {
@@ -36,20 +36,20 @@ describe('Acceptance | Controller | answer-controller', function () {
       }
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('answers').delete().then(() => {
         server.inject(options, () => {
           done();
         });
       });
     });
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('answers').delete().then(() => {
         done();
       });
     });
 
-    before(function (done) {
+    before(function(done) {
       nock('https://api.airtable.com')
         .get('/v0/test-base/Epreuves/a_challenge_id')
         .times(5)
@@ -64,14 +64,14 @@ describe('Acceptance | Controller | answer-controller', function () {
       done();
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -79,7 +79,7 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should not add a new answer into the database', function (done) {
+    it('should not add a new answer into the database', function(done) {
       server.inject(options, () => {
         Answer.count().then((afterAnswersNumber) => {
           expect(afterAnswersNumber).to.equal(1);
@@ -88,14 +88,14 @@ describe('Acceptance | Controller | answer-controller', function () {
       });
     });
 
-    it('should return updated answer', function (done) {
+    it('should return updated answer', function(done) {
       // when
       server.inject(options, (response) => {
         const answer = response.result.data;
 
         new Answer()
           .fetch()
-          .then(function (model) {
+          .then(function(model) {
             expect(model.id).to.be.a('number');
             expect(model.get('value')).to.equal(options.payload.data.attributes.value);
             expect(model.get('elapsedTime')).to.equal(options.payload.data.attributes['elapsed-time']);

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -80,7 +80,7 @@ describe('Acceptance | Controller | answer-controller', function () {
     });
 
     it('should not add a new answer into the database', function (done) {
-      server.inject(options, (response) => {
+      server.inject(options, () => {
         Answer.count().then((afterAnswersNumber) => {
           expect(afterAnswersNumber).to.equal(1);
           done();

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -1,9 +1,9 @@
 const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | Assessments', function () {
+describe('Acceptance | API | Assessments', function() {
 
-  before(function (done) {
+  before(function(done) {
 
     nock.cleanAll();
     nock('https://api.airtable.com')
@@ -53,13 +53,13 @@ describe('Acceptance | API | Assessments', function () {
     done();
   });
 
-  after(function (done) {
+  after(function(done) {
     nock.cleanAll();
     server.stop(done);
   });
 
 
-  describe('(adaptive correct answer) GET /api/assessments/:assessment_id/next/:current_challenge_id', function () {
+  describe('(adaptive correct answer) GET /api/assessments/:assessment_id/next/:current_challenge_id', function() {
 
     let insertedAssessmentId = null;
 
@@ -79,7 +79,7 @@ describe('Acceptance | API | Assessments', function () {
       nextChallengeId: 'w_third_challenge'
     }];
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('assessments').insert([insertedAssessment]).then((rows) => {
           insertedAssessmentId = rows[0];
@@ -105,7 +105,7 @@ describe('Acceptance | API | Assessments', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('answers').delete().then(() => {
           knex('scenarios').delete().then(() => {
@@ -115,7 +115,7 @@ describe('Acceptance | API | Assessments', function () {
       });
     });
 
-    it('should return the second challenge if the first answer is correct', function (done) {
+    it('should return the second challenge if the first answer is correct', function(done) {
 
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next/w_first_challenge' };
       server.inject(options, (response) => {

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -58,7 +58,6 @@ describe('Acceptance | API | Assessments', function() {
     server.stop(done);
   });
 
-
   describe('(adaptive correct answer) GET /api/assessments/:assessment_id/next/:current_challenge_id', function() {
 
     let insertedAssessmentId = null;

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -1,10 +1,10 @@
 const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | Assessments', function () {
+describe('Acceptance | API | Assessments', function() {
 
 
-  before(function (done) {
+  before(function(done) {
 
     nock.cleanAll();
     nock('https://api.airtable.com')
@@ -54,13 +54,13 @@ describe('Acceptance | API | Assessments', function () {
     done();
   });
 
-  after(function (done) {
+  after(function(done) {
     nock.cleanAll();
     server.stop(done);
   });
 
 
-  describe('(adaptive) GET /api/assessments/:assessment_id/next', function () {
+  describe('(adaptive) GET /api/assessments/:assessment_id/next', function() {
 
     let insertedAssessmentId = null;
 
@@ -70,7 +70,7 @@ describe('Acceptance | API | Assessments', function () {
       courseId: 'the_adaptive_course_id'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('assessments').insert([inserted_assessment]).then((rows) => {
           insertedAssessmentId = rows[0];
@@ -79,11 +79,11 @@ describe('Acceptance | API | Assessments', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {done();});
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
@@ -91,7 +91,7 @@ describe('Acceptance | API | Assessments', function () {
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
@@ -100,7 +100,7 @@ describe('Acceptance | API | Assessments', function () {
       });
     });
 
-    it('should return the first challenge if no challenge specified', function (done) {
+    it('should return the first challenge if no challenge specified', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         expect(response.result.data.id).to.equal('z_first_challenge');

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -3,7 +3,6 @@ const server = require('../../../server');
 
 describe('Acceptance | API | Assessments', function() {
 
-
   before(function(done) {
 
     nock.cleanAll();
@@ -59,7 +58,6 @@ describe('Acceptance | API | Assessments', function() {
     server.stop(done);
   });
 
-
   describe('(adaptive) GET /api/assessments/:assessment_id/next', function() {
 
     let insertedAssessmentId = null;
@@ -109,6 +107,5 @@ describe('Acceptance | API | Assessments', function() {
     });
 
   });
-
 
 });

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -1,9 +1,9 @@
 const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | Assessments GET (non adaptive)', function () {
+describe('Acceptance | API | Assessments GET (non adaptive)', function() {
 
-  before(function (done) {
+  before(function(done) {
     
     nock.cleanAll();
     nock('https://api.airtable.com')
@@ -53,12 +53,12 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
     done();
   });
 
-  after(function (done) {
+  after(function(done) {
     nock.cleanAll();
     server.stop(done);
   });
 
-  describe('(non-adaptive) GET /api/assessments/:assessment_id/next', function () {
+  describe('(non-adaptive) GET /api/assessments/:assessment_id/next', function() {
 
     let insertedAssessmentId = null;
 
@@ -68,7 +68,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       courseId: 'a_non_adaptive_course_id'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('assessments').insert([insertedAssessment]).then((rows) => {
           insertedAssessmentId = rows[0];
@@ -77,11 +77,11 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {done();});
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
@@ -89,7 +89,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
@@ -98,7 +98,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    it('should return the first challenge if no challenge specified', function (done) {
+    it('should return the first challenge if no challenge specified', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
       server.inject(options, (response) => {
         expect(response.result.data.id).to.equal('first_challenge');
@@ -106,7 +106,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    it('should return the next challenge otherwise', function (done) {
+    it('should return the next challenge otherwise', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next/first_challenge' };
       server.inject(options, (response) => {
         expect(response.result.data.id).to.equal('second_challenge');
@@ -114,7 +114,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    it('should return null if reached the last challenge of the course', function (done) {
+    it('should return null if reached the last challenge of the course', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next/second_challenge' };
       server.inject(options, (response) => {
         expect(response.result).to.equal('null');
@@ -122,7 +122,7 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function () {
       });
     });
 
-    it('should return null if reached the last challenge of the course', function (done) {
+    it('should return null if reached the last challenge of the course', function(done) {
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next/second_challenge' };
       server.inject(options, (response) => {
         expect(response.result).to.equal('null');

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -14,64 +14,64 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
           .query(true)
           .times(4)
           .reply(200, {
-              'id': 'non_adaptive_course_id',
-              'fields': {
+            'id': 'non_adaptive_course_id',
+            'fields': {
                 // a bunch of fields
-                'Adaptatif ?': false,
-                '\u00c9preuves': [
-                  'second_challenge',
-                  'first_challenge',
-                ],
-              },
-            }
+              'Adaptatif ?': false,
+              '\u00c9preuves': [
+                'second_challenge',
+                'first_challenge',
+              ],
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Tests/adaptive_course_id')
           .query(true)
           .times(4)
           .reply(200, {
-              'id': 'adaptive_course_id',
-              'fields': {
+            'id': 'adaptive_course_id',
+            'fields': {
                 // a bunch of fields
-                'Adaptatif ?': true,
-                '\u00c9preuves': [
-                  'third_challenge',
-                  'second_challenge',
-                  'first_challenge',
-                ],
-              },
-            }
+              'Adaptatif ?': true,
+              '\u00c9preuves': [
+                'third_challenge',
+                'second_challenge',
+                'first_challenge',
+              ],
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/first_challenge')
           .query(true)
           .times(3)
           .reply(200, {
-              'id': 'first_challenge',
-              'fields': {
-                'Bonnes réponses': 'fromage'
-              },
-            }
+            'id': 'first_challenge',
+            'fields': {
+              'Bonnes réponses': 'fromage'
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/second_challenge')
           .query(true)
           .reply(200, {
-              'id': 'second_challenge',
-              'fields': {
-                'Bonnes réponses': 'truite'
-              },
-            }
+            'id': 'second_challenge',
+            'fields': {
+              'Bonnes réponses': 'truite'
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/third_challenge')
           .query(true)
           .reply(200, {
-              'id': 'third_challenge',
-              'fields': {
-                'Bonnes réponses': 'dromadaire'
-              },
-            }
+            'id': 'third_challenge',
+            'fields': {
+              'Bonnes réponses': 'dromadaire'
+            },
+          }
           );
       });
   });
@@ -84,7 +84,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
   afterEach(() => {
     return knex('assessments').delete()
       .then(() => {
-        return knex('answers').delete()
+        return knex('answers').delete();
       });
   });
 
@@ -139,7 +139,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
       };
 
       // When
-      let promise = server.injectThen(options);
+      const promise = server.injectThen(options);
 
       // Then
       return promise.then((response) => {
@@ -186,7 +186,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
       };
 
       // When
-      let promise = server.inject(options);
+      const promise = server.inject(options);
 
       // Then
       return promise.then((response) => {
@@ -238,7 +238,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
       };
 
       // When
-      let promise = server.injectThen(options);
+      const promise = server.injectThen(options);
 
       // Then
       return promise.then((response) => {
@@ -296,7 +296,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
       };
 
       // When
-      let promise = server.injectThen(options);
+      const promise = server.injectThen(options);
 
       // Then
       return promise.then((response) => {

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -1,9 +1,9 @@
 const { describe, it, after, before, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | Assessments GET', function () {
+describe('Acceptance | API | Assessments GET', function() {
 
-  before(function (done) {
+  before(function(done) {
 
     nock.cleanAll();
     nock('https://api.airtable.com')
@@ -55,11 +55,11 @@ describe('Acceptance | API | Assessments GET', function () {
 
   });
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('(no provided answer) GET /api/assessments/:id', function () {//
+  describe('(no provided answer) GET /api/assessments/:id', function() {//
 
     let options;
     let inserted_assessment_id;
@@ -70,7 +70,7 @@ describe('Acceptance | API | Assessments GET', function () {
       courseId: 'anyFromAirTable'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('assessments').insert([inserted_assessment]).then((rows) => {
           inserted_assessment_id = rows[0];
@@ -80,18 +80,18 @@ describe('Acceptance | API | Assessments GET', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {
         done();
       });
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
 
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject(options, (response) => {
             expect(response.statusCode).to.equal(200);
             done();
@@ -100,12 +100,12 @@ describe('Acceptance | API | Assessments GET', function () {
 
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
 
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject(options, (response) => {
             const contentType = response.headers['content-type'];
             expect(contentType).to.contain('application/json');
@@ -115,11 +115,11 @@ describe('Acceptance | API | Assessments GET', function () {
 
     });
 
-    it('should return the expected assessment', function (done) {
+    it('should return the expected assessment', function(done) {
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject(options, (response) => {
             const expectedAssessment = {
               'type': 'assessment',
@@ -145,7 +145,7 @@ describe('Acceptance | API | Assessments GET', function () {
     });
   });
 
-  describe('(answers provided) GET /api/assessments/:id', function () {//
+  describe('(answers provided) GET /api/assessments/:id', function() {//
 
     let inserted_assessment_id = null;
     let inserted_answer_ids = null;
@@ -156,7 +156,7 @@ describe('Acceptance | API | Assessments GET', function () {
       courseId: 'anyFromAirTable'
     };
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       inserted_answer_ids = [];
       knex('assessments').delete().then(() => {
         knex('assessments').insert([inserted_assessment]).then((rows) => {
@@ -187,7 +187,7 @@ describe('Acceptance | API | Assessments GET', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {
         knex('answers').delete().then(() => {
           done();
@@ -195,12 +195,12 @@ describe('Acceptance | API | Assessments GET', function () {
       });
     });
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
 
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject({ method: 'GET', url: `/api/assessments/${inserted_assessment_id}` }).then((response) => {
             expect(response.statusCode).to.equal(200);
             done();
@@ -209,12 +209,12 @@ describe('Acceptance | API | Assessments GET', function () {
 
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
 
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject({ method: 'GET', url: `/api/assessments/${inserted_assessment_id}` }).then((response) => {
             const contentType = response.headers['content-type'];
             expect(contentType).to.contain('application/json');
@@ -224,11 +224,11 @@ describe('Acceptance | API | Assessments GET', function () {
 
     });
 
-    it('should return the expected assessment', function (done) {
+    it('should return the expected assessment', function(done) {
       knex.select('id')
         .from('assessments')
         .limit(1)
-        .then(function () {
+        .then(function() {
           server.inject({ method: 'GET', url: `/api/assessments/${inserted_assessment_id}` }).then((response) => {
             const expectedAssessment = {
               'type': 'assessment',

--- a/api/tests/acceptance/application/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessment-controller-post_test.js
@@ -2,15 +2,15 @@ const { describe, it, after, afterEach, expect, knex } = require('../../test-hel
 const server = require('../../../server');
 const Assessment = require('../../../lib/domain/models/data/assessment');
 
-describe('Acceptance | API | Assessments POST', function () {
+describe('Acceptance | API | Assessments POST', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('POST /api/assessments', function () {
+  describe('POST /api/assessments', function() {
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('assessments').delete().then(() => {done();});
     });
 
@@ -34,14 +34,14 @@ describe('Acceptance | API | Assessments POST', function () {
       }
     };
 
-    it('should return 201 HTTP status code', function (done) {
+    it('should return 201 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(201);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -49,12 +49,12 @@ describe('Acceptance | API | Assessments POST', function () {
       });
     });
 
-    it('should add a new assessment into the database', function (done) {
+    it('should add a new assessment into the database', function(done) {
       // given
-      Assessment.count().then(function (beforeAssessmentsNumber) {
+      Assessment.count().then(function(beforeAssessmentsNumber) {
         // when
         server.inject(options, () => {
-          Assessment.count().then(function (afterAssessmentsNumber) {
+          Assessment.count().then(function(afterAssessmentsNumber) {
             // then
             expect(afterAssessmentsNumber).to.equal(beforeAssessmentsNumber + 1);
             done();
@@ -63,14 +63,14 @@ describe('Acceptance | API | Assessments POST', function () {
       });
     });
 
-    it('should persist the given course ID and user ID', function (done) {
+    it('should persist the given course ID and user ID', function(done) {
 
       // when
       server.inject(options, (response) => {
 
         new Assessment({ id: response.result.data.id })
         .fetch()
-        .then(function (model) {
+        .then(function(model) {
           expect(model.get('courseId')).to.equal(options.payload.data.relationships.course.data.id);
           expect(model.get('userName')).to.equal(options.payload.data.attributes['user-name']);
           expect(model.get('userEmail')).to.equal(options.payload.data.attributes['user-email']);
@@ -80,7 +80,7 @@ describe('Acceptance | API | Assessments POST', function () {
       });
     });
 
-    it('should return persisted assessement', function (done) {
+    it('should return persisted assessement', function(done) {
 
       // when
       server.inject(options, (response) => {

--- a/api/tests/acceptance/application/challenge-controller-validate_test.js
+++ b/api/tests/acceptance/application/challenge-controller-validate_test.js
@@ -2,16 +2,16 @@ const { describe, after, afterEach, beforeEach, it, knex, expect, nock, before }
 
 const server = require('../../../server');
 
-describe('Acceptance | API | ChallengeController', function () {
+describe('Acceptance | API | ChallengeController', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
   // validate again all answers of the challenge
-  describe('PUT /api/challenges/:challenge_id/validate', function () {
+  describe('PUT /api/challenges/:challenge_id/validate', function() {
 
-    before(function (done) {
+    before(function(done) {
       nock.cleanAll();
       nock('https://api.airtable.com')
         .get('/v0/test-base/Epreuves/challenge_1234')
@@ -28,7 +28,7 @@ describe('Acceptance | API | ChallengeController', function () {
       done();
     });
 
-    after(function (done) {
+    after(function(done) {
       nock.cleanAll();
       done();
     });
@@ -70,7 +70,7 @@ describe('Acceptance | API | ChallengeController', function () {
     };
 
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([
           ko_answer,
@@ -84,20 +84,20 @@ describe('Acceptance | API | ChallengeController', function () {
       });
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('answers').delete().then(() => {done();});
     });
 
     const options = { method: 'PUT', url: '/api/challenges/challenge_1234/validate' };
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       server.inject(options).then((response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options).then((response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -105,7 +105,7 @@ describe('Acceptance | API | ChallengeController', function () {
       });
     });
 
-    it('should be able to transform all related answer, but not unrelated answer(s)', function (done) {
+    it('should be able to transform all related answer, but not unrelated answer(s)', function(done) {
       server.inject(options).then(() => {
         knex.select('*').from('answers').then((answers) => {
           const answer_1 = answers[0];
@@ -119,7 +119,7 @@ describe('Acceptance | API | ChallengeController', function () {
       });
     });
 
-    it('should be able to change "ok", "ko", "partially", "unimplemented"', function (done) {
+    it('should be able to change "ok", "ko", "partially", "unimplemented"', function(done) {
       server.inject(options).then((response) => {
         const payload = response.payload;
         const result = JSON.parse(payload);
@@ -135,7 +135,7 @@ describe('Acceptance | API | ChallengeController', function () {
       });
     });
 
-    it('should NOT be able to change "timedout", "aband"', function (done) {
+    it('should NOT be able to change "timedout", "aband"', function(done) {
       server.inject(options).then((response) => {
         const payload = response.payload;
         const result = JSON.parse(payload);

--- a/api/tests/acceptance/application/challenge-controller-validate_test.js
+++ b/api/tests/acceptance/application/challenge-controller-validate_test.js
@@ -69,7 +69,6 @@ describe('Acceptance | API | ChallengeController', function() {
       challengeId: 'challenge_1234'
     };
 
-
     beforeEach(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([
@@ -148,6 +147,5 @@ describe('Acceptance | API | ChallengeController', function() {
     });
 
   });
-
 
 });

--- a/api/tests/acceptance/application/challenge-controller_test.js
+++ b/api/tests/acceptance/application/challenge-controller_test.js
@@ -1,15 +1,15 @@
 const { describe, it, before, after, expect, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | ChallengeController', function () {
+describe('Acceptance | API | ChallengeController', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('GET /api/challenges/:challenge_id', function () {
+  describe('GET /api/challenges/:challenge_id', function() {
 
-    before(function (done) {
+    before(function(done) {
       nock.cleanAll();
       nock('https://api.airtable.com')
         .get('/v0/test-base/Epreuves/recLt9uwa2dR3IYpi')
@@ -57,21 +57,21 @@ describe('Acceptance | API | ChallengeController', function () {
       done();
     });
 
-    after(function (done) {
+    after(function(done) {
       nock.cleanAll();
       done();
     });
 
     const options = { method: 'GET', url: '/api/challenges/recLt9uwa2dR3IYpi' };
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -79,7 +79,7 @@ describe('Acceptance | API | ChallengeController', function () {
       });
     });
 
-    it('should return the expected challenge', function (done) {
+    it('should return the expected challenge', function(done) {
       server.inject(options, (response) => {
         const challenge = response.result.data;
         expect(challenge.id).to.equal('recLt9uwa2dR3IYpi');

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -1,15 +1,15 @@
 const { describe, it, before, after, expect, nock } = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | API | Courses', function () {
+describe('Acceptance | API | Courses', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('GET /api/courses', function () {
+  describe('GET /api/courses', function() {
 
-    before(function (done) {
+    before(function(done) {
       nock.cleanAll();
       nock('https://api.airtable.com')
         .get('/v0/test-base/Tests')
@@ -46,14 +46,14 @@ describe('Acceptance | API | Courses', function () {
       done();
     });
 
-    after(function (done) {
+    after(function(done) {
       nock.cleanAll();
       done();
     });
 
     const options = { method: 'GET', url: '/api/courses' };
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       // when
       server.inject(options, (response) => {
 
@@ -63,7 +63,7 @@ describe('Acceptance | API | Courses', function () {
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       // when
       server.inject(options, (response) => {
 
@@ -74,7 +74,7 @@ describe('Acceptance | API | Courses', function () {
       });
     });
 
-    it('should return all the courses from the tests referential', function (done) {
+    it('should return all the courses from the tests referential', function(done) {
       // when
       server.inject(options, (response) => {
         // then
@@ -85,9 +85,9 @@ describe('Acceptance | API | Courses', function () {
     });
   });
 
-  describe('GET /api/courses/:course_id', function () {
+  describe('GET /api/courses/:course_id', function() {
 
-    before(function (done) {
+    before(function(done) {
       nock.cleanAll();
       nock('https://api.airtable.com')
         .get('/v0/test-base/Tests/course_id')
@@ -127,14 +127,14 @@ describe('Acceptance | API | Courses', function () {
       done();
     });
 
-    after(function (done) {
+    after(function(done) {
       nock.cleanAll();
       done();
     });
 
     const options = { method: 'GET', url: '/api/courses/course_id' };
 
-    it('should return 200 HTTP status code', function (done) {
+    it('should return 200 HTTP status code', function(done) {
       // when
       server.inject(options, (response) => {
 
@@ -144,7 +144,7 @@ describe('Acceptance | API | Courses', function () {
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       // when
       server.inject(options, (response) => {
 
@@ -155,7 +155,7 @@ describe('Acceptance | API | Courses', function () {
       });
     });
 
-    it('should return the expected course', function (done) {
+    it('should return the expected course', function(done) {
       // when
       server.inject(options, (response) => {
 

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -2,19 +2,19 @@ const { describe, it, after, beforeEach, afterEach, expect, knex } = require('..
 const server = require('../../../server');
 const Feedback = require('../../../lib/domain/models/data/feedback');
 
-describe('Acceptance | Controller | feedback-controller', function () {
+describe('Acceptance | Controller | feedback-controller', function() {
 
-  after(function (done) {
+  after(function(done) {
     server.stop(done);
   });
 
-  describe('POST /api/feedbacks', function () {
+  describe('POST /api/feedbacks', function() {
 
-    beforeEach(function (done) {
+    beforeEach(function(done) {
       knex('feedbacks').delete().then(() => done());
     });
 
-    afterEach(function (done) {
+    afterEach(function(done) {
       knex('feedbacks').delete().then(() => done());
     });
 
@@ -44,14 +44,14 @@ describe('Acceptance | Controller | feedback-controller', function () {
       }
     };
 
-    it('should return 201 HTTP status code', function (done) {
+    it('should return 201 HTTP status code', function(done) {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(201);
         done();
       });
     });
 
-    it('should return application/json', function (done) {
+    it('should return application/json', function(done) {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -59,7 +59,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
       });
     });
 
-    it('should add a new feedback into the database', function (done) {
+    it('should add a new feedback into the database', function(done) {
       server.inject(options, () => {
         Feedback.count().then((afterFeedbacksNumber) => {
           expect(afterFeedbacksNumber).to.equal(1);
@@ -68,7 +68,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
       });
     });
 
-    it('should return persisted feedback', function (done) {
+    it('should return persisted feedback', function(done) {
       // when
       server.inject(options, (response) => {
         const feedback = response.result.data;
@@ -76,7 +76,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
         // then
         new Feedback()
           .fetch()
-          .then(function (model) {
+          .then(function(model) {
             expect(model.id).to.be.a('number');
             expect(model.get('email')).to.equal(options.payload.data.attributes.email);
             expect(model.get('content')).to.equal(options.payload.data.attributes.content);

--- a/api/tests/acceptance/application/follower-controller_test.js
+++ b/api/tests/acceptance/application/follower-controller_test.js
@@ -35,7 +35,7 @@ describe('Acceptance | Controller | follower-controller', () => {
       };
 
       // When
-      let promise = server.injectThen({ method: 'POST', url: '/api/followers', payload });
+      const promise = server.injectThen({ method: 'POST', url: '/api/followers', payload });
 
       // Then
       return promise.then((response) => {

--- a/api/tests/acceptance/application/follower-controller_test.js
+++ b/api/tests/acceptance/application/follower-controller_test.js
@@ -4,15 +4,15 @@ const mailService = require('../../../lib/domain/services/mail-service');
 
 describe('Acceptance | Controller | follower-controller', () => {
 
-  beforeEach(function (done) {
+  beforeEach(function(done) {
     knex('followers').delete().then(() => done());
   });
 
-  afterEach(function (done) {
+  afterEach(function(done) {
     knex('followers').delete().then(() => done());
   });
 
-  describe('POST /api/followers', function () {
+  describe('POST /api/followers', function() {
 
     let mailServiceStub;
 
@@ -49,7 +49,7 @@ describe('Acceptance | Controller | follower-controller', () => {
       });
     });
 
-    it('should return an error with status code 409 if follower already exist', function () {
+    it('should return an error with status code 409 if follower already exist', function() {
       const payload = {
         data: {
           type: 'followers',

--- a/api/tests/acceptance/application/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users-controller-save_test.js
@@ -13,7 +13,7 @@ describe('Acceptance | Controller | users-controller', function () {
   let sendAccountCreationEmailStub;
 
   before(() => {
-    sendAccountCreationEmailStub = sinon.stub(mailService, "sendAccountCreationEmail")
+    sendAccountCreationEmailStub = sinon.stub(mailService, 'sendAccountCreationEmail');
   });
 
   beforeEach(function () {
@@ -65,7 +65,7 @@ describe('Acceptance | Controller | users-controller', function () {
     // When
     const secondRegistration = firstRegistration
       .then(_ => {
-        return server.injectThen(options)
+        return server.injectThen(options);
       });
 
     // Then
@@ -77,8 +77,8 @@ describe('Acceptance | Controller | users-controller', function () {
 
   it('should save the user in the database', function () {
     return server.injectThen(options)
-      .then(response => {
-        return new User({ email: attributes.email }).fetch()
+      .then(() => {
+        return new User({ email: attributes.email }).fetch();
       })
       .then((user) => {
         expect(attributes.firstName).to.equal(user.get('firstName'));
@@ -92,7 +92,7 @@ describe('Acceptance | Controller | users-controller', function () {
 
     return server.injectThen(options)
       .then(() => {
-        return new User({ email: attributes.email }).fetch()
+        return new User({ email: attributes.email }).fetch();
       })
       .then((user) => {
         expect(user.get('password')).not.to.equal('my-123-password');
@@ -102,10 +102,10 @@ describe('Acceptance | Controller | users-controller', function () {
   describe('should return 400 HTTP status code', () => {
     it('when the email is not valid', function () {
       // Given
-      options.payload.data.attributes.email = "invalid.email@";
+      options.payload.data.attributes.email = 'invalid.email@';
 
       // When
-      let promise = server.injectThen(options);
+      const promise = server.injectThen(options);
 
       // Then
       return promise.then(response => {

--- a/api/tests/acceptance/application/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users-controller-save_test.js
@@ -6,7 +6,7 @@ const User = require('../../../lib/domain/models/data/user');
 
 const mailService = require('../../../lib/domain/services/mail-service');
 
-describe('Acceptance | Controller | users-controller', function () {
+describe('Acceptance | Controller | users-controller', function() {
 
   let options;
   let attributes;
@@ -16,7 +16,7 @@ describe('Acceptance | Controller | users-controller', function () {
     sendAccountCreationEmailStub = sinon.stub(mailService, 'sendAccountCreationEmail');
   });
 
-  beforeEach(function () {
+  beforeEach(function() {
     attributes = {
       firstName: faker.name.firstName(),
       lastName: faker.name.lastName(),
@@ -38,17 +38,17 @@ describe('Acceptance | Controller | users-controller', function () {
     };
   });
 
-  after(function () {
+  after(function() {
     sendAccountCreationEmailStub.restore();
   });
 
-  it('should return 201 HTTP status code', function () {
+  it('should return 201 HTTP status code', function() {
     return server.injectThen(options).then(response => {
       expect(response.statusCode).to.equal(201);
     });
   });
 
-  it('should return 400 HTTP status code when no payload', function () {
+  it('should return 400 HTTP status code when no payload', function() {
     // Given
     options.payload = {};
 
@@ -58,7 +58,7 @@ describe('Acceptance | Controller | users-controller', function () {
     });
   });
 
-  it('should return 400 HTTP status code when email already exists', function () {
+  it('should return 400 HTTP status code when email already exists', function() {
     // Given
     const firstRegistration = server.injectThen(options);
 
@@ -75,7 +75,7 @@ describe('Acceptance | Controller | users-controller', function () {
   });
 
 
-  it('should save the user in the database', function () {
+  it('should save the user in the database', function() {
     return server.injectThen(options)
       .then(() => {
         return new User({ email: attributes.email }).fetch();
@@ -86,7 +86,7 @@ describe('Acceptance | Controller | users-controller', function () {
       });
   });
 
-  it('should crypt user password', function () {
+  it('should crypt user password', function() {
     // Given
     options.payload.data.attributes.password = 'my-123-password';
 
@@ -100,7 +100,7 @@ describe('Acceptance | Controller | users-controller', function () {
   });
 
   describe('should return 400 HTTP status code', () => {
-    it('when the email is not valid', function () {
+    it('when the email is not valid', function() {
       // Given
       options.payload.data.attributes.email = 'invalid.email@';
 

--- a/api/tests/acceptance/application/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users-controller-save_test.js
@@ -74,7 +74,6 @@ describe('Acceptance | Controller | users-controller', function() {
     });
   });
 
-
   it('should save the user in the database', function() {
     return server.injectThen(options)
       .then(() => {

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, sinon } = require('../../../test-helper');
+const { describe, it, before, expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const Answer = require('../../../../lib/domain/models/data/answer');
 const solutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -15,7 +15,6 @@ describe('Unit | Controller | answer-controller', function() {
     server.register({ register: require('../../../../lib/application/answers') });
   });
 
-
   function executeRequest(payload, callback) {
     server.inject({ method: 'POST', url: '/api/answers', payload }, (res) => {
       callback(res);

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -5,11 +5,11 @@ const solutionRepository = require('../../../../lib/infrastructure/repositories/
 const answerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 const solutionService = require('../../../../lib/domain/services/solution-service');
 
-describe('Unit | Controller | answer-controller', function () {
+describe('Unit | Controller | answer-controller', function() {
 
   let server;
 
-  before(function () {
+  before(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/answers') });
@@ -57,9 +57,9 @@ describe('Unit | Controller | answer-controller', function () {
     timeout: null
   });
 
-  describe('#save', function () {
+  describe('#save', function() {
 
-    it('should return a successful response with HTTP code 201 when answer was created', function (done) {
+    it('should return a successful response with HTTP code 201 when answer was created', function(done) {
       // given
       sinon.stub(answerRepository, 'findByChallengeAndAssessment').resolves(null);
       sinon.stub(solutionRepository, 'get').resolves(null);
@@ -78,7 +78,7 @@ describe('Unit | Controller | answer-controller', function () {
       });
     });
 
-    it('should return the field "resultDetails"', function (done) {
+    it('should return the field "resultDetails"', function(done) {
       // given
       sinon.stub(solutionRepository, 'get').resolves(null);
       sinon.stub(solutionService, 'validate').returns({result : 'ok', resultDetails : {NumA : true, NumB : true, NumC : true, NumD : true}});

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, before, after, beforeEach, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const AnswerController = require('../../../../lib/application/answers/answer-controller');
 
-describe('Unit | Router | answer-router', function () {
+describe('Unit | Router | answer-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/answers') });
@@ -19,47 +19,47 @@ describe('Unit | Router | answer-router', function () {
     });
   }
 
-  describe('POST /api/answers', function () {
+  describe('POST /api/answers', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AnswerController, 'save', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AnswerController.save.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/answers' }, done);
     });
   });
 
-  describe('GET /api/answers/{id}', function () {
+  describe('GET /api/answers/{id}', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AnswerController, 'get', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AnswerController.get.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/answers/answer_id' }, done);
     });
   });
 
-  describe('GET /api/answers?assessment=<assessment_id>&challenge=<challenge_id>', function () {
+  describe('GET /api/answers?assessment=<assessment_id>&challenge=<challenge_id>', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AnswerController, 'findByChallengeAndAssessment', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AnswerController.findByChallengeAndAssessment.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/answers' }, done);
     });
   });

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, before, after, beforeEach, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const AssessmentController = require('../../../../lib/application/assessments/assessment-controller');
 
-describe('Unit | Router | assessment-router', function () {
+describe('Unit | Router | assessment-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/assessments') });
@@ -19,62 +19,62 @@ describe('Unit | Router | assessment-router', function () {
     });
   }
 
-  describe('POST /api/assessments', function () {
+  describe('POST /api/assessments', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AssessmentController, 'save', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AssessmentController.save.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/assessments' }, done);
     });
   });
 
-  describe('GET /api/assessments/assessment_id/next', function () {
+  describe('GET /api/assessments/assessment_id/next', function() {
 
-    before(function () {      
+    before(function() {      
       sinon.stub(AssessmentController, 'getNextChallenge', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AssessmentController.getNextChallenge.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/assessments/assessment_id/next' }, done);
     });
   });
 
-  describe('GET /api/assessments/assessment_id/next/challenge_id', function () {
+  describe('GET /api/assessments/assessment_id/next/challenge_id', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AssessmentController, 'getNextChallenge', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AssessmentController.getNextChallenge.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/assessments/assessment_id/next/challenge_id' }, done);
     });
   });
 
-  describe('GET /api/assessments/assessment_id', function () {
+  describe('GET /api/assessments/assessment_id', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(AssessmentController, 'get', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       AssessmentController.get.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/assessments/assessment_id' }, done);
     });
   });

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -19,9 +19,9 @@ describe('Unit | Controller | challenge-controller', function () {
   describe('#list', function () {
 
     const challenges = [
-      new Challenge({ "id": "challenge_1" }),
-      new Challenge({ "id": "challenge_2" }),
-      new Challenge({ "id": "challenge_3" })
+      new Challenge({ 'id': 'challenge_1' }),
+      new Challenge({ 'id': 'challenge_2' }),
+      new Challenge({ 'id': 'challenge_3' })
     ];
 
     it('should fetch and return all the challenges, serialized as JSONAPI', function (done) {
@@ -45,7 +45,7 @@ describe('Unit | Controller | challenge-controller', function () {
 
   describe('#get', function () {
 
-    const challenge = new Challenge({ "id": "challenge_id" });
+    const challenge = new Challenge({ 'id': 'challenge_id' });
 
     it('should fetch and return the given challenge, serialized as JSONAPI', function (done) {
       // given
@@ -68,9 +68,9 @@ describe('Unit | Controller | challenge-controller', function () {
     it('should reply with error status code 404 if challenge not found', function (done) {
       // given
       const error = {
-        "error": {
-          "type": "MODEL_ID_NOT_FOUND",
-          "message": "Could not find row by id unknown_id"
+        'error': {
+          'type': 'MODEL_ID_NOT_FOUND',
+          'message': 'Could not find row by id unknown_id'
         }
       };
       sinon.stub(ChallengeRepository, 'get').rejects(error);

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -6,17 +6,17 @@ const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/
 const Solution = require('../../../../lib/domain/models/referential/solution');
 const SolutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');
 
-describe('Unit | Controller | challenge-controller', function () {
+describe('Unit | Controller | challenge-controller', function() {
 
   let server;
 
-  before(function () {
+  before(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/challenges') });
   });
 
-  describe('#list', function () {
+  describe('#list', function() {
 
     const challenges = [
       new Challenge({ 'id': 'challenge_1' }),
@@ -24,7 +24,7 @@ describe('Unit | Controller | challenge-controller', function () {
       new Challenge({ 'id': 'challenge_3' })
     ];
 
-    it('should fetch and return all the challenges, serialized as JSONAPI', function (done) {
+    it('should fetch and return all the challenges, serialized as JSONAPI', function(done) {
       // given
       sinon.stub(ChallengeRepository, 'list').resolves(challenges);
       sinon.stub(ChallengeSerializer, 'serializeArray', _ => challenges);
@@ -43,11 +43,11 @@ describe('Unit | Controller | challenge-controller', function () {
     });
   });
 
-  describe('#get', function () {
+  describe('#get', function() {
 
     const challenge = new Challenge({ 'id': 'challenge_id' });
 
-    it('should fetch and return the given challenge, serialized as JSONAPI', function (done) {
+    it('should fetch and return the given challenge, serialized as JSONAPI', function(done) {
       // given
       sinon.stub(ChallengeRepository, 'get').resolves(challenge);
       sinon.stub(ChallengeSerializer, 'serialize', () => challenge);
@@ -65,7 +65,7 @@ describe('Unit | Controller | challenge-controller', function () {
       });
     });
 
-    it('should reply with error status code 404 if challenge not found', function (done) {
+    it('should reply with error status code 404 if challenge not found', function(done) {
       // given
       const error = {
         'error': {
@@ -88,9 +88,9 @@ describe('Unit | Controller | challenge-controller', function () {
     });
   });
 
-  describe('#refreshSolution', function () {
+  describe('#refreshSolution', function() {
 
-    it('should refresh all the given challenge solutions', function (done) {
+    it('should refresh all the given challenge solutions', function(done) {
       // given
       const solution = new Solution({
         id: 1,

--- a/api/tests/unit/application/challenges/index_test.js
+++ b/api/tests/unit/application/challenges/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, before, after, beforeEach, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const ChallengeController = require('../../../../lib/application/challenges/challenge-controller');
 
-describe('Unit | Router | challenge-router', function () {
+describe('Unit | Router | challenge-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/challenges') });
@@ -19,77 +19,77 @@ describe('Unit | Router | challenge-router', function () {
     });
   }
 
-  describe('GET /api/challenges', function () {
+  describe('GET /api/challenges', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(ChallengeController, 'list', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       ChallengeController.list.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/challenges' }, done);
     });
   });
 
-  describe('GET /api/challenges/{id}', function () {
+  describe('GET /api/challenges/{id}', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(ChallengeController, 'get', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       ChallengeController.get.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/challenges/challenge_id' }, done);
     });
   });
 
-  describe('POST /api/challenges/{id}', function () {
+  describe('POST /api/challenges/{id}', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(ChallengeController, 'refresh', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       ChallengeController.refresh.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/challenges/challenge_id' }, done);
     });
   });
 
-  describe('PUT /api/challenges/{id}/validate', function () {
+  describe('PUT /api/challenges/{id}/validate', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(ChallengeController, 'revalidateAnswers', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       ChallengeController.revalidateAnswers.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'PUT', url: '/api/challenges/{id}/validate' }, done);
     });
   });
   
-  describe('POST /api/challenges/{id}/solution', function () {
+  describe('POST /api/challenges/{id}/solution', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(ChallengeController, 'refreshSolution', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       ChallengeController.refreshSolution.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/challenges/challenge_id/solution' }, done);
     });
   });

--- a/api/tests/unit/application/controller/assessment-controller_test.js
+++ b/api/tests/unit/application/controller/assessment-controller_test.js
@@ -54,12 +54,12 @@ describe('Unit | Controller | assessment-controller', () => {
       // given
       const expectedError = { error: 'Expected API Return 404' };
 
-      let boomNotFound = sinon.stub(Boom, 'notFound').returns(expectedError);
+      const boomNotFound = sinon.stub(Boom, 'notFound').returns(expectedError);
       const getScoredError = new NotFoundError('Expected API Return 404');
       getScoredAssessmentStub.rejects(getScoredError);
 
       // when
-      let promise = assessmentController.get(request, reply);
+      const promise = assessmentController.get(request, reply);
 
       // then
       return promise.then(() => {
@@ -80,7 +80,7 @@ describe('Unit | Controller | assessment-controller', () => {
       assessmentSerializerStub.returns(expectedSerializedAssessment);
 
       // When
-      let promise = assessmentController.get(request, reply);
+      const promise = assessmentController.get(request, reply);
 
       // Then
       return promise.then(() => {
@@ -96,11 +96,11 @@ describe('Unit | Controller | assessment-controller', () => {
       // given
       const expectedError = { error: 'Expected API Return ' };
 
-      let boomBadImplementationStub = sinon.stub(Boom, 'badImplementation').returns(expectedError);
+      const boomBadImplementationStub = sinon.stub(Boom, 'badImplementation').returns(expectedError);
       getScoredAssessmentStub.rejects(new Error('Expected Error Message'));
 
       // when
-      let promise = assessmentController.get(request, reply);
+      const promise = assessmentController.get(request, reply);
 
       // then
       return promise.then(() => {
@@ -118,7 +118,7 @@ describe('Unit | Controller | assessment-controller', () => {
       getScoredAssessmentStub.resolves(scoredAssessement);
 
       // when
-      let promise = assessmentController.get(request, reply);
+      const promise = assessmentController.get(request, reply);
 
       // then
       return promise.then(() => {

--- a/api/tests/unit/application/controller/assessment-controller_test.js
+++ b/api/tests/unit/application/controller/assessment-controller_test.js
@@ -10,7 +10,6 @@ const assessmentSerializer = require('../../../../lib/infrastructure/serializers
 const { NotFoundError, NotElligibleToScoringError } = require('../../../../lib/domain/errors');
 const Assessment = require('../../../../lib/domain/models/data/assessment');
 
-
 describe('Unit | Controller | assessment-controller', () => {
 
   describe('#get', () => {
@@ -66,7 +65,6 @@ describe('Unit | Controller | assessment-controller', () => {
         boomNotFound.restore();
         sinon.assert.calledWithExactly(boomNotFound, getScoredError);
 
-
       });
     });
 
@@ -90,7 +88,6 @@ describe('Unit | Controller | assessment-controller', () => {
       });
 
     });
-
 
     it('should return a Bad Implementation error when we cannot retrieve the score', () => {
       // given

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -5,25 +5,25 @@ const courseRepository = require('../../../../lib/infrastructure/repositories/co
 const courseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/course-serializer');
 const cache = require('../../../../lib/infrastructure/cache');
 
-describe('Unit | Controller | course-controller', function () {
+describe('Unit | Controller | course-controller', function() {
 
   let server;
 
-  before(function () {
+  before(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/courses') });
   });
 
-  beforeEach(function () {
+  beforeEach(function() {
     cache.flushAll();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     cache.flushAll();
   });
 
-  describe('#list', function () {
+  describe('#list', function() {
 
     const courses = [
       new Course({ id: 'course_1' }),
@@ -31,7 +31,7 @@ describe('Unit | Controller | course-controller', function () {
       new Course({ id: 'course_3' })
     ];
 
-    it('should fetch and return all the courses', function (done) {
+    it('should fetch and return all the courses', function(done) {
       // given
       sinon.stub(courseRepository, 'getProgressionCourses').resolves(courses);
       sinon.stub(courseSerializer, 'serializeArray', () => courses);
@@ -49,7 +49,7 @@ describe('Unit | Controller | course-controller', function () {
       });
     });
 
-    it('should fetch and return all the adaptive courses', function (done) {
+    it('should fetch and return all the adaptive courses', function(done) {
       // given
       sinon.stub(courseRepository, 'getAdaptiveCourses').resolves(courses);
       sinon.stub(courseSerializer, 'serializeArray', () => courses);
@@ -67,7 +67,7 @@ describe('Unit | Controller | course-controller', function () {
       });
     });
 
-    it('should fetch and return all the highlitghted courses of the week', function (done) {
+    it('should fetch and return all the highlitghted courses of the week', function(done) {
       // given
       sinon.stub(courseRepository, 'getCoursesOfTheWeek').resolves(courses);
       sinon.stub(courseSerializer, 'serializeArray', () => courses);
@@ -86,11 +86,11 @@ describe('Unit | Controller | course-controller', function () {
     });
   });
 
-  describe('#get', function () {
+  describe('#get', function() {
 
     const course = new Course({ 'id': 'course_id' });
 
-    it('should fetch and return the given course, serialized as JSONAPI', function (done) {
+    it('should fetch and return the given course, serialized as JSONAPI', function(done) {
       // given
       sinon.stub(courseRepository, 'get').resolves(course);
       sinon.stub(courseSerializer, 'serialize', () => course);
@@ -108,7 +108,7 @@ describe('Unit | Controller | course-controller', function () {
       });
     });
 
-    it('should reply with error status code 404 if course not found', function (done) {
+    it('should reply with error status code 404 if course not found', function(done) {
       // given
       const error = {
         error: {
@@ -131,9 +131,9 @@ describe('Unit | Controller | course-controller', function () {
     });
   });
 
-  describe('#refreshAll', function () {
+  describe('#refreshAll', function() {
 
-    it('should return "courses updated" if refresh is ok', function (done) {
+    it('should return "courses updated" if refresh is ok', function(done) {
       // given
       sinon.stub(courseRepository, 'refreshAll').resolves(true);
 
@@ -150,7 +150,7 @@ describe('Unit | Controller | course-controller', function () {
       });
     });
 
-    it('should return "courses updated" if refresh is ok', function (done) {
+    it('should return "courses updated" if refresh is ok', function(done) {
       // given
       const error = 'An internal server error occurred';
       sinon.stub(courseRepository, 'refreshAll').rejects(error);

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -79,5 +79,4 @@ describe('Unit | Router | course-router', function() {
     });
   });
 
-
 });

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, before, after, beforeEach, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const CourseController = require('../../../../lib/application/courses/course-controller');
 
-describe('Unit | Router | course-router', function () {
+describe('Unit | Router | course-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/courses') });
@@ -19,62 +19,62 @@ describe('Unit | Router | course-router', function () {
     });
   }
 
-  describe('GET /api/courses', function () {
+  describe('GET /api/courses', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(CourseController, 'list', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       CourseController.list.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/courses' }, done);
     });
   });
 
-  describe('GET /api/courses/{id}', function () {
+  describe('GET /api/courses/{id}', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(CourseController, 'get', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       CourseController.get.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'GET', url: '/api/courses/course_id' }, done);
     });
   });
 
-  describe('POST /api/courses/{id}', function () {
+  describe('POST /api/courses/{id}', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(CourseController, 'refresh', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       CourseController.refresh.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/courses/course_id' }, done);
     });
   });
 
-  describe('PUT /api/courses', function () {
+  describe('PUT /api/courses', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(CourseController, 'refreshAll', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       CourseController.refreshAll.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'PUT', url: '/api/courses' }, done);
     });
   });

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -3,17 +3,17 @@ const Hapi = require('hapi');
 const _ = require('lodash');
 const Feedback = require('../../../../lib/domain/models/data/feedback');
 
-describe('Unit | Controller | feedback-controller', function () {
+describe('Unit | Controller | feedback-controller', function() {
 
   let server;
 
-  before(function () {
+  before(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/feedbacks') });
   });
 
-  describe('#save', function () {
+  describe('#save', function() {
 
     const jsonFeedback = {
       data: {
@@ -45,12 +45,12 @@ describe('Unit | Controller | feedback-controller', function () {
       content: 'Lorem ipsum dolor sit amet consectetur adipiscet.'
     });
 
-    before(function () {
+    before(function() {
       Feedback.prototype.save = sinon.stub();
       Feedback.prototype.save.resolves(persistedFeedback);
     });
 
-    after(function () {
+    after(function() {
       sinon.restore(Feedback.prototype.save);
     });
 
@@ -60,7 +60,7 @@ describe('Unit | Controller | feedback-controller', function () {
       });
     }
 
-    it('should return a successful response with HTTP code 201 when feedback was saved', function (done) {
+    it('should return a successful response with HTTP code 201 when feedback was saved', function(done) {
       // when
       executeRequest(jsonFeedback, (res) => {
         // then
@@ -69,7 +69,7 @@ describe('Unit | Controller | feedback-controller', function () {
       });
     });
 
-    it('should return an error 400 if feedback content is missing or empty', function (done) {
+    it('should return an error 400 if feedback content is missing or empty', function(done) {
       // given
       const payload = _.clone(jsonFeedback);
       payload.data.attributes.content = '   ';
@@ -82,7 +82,7 @@ describe('Unit | Controller | feedback-controller', function () {
       });
     });
 
-    it('should persist feedback data into the Feedback Repository', function (done) {
+    it('should persist feedback data into the Feedback Repository', function(done) {
       // given
       const payload = _.clone(jsonFeedback);
 

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, beforeEach, before, after, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const FeedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
 
-describe('Unit | Router | feedback-router', function () {
+describe('Unit | Router | feedback-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/feedbacks') });
@@ -18,17 +18,17 @@ describe('Unit | Router | feedback-router', function () {
       done();
     });
   }
-  describe('POST /api/feedbacks', function () {
+  describe('POST /api/feedbacks', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(FeedbackController, 'save', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       FeedbackController.save.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       expectRouteToExist({ method: 'POST', url: '/api/feedbacks' }, done);
     });
   });

--- a/api/tests/unit/application/followers/follower-controller_test.js
+++ b/api/tests/unit/application/followers/follower-controller_test.js
@@ -9,9 +9,9 @@ const mailService = require('../../../../lib/domain/services/mail-service');
 const faker = require('faker');
 const server = require('../../../../server');
 
-describe('Unit | Controller | FollowerController', function () {
+describe('Unit | Controller | FollowerController', function() {
 
-  describe('#save', function () {
+  describe('#save', function() {
 
     let sendWelcomeEmail;
 
@@ -23,7 +23,7 @@ describe('Unit | Controller | FollowerController', function () {
       sendWelcomeEmail.restore();
     });
 
-    it('should return 400 status code when email provided is not valid', function () {
+    it('should return 400 status code when email provided is not valid', function() {
       // Given
       const follower = { 'email': 'testeur@follower.pix' };
       const emailValidatorStub = sinon.stub(EmailValidator, 'emailIsValid').returns(false);
@@ -40,7 +40,7 @@ describe('Unit | Controller | FollowerController', function () {
       });
     });
 
-    it('should send a welcome email', function () {
+    it('should send a welcome email', function() {
       // Given
       const email = faker.internet.email();
       const request = { payload: { data: { attributes: { email } } } };

--- a/api/tests/unit/application/followers/follower-controller_test.js
+++ b/api/tests/unit/application/followers/follower-controller_test.js
@@ -25,12 +25,12 @@ describe('Unit | Controller | FollowerController', function () {
 
     it('should return 400 status code when email provided is not valid', function () {
       // Given
-      const follower = { "email": "testeur@follower.pix" };
+      const follower = { 'email': 'testeur@follower.pix' };
       const emailValidatorStub = sinon.stub(EmailValidator, 'emailIsValid').returns(false);
       sinon.stub(followerSerializer, 'deserialize', _ => new Follower(follower));
 
       // When
-      let promise = server.injectThen({ method: 'POST', url: '/api/followers', payload: { "email": 'INVALID_EMAIL' } });
+      const promise = server.injectThen({ method: 'POST', url: '/api/followers', payload: { 'email': 'INVALID_EMAIL' } });
 
       // Then
       return promise.then((res) => {

--- a/api/tests/unit/application/followers/index_test.js
+++ b/api/tests/unit/application/followers/index_test.js
@@ -2,11 +2,11 @@ const {describe, it, expect, before, after, beforeEach, sinon} = require('../../
 const Hapi = require('hapi');
 const FollowerController = require('../../../../lib/application/followers/follower-controller');
 
-describe('Unit | Router | FollowerRouter', function () {
+describe('Unit | Router | FollowerRouter', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/followers') });
@@ -19,17 +19,17 @@ describe('Unit | Router | FollowerRouter', function () {
     });
   }
 
-  describe('POST /api/followers', function () {
+  describe('POST /api/followers', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(FollowerController, 'save', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       FollowerController.save.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       return expectRouteToExist({ method: 'POST', url: '/api/followers' }, done);
     });
   });

--- a/api/tests/unit/application/followers/index_test.js
+++ b/api/tests/unit/application/followers/index_test.js
@@ -1,4 +1,4 @@
-const {describe, it, expect, before, after, sinon} = require('../../../test-helper');
+const {describe, it, expect, before, after, beforeEach, sinon} = require('../../../test-helper');
 const Hapi = require('hapi');
 const FollowerController = require('../../../../lib/application/followers/follower-controller');
 

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -9,7 +9,7 @@ describe('Unit | Controller | healthcheckController', () => {
       expect(healthcheckController.get).to.exist;
     });
 
-    it('should reply with the API description', function () {
+    it('should reply with the API description', function() {
       // given
       const replySpy = sinon.spy();
 

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -2,11 +2,11 @@ const {describe, it, expect, before, beforeEach, after, sinon} = require('../../
 const Hapi = require('hapi');
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');
 
-describe('Unit | Router | HealthcheckRouter', function () {
+describe('Unit | Router | HealthcheckRouter', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = this.server = new Hapi.Server();
     server.connection({port: null});
     server.register({register: require('../../../../lib/application/healthcheck')});
@@ -19,17 +19,17 @@ describe('Unit | Router | HealthcheckRouter', function () {
     });
   }
 
-  describe('GET /api', function () {
+  describe('GET /api', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(healthcheckController, 'get', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       healthcheckController.get.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       return expectRouteToExist({method: 'GET', url: '/api'}, done);
     });
   });

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -2,11 +2,11 @@ const { describe, it, before, after, beforeEach, expect, sinon } = require('../.
 const Hapi = require('hapi');
 const UserController = require('../../../../lib/application/users/user-controller');
 
-describe('Unit | Router | user-router', function () {
+describe('Unit | Router | user-router', function() {
 
   let server;
 
-  beforeEach(function () {
+  beforeEach(function() {
     server = new Hapi.Server();
     server.connection({ port: null });
     server.register({ register: require('../../../../lib/application/users') });
@@ -19,17 +19,17 @@ describe('Unit | Router | user-router', function () {
     });
   }
 
-  describe('POST /api/accounts', function () {
+  describe('POST /api/accounts', function() {
 
-    before(function () {
+    before(function() {
       sinon.stub(UserController, 'save', (request, reply) => reply('ok'));
     });
 
-    after(function () {
+    after(function() {
       UserController.save.restore();
     });
 
-    it('should exist', function (done) {
+    it('should exist', function(done) {
       return expectRouteToExist({ method: 'POST', url: '/api/accounts' }, done);
     });
   });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -195,8 +195,6 @@ describe('Unit | Controller | user-controller', () => {
 
       });
 
-
-
       it('when there is not payload', () => {
         // Given
         const request = {};
@@ -238,7 +236,6 @@ describe('Unit | Controller | user-controller', () => {
         // Then
         boomBadRequestMock.verify();
       });
-
 
     });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -50,13 +50,13 @@ describe('Unit | Controller | user-controller', () => {
         });
 
         mailServiceMock = sinon.mock(mailService);
-        userSerializerStub = sinon.stub(userSerializer, "deserialize").returns({
+        userSerializerStub = sinon.stub(userSerializer, 'deserialize').returns({
           save: _ => { return Promise.resolve(user); }
         });
 
         replyStub.returns({
           code: _ => {}
-        })
+        });
       });
 
       afterEach(() => {
@@ -76,10 +76,10 @@ describe('Unit | Controller | user-controller', () => {
             }
           }
         };
-        mailServiceMock.expects("sendAccountCreationEmail").once().withArgs(email);
+        mailServiceMock.expects('sendAccountCreationEmail').once().withArgs(email);
 
         // When
-        let promise = userController.save(request, replyStub);
+        const promise = userController.save(request, replyStub);
 
         // Then
         return promise.then(() => {
@@ -108,7 +108,7 @@ describe('Unit | Controller | user-controller', () => {
       };
 
       // When
-      let promise = userController.save(request, replyStub);
+      const promise = userController.save(request, replyStub);
 
       // Then
       return promise.then(() => {
@@ -154,7 +154,7 @@ describe('Unit | Controller | user-controller', () => {
           });
 
           // When
-          let promise = userController.save(request, replyStub);
+          const promise = userController.save(request, replyStub);
 
           // Then
           return promise.then(() => {
@@ -181,7 +181,7 @@ describe('Unit | Controller | user-controller', () => {
           });
 
           // When
-          let promise = userController.save(request, replyStub);
+          const promise = userController.save(request, replyStub);
 
           // Then
           return promise.then(() => {

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../test-helper');
+const { describe, it, expect } = require('../../test-helper');
 
 const errors = require('../../../lib/domain/errors');
 

--- a/api/tests/unit/domain/models/user_test.js
+++ b/api/tests/unit/domain/models/user_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../../test-helper');
+const { describe, it, expect, beforeEach, sinon } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/data/user');
 const faker = require('faker');

--- a/api/tests/unit/domain/models/user_test.js
+++ b/api/tests/unit/domain/models/user_test.js
@@ -5,7 +5,6 @@ const faker = require('faker');
 
 describe('Unit | Domain | Models | User', () => {
 
-
   describe('validation', () => {
 
     let rawData;
@@ -76,7 +75,6 @@ describe('Unit | Domain | Models | User', () => {
           expect(lastName).to.deep.equal([ 'Votre nom n\'est pas renseigné.' ]);
         });
     });
-
 
     describe('the password field', () => {
       it('should have a minimum length', () => {
@@ -181,7 +179,6 @@ describe('Unit | Domain | Models | User', () => {
           });
       });
 
-
       it('is valid when everything works', () => {
         // Given
         const user = new User(rawData);
@@ -199,6 +196,5 @@ describe('Unit | Domain | Models | User', () => {
     });
 
   });
-
 
 });

--- a/api/tests/unit/domain/services/assessment-service-utils_tests.js
+++ b/api/tests/unit/domain/services/assessment-service-utils_tests.js
@@ -2,9 +2,9 @@ const { describe, it } = require('mocha');
 const { expect } = require('chai');
 const service = require('../../../../lib/domain/services/assessment-service-utils');
 
-describe('Unit | Domain | Services | assessment-service-utils', function () {
+describe('Unit | Domain | Services | assessment-service-utils', function() {
 
-  describe('#getResponsePattern', function () {
+  describe('#getResponsePattern', function() {
 
     const correctAnswer = {attributes: {result: 'ok'}};
     const incorrectAnswer = {attributes: {result: 'ko'}};
@@ -15,7 +15,7 @@ describe('Unit | Domain | Services | assessment-service-utils', function () {
       { answers: [], value: '' }
     ].forEach(pattern => {
 
-      it(`should return "${pattern.value}" when user pattern is ${pattern.title}`, function () {
+      it(`should return "${pattern.value}" when user pattern is ${pattern.title}`, function() {
         expect(service.getResponsePattern(pattern.answers)).to.equal(pattern.value);
       });
     });

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../../test-helper');
+const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/assessment-service');
 
@@ -173,7 +173,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
     it('should retrieve assessment from repository', () => {
       // When
-      let promise = service.getScoredAssessment(ASSESSMENT_ID);
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
       // Then
       return promise.then(() => {
@@ -187,7 +187,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
       getAssessmentStub.returns(Promise.reject(errorOnRepository));
 
       // When
-      let promise = service.getScoredAssessment(ASSESSMENT_ID);
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
       // Then
       return promise.then(() => {
@@ -203,7 +203,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
       getAssessmentStub.returns(Promise.resolve(null));
 
       // When
-      let promise = service.getScoredAssessment(ASSESSMENT_ID);
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
       // Then
       return promise.then(() => {
@@ -215,7 +215,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
     it('should detect Assessement created for preview Challenge and do not evaluate score', () => {
       // Given
-      let assessmentFromPreview = new Assessment({
+      const assessmentFromPreview = new Assessment({
         id: '1',
         courseId: 'nullfec89bd5-a706-419b-a6d2-f8805e708ace'
       });
@@ -223,7 +223,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
       findByAssessmentStub.returns(Promise.reject());
 
       // When
-      let promise = service.getScoredAssessment(ASSESSMENT_ID);
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
       // Then
       return promise
@@ -248,13 +248,13 @@ describe('Unit | Domain | Services | assessment-service', function () {
         getCourseStub.returns(Promise.reject(new Error('Error from courseRepository')));
 
         // When
-        let promise = service.getScoredAssessment(ASSESSMENT_ID);
+        const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
         // Then
         return promise
           .then(() => {
-              sinon.assert.fail('Should not succeed');
-            },
+            sinon.assert.fail('Should not succeed');
+          },
             (error) => {
               sinon.assert.calledWithExactly(getCourseStub, COURSE_ID);
               expect(error.message).to.equal('Error from courseRepository');
@@ -263,7 +263,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
       it('should load answers for the assessment', () => {
         // When
-        let promise = service.getScoredAssessment(ASSESSMENT_ID);
+        const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
         // Then
         return promise
@@ -279,7 +279,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
         let secondFakeChallenge;
 
         beforeEach(() => {
-          let course = { challenges: [ 'challenge_web_1', 'challenge_web_2' ] };
+          const course = { challenges: [ 'challenge_web_1', 'challenge_web_2' ] };
           getCourseStub.returns(Promise.resolve(course));
 
           firstFakeChallenge = _buildChallenge([ '@web1' ]);
@@ -291,7 +291,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
         it('should get knowledgeData each one', () => {
           // When
-          let promise = service.getScoredAssessment(ASSESSMENT_ID);
+          const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
           // Then
           return promise
@@ -303,7 +303,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
         it('should resolve the promise with a scored assessment', () => {
           // When
-          let promise = service.getScoredAssessment(ASSESSMENT_ID);
+          const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
           // Then
           return promise

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -37,7 +37,6 @@ function _buildAnswer(challengeId, result, assessmentId = 1) {
   return answer;
 }
 
-
 function _buildAssessment(estimatedLevel, pixScore, notAcquiredKnowledgeTags, acquiredKnowledgeTags, cid) {
   const assessment = new Assessment({ id: 'assessment_id' });
   assessment.set('estimatedLevel', estimatedLevel);
@@ -47,7 +46,6 @@ function _buildAssessment(estimatedLevel, pixScore, notAcquiredKnowledgeTags, ac
   assessment.cid = cid;
   return assessment;
 }
-
 
 describe('Unit | Domain | Services | assessment-service', function() {
 
@@ -73,7 +71,6 @@ describe('Unit | Domain | Services | assessment-service', function() {
 
     });
 
-
     it('Should return the next challenge if currentChallengeId is given', function(done) {
 
       sinon.stub(courseRepository, 'get').resolves({ challenges: [ '1st_challenge', '2nd_challenge' ] });
@@ -86,7 +83,6 @@ describe('Unit | Domain | Services | assessment-service', function() {
 
     });
 
-
     it('Should resolves to "null" if no assessment is given', function(done) {
 
       service.getAssessmentNextChallengeId().then(function(result) {
@@ -95,7 +91,6 @@ describe('Unit | Domain | Services | assessment-service', function() {
       });
 
     });
-
 
     it('Should resolves to "null" if no courseId is given', function(done) {
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -49,23 +49,23 @@ function _buildAssessment(estimatedLevel, pixScore, notAcquiredKnowledgeTags, ac
 }
 
 
-describe('Unit | Domain | Services | assessment-service', function () {
+describe('Unit | Domain | Services | assessment-service', function() {
 
-  it('should exist', function () {
+  it('should exist', function() {
     expect(service).to.exist;
   });
 
-  it('#getAssessmentNextChallengeId should exist', function () {
+  it('#getAssessmentNextChallengeId should exist', function() {
     expect(service.getAssessmentNextChallengeId).to.exist;
   });
 
-  describe('#getAssessmentNextChallengeId', function () {
+  describe('#getAssessmentNextChallengeId', function() {
 
-    it('Should return the first challenge if no currentChallengeId is given', function (done) {
+    it('Should return the first challenge if no currentChallengeId is given', function(done) {
 
       sinon.stub(courseRepository, 'get').resolves({ challenges: [ 'the_first_challenge' ] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null).then(function (result) {
+      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null).then(function(result) {
         expect(result).to.equal('the_first_challenge');
         courseRepository.get.restore();
         done();
@@ -74,11 +74,11 @@ describe('Unit | Domain | Services | assessment-service', function () {
     });
 
 
-    it('Should return the next challenge if currentChallengeId is given', function (done) {
+    it('Should return the next challenge if currentChallengeId is given', function(done) {
 
       sinon.stub(courseRepository, 'get').resolves({ challenges: [ '1st_challenge', '2nd_challenge' ] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge').then(function (result) {
+      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge').then(function(result) {
         expect(result).to.equal('2nd_challenge');
         courseRepository.get.restore();
         done();
@@ -87,9 +87,9 @@ describe('Unit | Domain | Services | assessment-service', function () {
     });
 
 
-    it('Should resolves to "null" if no assessment is given', function (done) {
+    it('Should resolves to "null" if no assessment is given', function(done) {
 
-      service.getAssessmentNextChallengeId().then(function (result) {
+      service.getAssessmentNextChallengeId().then(function(result) {
         expect(result).to.equal(null);
         done();
       });
@@ -97,11 +97,11 @@ describe('Unit | Domain | Services | assessment-service', function () {
     });
 
 
-    it('Should resolves to "null" if no courseId is given', function (done) {
+    it('Should resolves to "null" if no courseId is given', function(done) {
 
       sinon.stub(courseRepository, 'get').resolves({ challenges: [ '1st_challenge', '2nd_challenge' ] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge').then(function (result) {
+      service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge').then(function(result) {
         expect(result).to.equal(null);
         courseRepository.get.restore();
         done();
@@ -109,11 +109,11 @@ describe('Unit | Domain | Services | assessment-service', function () {
 
     });
 
-    it('Should resolves to "null" if courseId starts with "null"', function (done) {
+    it('Should resolves to "null" if courseId starts with "null"', function(done) {
 
       sinon.stub(courseRepository, 'get').resolves({ challenges: [ '1st_challenge', '2nd_challenge' ] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge').then(function (result) {
+      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge').then(function(result) {
         expect(result).to.equal(null);
         courseRepository.get.restore();
         done();
@@ -318,7 +318,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
     });
   });
 
-  describe('#_completeAssessmentWithScore', function () {
+  describe('#_completeAssessmentWithScore', function() {
 
     const knowledgeData = {
       challengesById: {
@@ -374,7 +374,7 @@ describe('Unit | Domain | Services | assessment-service', function () {
       }
     ]
       .forEach(pattern => {
-        it(`should compute ${pattern.score} and level ${pattern.level} when user pattern is ${pattern.title}`, function () {
+        it(`should compute ${pattern.score} and level ${pattern.level} when user pattern is ${pattern.title}`, function() {
           // When
           const scoredAssessment = service._completeAssessmentWithScore(assessment, pattern.answers, knowledgeData);
 

--- a/api/tests/unit/domain/services/challenge-service_test.js
+++ b/api/tests/unit/domain/services/challenge-service_test.js
@@ -66,7 +66,6 @@ describe('Unit | Service | ChallengeService', function() {
       // when
       const result = service.getKnowledgeData(challenges);
 
-
       // then
       const expected = {
         challengesById: {
@@ -95,6 +94,5 @@ describe('Unit | Service | ChallengeService', function() {
     });
 
   });
-
 
 });

--- a/api/tests/unit/domain/services/challenge-service_test.js
+++ b/api/tests/unit/domain/services/challenge-service_test.js
@@ -9,7 +9,7 @@ function _buildAnswer(result) {
   return answer;
 }
 
-describe('Unit | Service | ChallengeService', function () {
+describe('Unit | Service | ChallengeService', function() {
 
   describe('#getRevalidationStatistics', () => {
 
@@ -23,7 +23,7 @@ describe('Unit | Service | ChallengeService', function () {
     ]
       .forEach((testCase) => {
 
-        it('should be able to return stats about added ' + testCase.case + ' solution', function () {
+        it('should be able to return stats about added ' + testCase.case + ' solution', function() {
           const old_answer = [ _buildAnswer(testCase.oppositeCase) ];
           const new_answer = [ _buildAnswer(testCase.case) ];
           const under_test = service.getRevalidationStatistics(old_answer, new_answer);
@@ -32,7 +32,7 @@ describe('Unit | Service | ChallengeService', function () {
           expect(under_test[ diffProperty ]).to.equal(1);
         });
 
-        it('should be able to return stats about removed ' + testCase.case + ' solution', function () {
+        it('should be able to return stats about removed ' + testCase.case + ' solution', function() {
           const old_answer = [ _buildAnswer(testCase.case) ];
           const new_answer = [ _buildAnswer(testCase.oppositeCase) ];
           const under_test = service.getRevalidationStatistics(old_answer, new_answer);
@@ -41,7 +41,7 @@ describe('Unit | Service | ChallengeService', function () {
           expect(under_test[ diffProperty ]).to.equal(-1);
         });
 
-        it('should be able to return stats that add all ' + testCase.case + ' solutions', function () {
+        it('should be able to return stats that add all ' + testCase.case + ' solutions', function() {
           const old_answer = [ _buildAnswer(testCase.case), _buildAnswer(testCase.case) ];
           const new_answer = [ _buildAnswer(testCase.case), _buildAnswer(testCase.case) ];
           const under_test = service.getRevalidationStatistics(old_answer, new_answer);

--- a/api/tests/unit/domain/services/challenge-service_test.js
+++ b/api/tests/unit/domain/services/challenge-service_test.js
@@ -64,7 +64,7 @@ describe('Unit | Service | ChallengeService', function () {
       ];
 
       // when
-      let result = service.getKnowledgeData(challenges);
+      const result = service.getKnowledgeData(challenges);
 
 
       // then

--- a/api/tests/unit/domain/services/deactivations-service_test.js
+++ b/api/tests/unit/domain/services/deactivations-service_test.js
@@ -2,9 +2,9 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/deactivations-service');
 
-describe('Unit | Service | DeactivationsService ', function () {
+describe('Unit | Service | DeactivationsService ', function() {
 
-  describe('isDefault | all treatments should apply by default', function () {
+  describe('isDefault | all treatments should apply by default', function() {
     const allCases = [
       {when:'No deactivations at all', output: true, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: true, deactivations: new Date()},
@@ -23,14 +23,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.isDefault(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasOnlyT1 | only T1 is declared as deactivated  ', function () {
+  describe('hasOnlyT1 | only T1 is declared as deactivated  ', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -49,15 +49,15 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
 
-  describe('hasOnlyT2 | only T2 is declared as deactivated  ', function () {
+  describe('hasOnlyT2 | only T2 is declared as deactivated  ', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -76,14 +76,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasOnlyT3 | only T3 is declared as deactivated', function () {
+  describe('hasOnlyT3 | only T3 is declared as deactivated', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -102,14 +102,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT3(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasOnlyT1T2 | only T1 and T2 are declared as deactivated', function () {
+  describe('hasOnlyT1T2 | only T1 and T2 are declared as deactivated', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -128,14 +128,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T2(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasOnlyT1T3 | only T1 and T3 are declared as deactivated', function () {
+  describe('hasOnlyT1T3 | only T1 and T3 are declared as deactivated', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -154,14 +154,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T3(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasOnlyT2T3 | only T2 and T3 are declared as deactivated', function () {
+  describe('hasOnlyT2T3 | only T2 and T3 are declared as deactivated', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -180,14 +180,14 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2T3(caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('hasT1T2T3 | T1, T2 and T3 are declared as deactivated', function () {
+  describe('hasT1T2T3 | T1, T2 and T3 are declared as deactivated', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
       {when:'Deactivations is of wrong type', output: false, deactivations: new Date()},
@@ -206,8 +206,8 @@ describe('Unit | Service | DeactivationsService ', function () {
       {when:'Deactivations has t1, t2, t3 with truthy value', output: true, deactivations: {t1: true, t2: 'other', t3: 'any'}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasT1T2T3(caze.deactivations)).to.equal(caze.output);
       });
     });

--- a/api/tests/unit/domain/services/deactivations-service_test.js
+++ b/api/tests/unit/domain/services/deactivations-service_test.js
@@ -56,7 +56,6 @@ describe('Unit | Service | DeactivationsService ', function() {
     });
   });
 
-
   describe('hasOnlyT2 | only T2 is declared as deactivated  ', function() {
     const allCases = [
       {when:'No deactivations at all', output: false, deactivations: undefined},
@@ -212,7 +211,6 @@ describe('Unit | Service | DeactivationsService ', function() {
       });
     });
   });
-
 
 });
 

--- a/api/tests/unit/domain/services/email-validator_test.js
+++ b/api/tests/unit/domain/services/email-validator_test.js
@@ -1,9 +1,9 @@
 const { describe, it, expect } = require('../../../test-helper');
 const service = require('../../../../lib/domain/services/email-validator');
 
-describe('Unit | Service | email-validator', function () {
+describe('Unit | Service | email-validator', function() {
 
-  it('should return false when email is not provided', function () {
+  it('should return false when email is not provided', function() {
     expect(service.emailIsValid()).to.be.false;
   });
 
@@ -17,8 +17,8 @@ describe('Unit | Service | email-validator', function () {
     'INVALID_EMAIL@pix.',
     '@pix.fr',
     '@pix'
-  ].forEach(function (badEmail) {
-    it(`should return false when email is invalid: ${badEmail}`, function () {
+  ].forEach(function(badEmail) {
+    it(`should return false when email is invalid: ${badEmail}`, function() {
       expect(service.emailIsValid(badEmail)).to.be.false;
     });
   });
@@ -33,8 +33,8 @@ describe('Unit | Service | email-validator', function () {
     'follower+beta@pix.fr',
     'follower+beta@pix.gouv.fr',
     'follower+beta@pix.beta.gouv.fr'
-  ].forEach(function (validEmail) {
-    it(`should return true if provided email is valid: ${validEmail}`, function () {
+  ].forEach(function(validEmail) {
+    it(`should return true if provided email is valid: ${validEmail}`, function() {
       expect(service.emailIsValid(validEmail)).to.be.true;
     });
   });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -21,7 +21,6 @@ describe('Unit | Service | MailService', () => {
       // Given
       const email = 'text@example.net';
 
-
       // When
       const promise = mailService.sendAccountCreationEmail(email);
 
@@ -53,7 +52,6 @@ describe('Unit | Service | MailService', () => {
     it('should use mailJet to send an email', () => {
       // Given
       const email = 'text@example.net';
-
 
       // When
       const promise = mailService.sendWelcomeEmail(email);

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -10,7 +10,7 @@ describe('Unit | Service | MailService', () => {
     let sendEmailStub;
 
     beforeEach(() => {
-      sendEmailStub = sinon.stub(mailJet, "sendEmail").resolves()
+      sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
     });
 
     afterEach(() => {
@@ -43,7 +43,7 @@ describe('Unit | Service | MailService', () => {
     let sendEmailStub;
 
     beforeEach(() => {
-      sendEmailStub = sinon.stub(mailJet, "sendEmail").resolves()
+      sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
     });
 
     afterEach(() => {
@@ -67,6 +67,6 @@ describe('Unit | Service | MailService', () => {
         });
       });
     });
-  })
+  });
 
 });

--- a/api/tests/unit/domain/services/scoring_test.js
+++ b/api/tests/unit/domain/services/scoring_test.js
@@ -295,7 +295,7 @@ describe('Unit | Domain | Service | scoring', function () {
         {
           performanceStats: {
             nbAcquiredKnowledgeTagsByLevel: {
-              "1": 0, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0
+              '1': 0, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0
             }
           },
           expectedEstimatedLevel: 0,
@@ -304,7 +304,7 @@ describe('Unit | Domain | Service | scoring', function () {
         {
           performanceStats: {
             nbAcquiredKnowledgeTagsByLevel: {
-              "1": 1, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0
+              '1': 1, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0
             }
           },
           expectedEstimatedLevel: 0,
@@ -313,7 +313,7 @@ describe('Unit | Domain | Service | scoring', function () {
         {
           performanceStats: {
             nbAcquiredKnowledgeTagsByLevel: {
-              "1": 2, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0
+              '1': 2, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0
             }
           },
           expectedEstimatedLevel: 1,
@@ -322,7 +322,7 @@ describe('Unit | Domain | Service | scoring', function () {
         {
           performanceStats: {
             nbAcquiredKnowledgeTagsByLevel: {
-              "1": 0, "2": 1, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0
+              '1': 0, '2': 1, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0
             }
           },
           expectedEstimatedLevel: 0,
@@ -331,7 +331,7 @@ describe('Unit | Domain | Service | scoring', function () {
         {
           performanceStats: {
             nbAcquiredKnowledgeTagsByLevel: {
-              "1": 2, "2": 1, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0
+              '1': 2, '2': 1, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0
             }
           },
           expectedEstimatedLevel: 2,
@@ -363,6 +363,6 @@ describe('Unit | Domain | Service | scoring', function () {
         });
 
       });
-    })
+    });
   });
 });

--- a/api/tests/unit/domain/services/scoring_test.js
+++ b/api/tests/unit/domain/services/scoring_test.js
@@ -6,7 +6,6 @@ const scoring = require(pathToSource + '/lib/domain/services/scoring-service');
 const Answer = require(pathToSource + '/lib/domain/models/data/answer');
 const Challenge = require(pathToSource + '/lib/domain/models/referential/challenge');
 
-
 function _buildChallenge(knowledgeTags) {
   const challenge = new Challenge({ id: 'challenge_id' });
   challenge.knowledgeTags = knowledgeTags;
@@ -220,7 +219,6 @@ describe('Unit | Domain | Service | scoring', function() {
         // Then
         expect(result.performanceHistory).to.deep.equal([ { difficulty: 2, outcome: 1 } ]);
       });
-
 
       it('should not record an outcome from an answer which is partially correct', () => {
         // Given

--- a/api/tests/unit/domain/services/scoring_test.js
+++ b/api/tests/unit/domain/services/scoring_test.js
@@ -20,16 +20,16 @@ function _buildAnswer(challengeId, result) {
   return answer;
 }
 
-describe('Unit | Domain | Service | scoring', function () {
+describe('Unit | Domain | Service | scoring', function() {
 
-  describe('#nextNode', function () {
+  describe('#nextNode', function() {
 
     [
       { title: 'direction is increasing', node: 'web4', dir: 1, answer: 'web5' },
       { title: 'direction is decreasing', node: 'rechInfo3', dir: -1, answer: 'rechInfo2' },
     ].forEach(testCase => {
 
-      it(`should return ${testCase.answer} when ${testCase.title} and node is ${testCase.node}`, function () {
+      it(`should return ${testCase.answer} when ${testCase.title} and node is ${testCase.node}`, function() {
         const result = scoring.nextNode(testCase.node, testCase.dir);
         expect(result).to.equal(testCase.answer);
       });
@@ -37,7 +37,7 @@ describe('Unit | Domain | Service | scoring', function () {
 
   });
 
-  describe('#propagateKnowledge', function () {
+  describe('#propagateKnowledge', function() {
 
     const allKnowledge = { 'web3': 1, 'web4': 1, 'web5': 1, 'web6': 1 };
 
@@ -46,7 +46,7 @@ describe('Unit | Domain | Service | scoring', function () {
       { title: 'direction is decreasing', startNode: 'web4', dir: -1, answer: [ 'web3', 'web4' ] }
     ].forEach(testCase => {
 
-      it(`should return ${testCase.answer} when ${testCase.title} and node is ${testCase.node}`, function () {
+      it(`should return ${testCase.answer} when ${testCase.title} and node is ${testCase.node}`, function() {
         // When
         const result = scoring.propagateKnowledge(allKnowledge, testCase.startNode, testCase.dir);
 

--- a/api/tests/unit/domain/services/solution-service-function-match_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-match_test.js
@@ -10,7 +10,7 @@ const Answer = require('../../../../lib/domain/models/data/answer');
 const Solution = require('../../../../lib/domain/models/referential/solution');
 const _ = require('../../../../lib/infrastructure/utils/lodash-utils');
 
-describe('Unit | Service | SolutionService', function () {
+describe('Unit | Service | SolutionService', function() {
 
   function buildSolution(type, value, scoring, deactivations, enabledTreatments) {
     const solution = new Solution({ id: 'solution_id' });
@@ -28,17 +28,17 @@ describe('Unit | Service | SolutionService', function () {
     return answer;
   }
 
-  describe('#validate', function () {
+  describe('#validate', function() {
 
-    describe('if solution type is QCU', function () {
+    describe('if solution type is QCU', function() {
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QCU', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({ result: 'aband', resultDetails: null });
       });
 
-      it('Should return result of solution-service-qcu.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qcu.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qcuAnswer');
@@ -57,7 +57,7 @@ describe('Unit | Service | SolutionService', function () {
         expect(result).to.deep.equal({result: 'qcuMatching', resultDetails: null});
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qcuAnswer', -15);
@@ -78,15 +78,15 @@ describe('Unit | Service | SolutionService', function () {
 
     });
 
-    describe('if solution type is QRU', function () {
+    describe('if solution type is QRU', function() {
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QRU', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('Should return result of solution-service-qru.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qru.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qruAnswer');
@@ -105,7 +105,7 @@ describe('Unit | Service | SolutionService', function () {
         expect(result).to.deep.equal({result: 'qruMatching', resultDetails: null});
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qruAnswer', -15);
@@ -125,15 +125,15 @@ describe('Unit | Service | SolutionService', function () {
       });
     });
 
-    describe('if solution type is QCM', function () {
+    describe('if solution type is QCM', function() {
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QCM', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('Should return result of solution-service-qcm.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qcm.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qcmAnswer');
@@ -152,7 +152,7 @@ describe('Unit | Service | SolutionService', function () {
         expect(result).to.deep.equal({result: 'qcmMatching', resultDetails: null});
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qcmAnswer', -15);
@@ -174,15 +174,15 @@ describe('Unit | Service | SolutionService', function () {
     });
 
 
-    describe('if solution type is QROC', function () {
+    describe('if solution type is QROC', function() {
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QROC', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('Should return result of solution-service-qroc.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qroc.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocAnswer');
@@ -206,7 +206,7 @@ describe('Unit | Service | SolutionService', function () {
         expect(result).to.deep.equal({result: 'qrocMatching', resultDetails: null});
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocAnswer', -15);
@@ -235,7 +235,7 @@ describe('Unit | Service | SolutionService', function () {
     });
 
 
-    describe('if solution type is QROCM-ind', function () {
+    describe('if solution type is QROCM-ind', function() {
 
       //TODO : FIX ME When refacto of qrocm-dep and qroc done delete deactivations in parameters of buildSolution and delete this one
       function buildSolutionQROCMind(type, value, scoring, enabledTreatments) {
@@ -247,13 +247,13 @@ describe('Unit | Service | SolutionService', function () {
         return solution;
       }
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QROCM-ind', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('Should return result of solution-service-qrocmInd.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qrocmInd.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocmIndAnswer');
@@ -277,7 +277,7 @@ describe('Unit | Service | SolutionService', function () {
 
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocmIndAnswer', -15);
@@ -305,15 +305,15 @@ describe('Unit | Service | SolutionService', function () {
 
     });
 
-    describe('if solution type is QROCM-dep', function () {
+    describe('if solution type is QROCM-dep', function() {
 
-      it('Should return "aband" if answer is #ABAND#', function () {
+      it('Should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('QROCM-dep', 'some value');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('Should return result of solution-service-qrocmDep.match() | user didnt abandoned | no timeout', function () {
+      it('Should return result of solution-service-qrocmDep.match() | user didnt abandoned | no timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocmDepAnswer');
@@ -336,7 +336,7 @@ describe('Unit | Service | SolutionService', function () {
         expect(result).to.deep.equal({result: 'qrocmDepMatching', resultDetails: null});
       });
 
-      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function () {
+      it('Should be verified against _timedOut function | user didnt abandoned | with timeout', function() {
 
         // Given
         const answer = buildAnswer('qrocmDepAnswer', -15);
@@ -364,16 +364,16 @@ describe('Unit | Service | SolutionService', function () {
 
     });
 
-    describe('if solution type is unknown', function () {
+    describe('if solution type is unknown', function() {
 
 
-      it('should return "aband" if answer is #ABAND#', function () {
+      it('should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('SOME_TYPE');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'aband', resultDetails: null});
       });
 
-      it('should return "unimplemented" if answer is not #ABAND#', function () {
+      it('should return "unimplemented" if answer is not #ABAND#', function() {
         const answer = buildAnswer('some value');
         const solution = buildSolution('SOME_TYPE');
         expect(service.validate(answer, solution)).to.deep.equal({result: 'unimplemented', resultDetails: null});

--- a/api/tests/unit/domain/services/solution-service-function-match_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-match_test.js
@@ -173,7 +173,6 @@ describe('Unit | Service | SolutionService', function() {
 
     });
 
-
     describe('if solution type is QROC', function() {
 
       it('Should return "aband" if answer is #ABAND#', function() {
@@ -233,7 +232,6 @@ describe('Unit | Service | SolutionService', function() {
       });
 
     });
-
 
     describe('if solution type is QROCM-ind', function() {
 
@@ -366,7 +364,6 @@ describe('Unit | Service | SolutionService', function() {
 
     describe('if solution type is unknown', function() {
 
-
       it('should return "aband" if answer is #ABAND#', function() {
         const answer = buildAnswer('#ABAND#');
         const solution = buildSolution('SOME_TYPE');
@@ -382,6 +379,5 @@ describe('Unit | Service | SolutionService', function() {
     });
 
   });
-
 
 });

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -6,7 +6,6 @@ const SolutionRepository = require('../../../../lib/infrastructure/repositories/
 
 describe('Unit | Service | SolutionService', function() {
 
-
   describe('#revalidate', function() {
 
     const ko_answer = {
@@ -55,7 +54,6 @@ describe('Unit | Service | SolutionService', function() {
     after(function(done) {
       knex('answers').delete().then(() => {done();});
     });
-
 
     it('If the answer is timedout, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
@@ -130,7 +128,6 @@ describe('Unit | Service | SolutionService', function() {
       });
 
     });
-
 
     it('If the answer is unimplemented, resolve to the answer itself, with result corresponding to the matching', function(done) {
 

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -4,10 +4,10 @@ const service = require('../../../../lib/domain/services/solution-service');
 const Answer = require('../../../../lib/domain/models/data/answer');
 const SolutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');
 
-describe('Unit | Service | SolutionService', function () {
+describe('Unit | Service | SolutionService', function() {
 
 
-  describe('#revalidate', function () {
+  describe('#revalidate', function() {
 
     const ko_answer = {
       id: 1,
@@ -44,7 +44,7 @@ describe('Unit | Service | SolutionService', function () {
       challengeId: 'any_challenge_id'
     };
 
-    before(function (done) {
+    before(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([ko_answer, ok_answer, unimplemented_answer, aband_answer, timedout_answer]).then(() => {
           done();
@@ -52,14 +52,14 @@ describe('Unit | Service | SolutionService', function () {
       });
     });
 
-    after(function (done) {
+    after(function(done) {
       knex('answers').delete().then(() => {done();});
     });
 
 
-    it('If the answer is timedout, resolve to the answer itself, unchanged', function (done) {
+    it('If the answer is timedout, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(timedout_answer)).then(function (foundAnswer) {
+      service.revalidate(new Answer(timedout_answer)).then(function(foundAnswer) {
         expect(foundAnswer.id).equals(timedout_answer.id);
         expect(foundAnswer.attributes.value).equals(timedout_answer.value);
         expect(foundAnswer.attributes.result).equals(timedout_answer.result);
@@ -68,9 +68,9 @@ describe('Unit | Service | SolutionService', function () {
       });
     });
 
-    it('If the answer is aband, resolve to the answer itself, unchanged', function (done) {
+    it('If the answer is aband, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(aband_answer)).then(function (foundAnswer) {
+      service.revalidate(new Answer(aband_answer)).then(function(foundAnswer) {
         expect(foundAnswer.id).equals(aband_answer.id);
         expect(foundAnswer.attributes.value).equals(aband_answer.value);
         expect(foundAnswer.attributes.result).equals(aband_answer.result);
@@ -79,7 +79,7 @@ describe('Unit | Service | SolutionService', function () {
       });
     });
 
-    it('If the answer is ko, resolve to the answer itself, with result corresponding to the matching', function (done) {
+    it('If the answer is ko, resolve to the answer itself, with result corresponding to the matching', function(done) {
 
       // given
       const MATCHING_RETURNS = {result: '#ANY_RESULT#', resultDetails: null};
@@ -89,7 +89,7 @@ describe('Unit | Service | SolutionService', function () {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(ko_answer)).then(function (foundAnswer) {
+      service.revalidate(new Answer(ko_answer)).then(function(foundAnswer) {
 
         // then
         SolutionRepository.get.restore();
@@ -105,7 +105,7 @@ describe('Unit | Service | SolutionService', function () {
 
     });
 
-    it('If the answer is ok, resolve to the answer itself, with result corresponding to the matching', function (done) {
+    it('If the answer is ok, resolve to the answer itself, with result corresponding to the matching', function(done) {
 
       // given
       const MATCHING_RETURNS = {result: '#ANY_RESULT#', resultDetails: null};
@@ -115,7 +115,7 @@ describe('Unit | Service | SolutionService', function () {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(ok_answer)).then(function (foundAnswer) {
+      service.revalidate(new Answer(ok_answer)).then(function(foundAnswer) {
 
         // then
         SolutionRepository.get.restore();
@@ -132,7 +132,7 @@ describe('Unit | Service | SolutionService', function () {
     });
 
 
-    it('If the answer is unimplemented, resolve to the answer itself, with result corresponding to the matching', function (done) {
+    it('If the answer is unimplemented, resolve to the answer itself, with result corresponding to the matching', function(done) {
 
       // given
       const MATCHING_RETURNS = {result: '#ANY_RESULT#', resultDetails: null};
@@ -142,7 +142,7 @@ describe('Unit | Service | SolutionService', function () {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(unimplemented_answer)).then(function (foundAnswer) {
+      service.revalidate(new Answer(unimplemented_answer)).then(function(foundAnswer) {
 
         // then
         SolutionRepository.get.restore();

--- a/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
@@ -2,9 +2,9 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service');
 
-describe('Unit | Service | SolutionService', function () {
+describe('Unit | Service | SolutionService', function() {
 
-  describe('#_timedOut', function () {
+  describe('#_timedOut', function() {
 
     const allCases = [
       {when: 'partially correct & timeout < 0', preresult: 'partially' , timeout: -5, output: 'timedout'},
@@ -19,8 +19,8 @@ describe('Unit | Service | SolutionService', function () {
 
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when preresult is "' + caze.preresult + '" and timeout is "' + caze.timeout + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when preresult is "' + caze.preresult + '" and timeout is "' + caze.timeout + '"', function() {
         expect(service._timedOut(caze.preresult, caze.timeout)).to.equal(caze.output);
       });
     });

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -7,7 +7,6 @@ const _ = require('../../../../lib/infrastructure/utils/lodash-utils');
 
 describe('Unit | Service | SolutionServiceQCM ', function() {
 
-
   function buildSolution(type, value, scoring) {
     const solution = new Solution({id: 'solution_id'});
     solution.type = type;
@@ -21,7 +20,6 @@ describe('Unit | Service | SolutionServiceQCM ', function() {
     answer.attributes = {value, timeout};
     return answer.get('value');
   }
-
 
   describe('if solution type is QCM', function() {
 

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -5,7 +5,7 @@ const Answer = require('../../../../lib/domain/models/data/answer');
 const Solution = require('../../../../lib/domain/models/referential/solution');
 const _ = require('../../../../lib/infrastructure/utils/lodash-utils');
 
-describe('Unit | Service | SolutionServiceQCM ', function () {
+describe('Unit | Service | SolutionServiceQCM ', function() {
 
 
   function buildSolution(type, value, scoring) {
@@ -23,7 +23,7 @@ describe('Unit | Service | SolutionServiceQCM ', function () {
   }
 
 
-  describe('if solution type is QCM', function () {
+  describe('if solution type is QCM', function() {
 
     const successfulCases = [
       {answer: '1', solution: '1'},
@@ -36,8 +36,8 @@ describe('Unit | Service | SolutionServiceQCM ', function () {
       {answer: '1, 2, 3', solution: '1, 2, 3'}
     ];
 
-    successfulCases.forEach(function (testCase) {
-      it('should return "ok" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    successfulCases.forEach(function(testCase) {
+      it('should return "ok" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);
         expect(service.match(answer, solution)).to.equal('ok');
@@ -51,8 +51,8 @@ describe('Unit | Service | SolutionServiceQCM ', function () {
       {answer: '3, 1', solution: '1, 2'}
     ];
 
-    failedCases.forEach(function (testCase) {
-      it('should return "ko" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    failedCases.forEach(function(testCase) {
+      it('should return "ko" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);
         expect(service.match(answer, solution)).to.equal('ko');

--- a/api/tests/unit/domain/services/solution-service-qcu_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcu_test.js
@@ -2,15 +2,15 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qcu');
 
-describe('Unit | Service | SolutionServiceQCU ', function () {
+describe('Unit | Service | SolutionServiceQCU ', function() {
 
-  describe('if solution type is QCU', function () {
+  describe('if solution type is QCU', function() {
 
-    it('should return "ok" when answer and solution are equal', function () {
+    it('should return "ok" when answer and solution are equal', function() {
       expect(service.match('same value', 'same value')).to.equal('ok');
     });
 
-    it('should return "ko" when answer and solution are different', function () {
+    it('should return "ko" when answer and solution are different', function() {
       expect(service.match('answer value', 'different solution value')).to.equal('ko');
     });
 

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -32,7 +32,6 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       });
     });
 
-
     const failingCases = [
       {case:'solution do not exists', answer: 'any answer'},
       {case:'solution is not a String', answer: 'a', solution : new Date()},
@@ -52,7 +51,6 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
     });
 
   });
-
 
   describe('match, strong focus on treatments', function() {
 

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -2,9 +2,9 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qroc');
 
-describe('Unit | Service | SolutionServiceQROC ', function () {
+describe('Unit | Service | SolutionServiceQROC ', function() {
 
-  describe('match, combining most weird cases without deactivations', function () {
+  describe('match, combining most weird cases without deactivations', function() {
 
     const successfulCases = [
 
@@ -26,8 +26,8 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {case:'(multiple solutions) answer is 0.25 away from the closest solution', answer: 'quak', solution: 'qvak\nqwak\nanything\n'}
     ];
 
-    successfulCases.forEach(function (caze) {
-      it (caze.case + ', should return "ok" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    successfulCases.forEach(function(caze) {
+      it (caze.case + ', should return "ok" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution)).to.equal('ok');
       });
     });
@@ -45,8 +45,8 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {case:'(multiple solutions) answer is minimum 0.4 away from a solution', answer: 'quaks', solution: 'qvakes\nqwakes\nanything\n'}
     ];
 
-    failingCases.forEach(function (caze) {
-      it(caze.case + ', should return "ko" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    failingCases.forEach(function(caze) {
+      it(caze.case + ', should return "ko" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution)).to.equal('ko');
       });
     });
@@ -54,7 +54,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
   });
 
 
-  describe('match, strong focus on treatments', function () {
+  describe('match, strong focus on treatments', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {}},
@@ -72,14 +72,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ok', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t1 deactivated', function () {
+  describe('match | t1 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t1:true}},
@@ -97,14 +97,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ok', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t1:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t2 deactivated', function () {
+  describe('match | t2 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t2:true}},
@@ -122,14 +122,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ok', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t2:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t3 deactivated', function () {
+  describe('match | t3 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t3:true}},
@@ -147,14 +147,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ko', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t3:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t1 and t2 deactivated', function () {
+  describe('match | t1 and t2 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t1:true, t2:true}},
@@ -172,14 +172,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ok', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t1:true, t2:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t1 and t3 deactivated', function () {
+  describe('match | t1 and t3 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t1:true, t3:true}},
@@ -197,14 +197,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ko', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t1:true, t3:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t2 and t3 deactivated', function () {
+  describe('match | t2 and t3 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t2:true, t3:true}},
@@ -222,14 +222,14 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ko', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t2:true, t3:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });
   });
 
-  describe('match | t1, t2 and t3 deactivated', function () {
+  describe('match | t1, t2 and t3 deactivated', function() {
 
     const allCases = [
       {when:'no stress',                   output: 'ok', answer: 'Answer',      solution: '\nvariant1\nAnswer\n',      deactivations: {t1:true, t2:true, t3:true}},
@@ -247,8 +247,8 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
       {when:'reverted levenshtein stress', output: 'ko', answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {t1:true, t2:true, t3:true}},
     ];
 
-    allCases.forEach(function (caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function () {
+    allCases.forEach(function(caze) {
+      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
         expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.equal(caze.output);
       });
     });

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -2,12 +2,12 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qrocm-dep');
 
-describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
+describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
 
   const twoPossibleSolutions = 'Google:\n- Google\n- google.fr\n- Google Search\nYahoo:\n- Yahoo\n- Yahoo Answer';
   const threePossibleSolutions = 'Google:\n- Google\n- google.fr\n- Google Search\nYahoo:\n- Yahoo\n- Yahoo Answer\nBing:\n- Bing';
 
-  describe('if solution type is QROCM-dep', function () {
+  describe('if solution type is QROCM-dep', function() {
 
     const failedCases = [
       {
@@ -91,21 +91,21 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       }
     ];
 
-    maximalScoreCases.forEach(function (testCase) {
-      it(`Should return "ok" when ${testCase.when}`, function () {
+    maximalScoreCases.forEach(function(testCase) {
+      it(`Should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution)).to.equal('ok');
       });
     });
 
   });
 
-  describe('if solution type is QROCM-dep with scoring', function () {
+  describe('if solution type is QROCM-dep with scoring', function() {
 
-    it('should return "ko" for badly formatted solution', function () {
+    it('should return "ko" for badly formatted solution', function() {
       expect(service.match('num1: Google\nnum2: Yahoo', 'solution like a QCU', '1: @acquix')).to.equal('ko');
     });
 
-    it('should return "ko" when answer is incorrect', function () {
+    it('should return "ko" when answer is incorrect', function() {
       expect(service.match('num1: Foo\nnum2: Bar', twoPossibleSolutions, '1: acquix')).to.equal('ko');
     });
 
@@ -130,8 +130,8 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       }
     ];
 
-    maximalScoreCases.forEach(function (testCase) {
-      it(`should return "ok" when ${testCase.when}`, function () {
+    maximalScoreCases.forEach(function(testCase) {
+      it(`should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.equal('ok');
       });
     });
@@ -157,9 +157,9 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       }
     ];
 
-    partialScoreCases.forEach(function (testCase) {
+    partialScoreCases.forEach(function(testCase) {
 
-      it(`should return "partially" when ${testCase.when}`, function () {
+      it(`should return "partially" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.equal('partially');
       });
 
@@ -192,15 +192,15 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       }
     ];
 
-    failedCases.forEach(function (testCase) {
-      it(`should return "ko" when ${testCase.when}`, function () {
+    failedCases.forEach(function(testCase) {
+      it(`should return "ko" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.equal('ko');
       });
     });
 
   });
 
-  describe('match, strong focus on treatments', function () {
+  describe('match, strong focus on treatments', function() {
 
     const allCases = [
       {
@@ -309,14 +309,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(`${testCase.when}, should return ${testCase.output} when answer is "${testCase.answer}" and solution is "${testCase.solution}"`, function () {
+    allCases.forEach(function(testCase) {
+      it(`${testCase.when}, should return ${testCase.output} when answer is "${testCase.answer}" and solution is "${testCase.solution}"`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 deactivated', function () {
+  describe('match, t1 deactivated', function() {
 
     const allCases = [
       {
@@ -425,14 +425,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t2 deactivated', function () {
+  describe('match, t2 deactivated', function() {
 
     const allCases = [
       {
@@ -541,14 +541,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t3 deactivated', function () {
+  describe('match, t3 deactivated', function() {
 
     const allCases = [
       {
@@ -657,14 +657,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 and t2 deactivated', function () {
+  describe('match, t1 and t2 deactivated', function() {
 
     const allCases = [
       {
@@ -773,14 +773,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 and t3 deactivated', function () {
+  describe('match, t1 and t3 deactivated', function() {
 
     const allCases = [
       {
@@ -889,14 +889,14 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1, t2, and t3 deactivated', function () {
+  describe('match, t1, t2, and t3 deactivated', function() {
 
     const allCases = [
       {
@@ -1005,8 +1005,8 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.equal(testCase.output);
       });
     });

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -2,11 +2,11 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qrocm-ind');
 
-describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
+describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
 
-  describe('#_applyTreatmentsToSolutions(solutions, enabledTreatments)', function () {
+  describe('#_applyTreatmentsToSolutions(solutions, enabledTreatments)', function() {
 
-    it('t1 and t2 should be executed (lowerCase, trim, breaking space)', function () {
+    it('t1 and t2 should be executed (lowerCase, trim, breaking space)', function() {
       // given
       const solutions = { '3lettres': ['OUI', 'NON   '], '4lettres': ['Good', 'Bad'] };
       const expected = { '3lettres': ['oui', 'non'], '4lettres': ['good', 'bad'] };
@@ -18,9 +18,9 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
     });
   });
 
-  describe('#_applyTreatmentsToAnswers(answers, enabledTreatments)', function () {
+  describe('#_applyTreatmentsToAnswers(answers, enabledTreatments)', function() {
 
-    it('should be transformed in string', function () {
+    it('should be transformed in string', function() {
       // given
       const answers = { 'Num1': 1, 'Num2': 2 };
       const expected = { 'Num1': '1', 'Num2': '2' };
@@ -31,7 +31,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('should be transformed', function () {
+    it('should be transformed', function() {
       // given
       const answers = { 'Num1': 1, 'Num2': 2 };
       const expected = { 'Num1': '1', 'Num2': '2' };
@@ -43,9 +43,9 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
     });
   });
 
-  describe('#_compareAnswersAndSolutions', function () {
+  describe('#_compareAnswersAndSolutions', function() {
 
-    it('should return results comparing answers and solutions strictly when T3 is disabled', function () {
+    it('should return results comparing answers and solutions strictly when T3 is disabled', function() {
       // given
       const answers = { 'Num1': '1', 'Num2': '3' };
       const solutions = { 'Num1': ['1', 'un', '01'], 'Num2': ['2', 'deux', '02'] };
@@ -59,7 +59,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('should return results comparing answers and solutions with Levenshtein ratio when T3 is enabled', function () {
+    it('should return results comparing answers and solutions with Levenshtein ratio when T3 is enabled', function() {
       // given
       const answers = { 'phrase1': 'Le silence est d\'ours', 'phrase2': 'faceboo', 'phrase3': 'lasagne' };
       const solutions = { 'phrase1': ['Le silence est d\'or'], 'phrase2': ['facebook'], 'phrase3': ['engasal'] };
@@ -74,9 +74,9 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
     });
   });
 
-  describe('#_formatResult', function () {
+  describe('#_formatResult', function() {
 
-    it('should return "ko"', function () {
+    it('should return "ko"', function() {
       // given
       const resultDetails = { 'phrase1': true, 'phrase2': false, 'phrase3': true };
 
@@ -86,7 +86,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       // then
       expect(actual).to.equal('ko');
     });
-    it('should return "ok"', function () {
+    it('should return "ok"', function() {
       // given
       const resultDetails = { 'phrase1': true, 'phrase2': true, 'phrase3': true };
 
@@ -98,7 +98,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
     });
   });
 
-  describe('Nominal and weird, combined cases', function () {
+  describe('Nominal and weird, combined cases', function() {
 
     const successfulCases = [{
       case: '(nominal case) Each answer strictly respect a corresponding solution',
@@ -187,8 +187,8 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
     }
     ];
 
-    successfulCases.forEach(function (testCase) {
-      it(testCase.case + ', should return "ok" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    successfulCases.forEach(function(testCase) {
+      it(testCase.case + ', should return "ok" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
@@ -252,15 +252,15 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       }
     ];
 
-    failingCases.forEach(function (testCase) {
-      it(testCase.case + ', should return "ko" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    failingCases.forEach(function(testCase) {
+      it(testCase.case + ', should return "ko" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
 
   });
 
-  describe('match, strong focus on treatments', function () {
+  describe('match, strong focus on treatments', function() {
 
     const allCases = [
       {
@@ -356,15 +356,15 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         const actual = service.match(testCase.answer, testCase.solution, testCase.enabledTreatments);
         expect(actual).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 deactivated', function () {
+  describe('match, t1 deactivated', function() {
 
     const allCases = [
       {
@@ -460,14 +460,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t2 deactivated', function () {
+  describe('match, t2 deactivated', function() {
 
     const allCases = [
       {
@@ -563,14 +563,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t3 deactivated', function () {
+  describe('match, t3 deactivated', function() {
 
     const allCases = [
       {
@@ -666,14 +666,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 and t2 deactivated', function () {
+  describe('match, t1 and t2 deactivated', function() {
 
     const allCases = [
       {
@@ -769,14 +769,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1 and t3 deactivated', function () {
+  describe('match, t1 and t3 deactivated', function() {
 
     const allCases = [
       {
@@ -872,14 +872,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t2 and t3 deactivated', function () {
+  describe('match, t2 and t3 deactivated', function() {
 
     const allCases = [
       {
@@ -975,14 +975,14 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });
   });
 
-  describe('match, t1, t2 and t3 deactivated', function () {
+  describe('match, t1, t2 and t3 deactivated', function() {
 
     const allCases = [
       {
@@ -1078,8 +1078,8 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
       },
     ];
 
-    allCases.forEach(function (testCase) {
-      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function () {
+    allCases.forEach(function(testCase) {
+      it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
     });

--- a/api/tests/unit/domain/services/solution-service-qru_test.js
+++ b/api/tests/unit/domain/services/solution-service-qru_test.js
@@ -2,11 +2,11 @@ const { describe, it, expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qru');
 
-describe('Unit | Service | SolutionServiceQRU ', function () {
+describe('Unit | Service | SolutionServiceQRU ', function() {
 
-  describe('if solution type is QRU', function () {
+  describe('if solution type is QRU', function() {
 
-    it('should return "unimplemented" in all cases', function () {
+    it('should return "unimplemented" in all cases', function() {
       expect(service.match()).to.equal('unimplemented');
     });
 

--- a/api/tests/unit/domain/services/solutions-service-utils_tests.js
+++ b/api/tests/unit/domain/services/solutions-service-utils_tests.js
@@ -2,34 +2,34 @@ const { describe, it } = require('mocha');
 const { expect } = require('chai');
 const service = require('../../../../lib/domain/services/solution-service-utils');
 
-describe('Unit | Domain | Services | solution-service-utils', function () {
+describe('Unit | Domain | Services | solution-service-utils', function() {
 
   describe('treatmentT1T2T3', function() {
-    it('Should exist', function () {
+    it('Should exist', function() {
       expect(service.treatmentT1T2T3).to.exist;
     });
-    it('Should return null if adminAnswers is not an array of String', function () {
+    it('Should return null if adminAnswers is not an array of String', function() {
       expect(service.treatmentT1T2T3('quack', [new Date(), new Date()])).to.equal(null);
     });
-    it('Should return t1 treatment', function () {
+    it('Should return t1 treatment', function() {
       expect(service.treatmentT1T2T3(' Crème BrûLée 1 ', ['any']).t1).to.equal('cremebrulee1');
     });
-    it('Should return t2 treatment', function () {
+    it('Should return t2 treatment', function() {
       expect(service.treatmentT1T2T3('Th!!is.,', ['any']).t2).to.equal('This');
     });
-    it('Should return t1 & t2 treatment', function () {
+    it('Should return t1 & t2 treatment', function() {
       expect(service.treatmentT1T2T3('Th!!is., is  Crème BrûLée 1 ', ['any']).t1t2).to.equal('thisiscremebrulee1');
     });
-    it('Should return t3 ratio', function () {
+    it('Should return t3 ratio', function() {
       expect(service.treatmentT1T2T3('beck', ['back', 'book']).t3Ratio).to.equal(0.25);
     });
-    it('Should return t3 ratio applied to t1', function () {
+    it('Should return t3 ratio applied to t1', function() {
       expect(service.treatmentT1T2T3(' Béck ', ['back', 'book']).t1t3Ratio).to.equal(0.25);
     });
-    it('Should return t3 ratio applied to t2', function () {
+    it('Should return t3 ratio applied to t2', function() {
       expect(service.treatmentT1T2T3('th!!is.', ['that', 'those']).t2t3Ratio).to.equal(0.5);
     });
-    it('Should return t3 ratio applied to t1 and t2', function () {
+    it('Should return t3 ratio applied to t1 and t2', function() {
       expect(service.treatmentT1T2T3('éeE1', ['eee12', 'blabla']).t1t2t3Ratio).to.equal(0.25);
     });
   });

--- a/api/tests/unit/domain/services/solutions-service-utils_tests.js
+++ b/api/tests/unit/domain/services/solutions-service-utils_tests.js
@@ -34,5 +34,4 @@ describe('Unit | Domain | Services | solution-service-utils', function() {
     });
   });
 
-
 });

--- a/api/tests/unit/domain/services/validation-comparison_test.js
+++ b/api/tests/unit/domain/services/validation-comparison_test.js
@@ -1,7 +1,7 @@
 const { describe, it, expect } = require('../../../test-helper');
 const { _getSmallestLevenshteinDistance, t3 } = require('../../../../lib/domain/services/validation-comparison');
 
-describe('Unit | Service | Validation Comparison', function () {
+describe('Unit | Service | Validation Comparison', function() {
 
   /**
    * #_getSmallestLevenshteinDistance(str1, str2)
@@ -9,11 +9,11 @@ describe('Unit | Service | Validation Comparison', function () {
 
   describe('_getSmallestLevenshteinDistance', function() {
 
-    it('Should exist', function () {
+    it('Should exist', function() {
       expect(_getSmallestLevenshteinDistance).to.exist;
     });
 
-    describe('Should return levenshtein distance if only one adminAnswer is given', function () {
+    describe('Should return levenshtein distance if only one adminAnswer is given', function() {
 
       const successfulCases = [
         { should: 'If both are empty', arg1: '', arg2: [''], output: 0 },
@@ -22,15 +22,15 @@ describe('Unit | Service | Validation Comparison', function () {
         { should: 'If they have two different characters', arg1: 'book', arg2: ['back'], output: 2 },
       ];
 
-      successfulCases.forEach(function (testCase) {
-        it(testCase.should + ', for example arg1 ' + JSON.stringify(testCase.arg1) + ', and arg2 ' + JSON.stringify(testCase.arg2) + ' => ' + testCase.output + '', function () {
+      successfulCases.forEach(function(testCase) {
+        it(testCase.should + ', for example arg1 ' + JSON.stringify(testCase.arg1) + ', and arg2 ' + JSON.stringify(testCase.arg2) + ' => ' + testCase.output + '', function() {
           expect(_getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });
       });
 
     });
 
-    describe('Should return the smallest levenshtein distance if many adminAnswers are given', function () {
+    describe('Should return the smallest levenshtein distance if many adminAnswers are given', function() {
 
       const successfulCases = [
         { should: 'If the smallest difference is 0', arg1: '', arg2: ['', 'a'], output: 0 },
@@ -41,8 +41,8 @@ describe('Unit | Service | Validation Comparison', function () {
         { should: 'If the difference is 2 for all elements', arg1: 'book', arg2: ['back', 'buck'], output: 2 },
       ];
 
-      successfulCases.forEach(function (testCase) {
-        it(testCase.should + ', for example arg1 ' + JSON.stringify(testCase.arg1) + ', and arg2 ' + JSON.stringify(testCase.arg2) + ' => ' + testCase.output + '', function () {
+      successfulCases.forEach(function(testCase) {
+        it(testCase.should + ', for example arg1 ' + JSON.stringify(testCase.arg1) + ', and arg2 ' + JSON.stringify(testCase.arg2) + ' => ' + testCase.output + '', function() {
           expect(_getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });
       });
@@ -80,7 +80,7 @@ describe('Unit | Service | Validation Comparison', function () {
       ];
 
       successfulCases.forEach((testCase) => {
-        it(testCase.should + ', for example answer ' + JSON.stringify(testCase.answer) + ', and solution ' + JSON.stringify(testCase.solution) + ' => ' + testCase.output + '', function () {
+        it(testCase.should + ', for example answer ' + JSON.stringify(testCase.answer) + ', and solution ' + JSON.stringify(testCase.solution) + ' => ' + testCase.output + '', function() {
           expect(t3(testCase.answer, testCase.solution)).to.equal(testCase.output);
         });
       });

--- a/api/tests/unit/domain/services/validation-treatments_test.js
+++ b/api/tests/unit/domain/services/validation-treatments_test.js
@@ -1,13 +1,13 @@
 const { describe, it, expect } = require('../../../test-helper');
 const { t1, t2, applyPreTreatments, applyTreatments } = require('../../../../lib/domain/services/validation-treatments');
 
-describe('Unit | Service | Validation Treatments', function () {
+describe('Unit | Service | Validation Treatments', function() {
 
   /**
    * #t1(string)
    */
 
-  describe('#t1', function () {
+  describe('#t1', function() {
 
     it('checks sanity', () => {
       expect(t1).to.exist;
@@ -20,12 +20,12 @@ describe('Unit | Service | Validation Treatments', function () {
       { description: 'cédille', input: 'hameçon', expected: 'hamecon' },
       { description: 'case', input: 'SHI-fu-Mi', expected: 'shi-fu-mi' }
     ].forEach((scenario) => {
-      it(`should return the given string without "${scenario.description}"`, function () {
+      it(`should return the given string without "${scenario.description}"`, function() {
         expect(t1(scenario.input)).to.equal(scenario.expected);
       });
     });
 
-    it('should not modify æ and œ', function () {
+    it('should not modify æ and œ', function() {
       expect(t1('æ/œ')).to.equal('æ/œ');
     });
 
@@ -39,7 +39,7 @@ describe('Unit | Service | Validation Treatments', function () {
    * #t2(string)
    */
 
-  describe('#t2', function () {
+  describe('#t2', function() {
 
     it('checks sanity', () => {
       expect(t2).to.exist;
@@ -52,7 +52,7 @@ describe('Unit | Service | Validation Treatments', function () {
       { description: 'underscore and dashes', input: 'Shi-fu_mi', expected: 'Shifumi' },
       { description: 'parenthesis', input: '(anyway)', expected: 'anyway' }
     ].forEach((scenario) => {
-      it(`should return the given string without "${scenario.description}"`, function () {
+      it(`should return the given string without "${scenario.description}"`, function() {
         expect(t2(scenario.input)).to.equal(scenario.expected);
       });
     });
@@ -71,7 +71,7 @@ describe('Unit | Service | Validation Treatments', function () {
    * #applyPreTreatments(string)
    */
 
-  describe('#applyPreTreatments', function () {
+  describe('#applyPreTreatments', function() {
 
     it('should return a copy of the given string with unbreakable spaces replaced by normal spaces', () => {
       // given

--- a/api/tests/unit/infrastructure/mailjet-test.js
+++ b/api/tests/unit/infrastructure/mailjet-test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../test-helper');
+const { describe, it, beforeEach, afterEach, sinon } = require('../../test-helper');
 const Mailjet = require('../../../lib/infrastructure/mailjet');
 
 const nodeMailjet = require('node-mailjet');
@@ -10,7 +10,7 @@ describe('Unit | Class | Mailjet', function () {
     let mailJetConnectStub;
 
     beforeEach(() => {
-      mailJetConnectStub = sinon.stub(nodeMailjet, "connect");
+      mailJetConnectStub = sinon.stub(nodeMailjet, 'connect');
     });
 
     afterEach(() => {
@@ -24,7 +24,7 @@ describe('Unit | Class | Mailjet', function () {
           return {
             request: () => {
             }
-          }
+          };
         }
       });
 
@@ -32,7 +32,7 @@ describe('Unit | Class | Mailjet', function () {
       Mailjet.sendEmail();
 
       // Then
-      sinon.assert.calledWith(mailJetConnectStub, 'test-api-ket', 'test-api-secret')
+      sinon.assert.calledWith(mailJetConnectStub, 'test-api-ket', 'test-api-secret');
     });
 
     it('should post a send instruction', () => {

--- a/api/tests/unit/infrastructure/mailjet-test.js
+++ b/api/tests/unit/infrastructure/mailjet-test.js
@@ -3,7 +3,7 @@ const Mailjet = require('../../../lib/infrastructure/mailjet');
 
 const nodeMailjet = require('node-mailjet');
 
-describe('Unit | Class | Mailjet', function () {
+describe('Unit | Class | Mailjet', function() {
 
   describe('#sendEmail', () => {
 

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -4,7 +4,6 @@ const AnswerRepository = require('../../../../lib/infrastructure/repositories/an
 
 describe('Unit | Repository | AnswerRepository', function() {
 
-
   describe('findByChallengeAndAssessment', function() {
 
     // nominal case

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -2,10 +2,10 @@ const { describe, it, before, after, expect, knex } = require('../../../test-hel
 
 const AnswerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 
-describe('Unit | Repository | AnswerRepository', function () {
+describe('Unit | Repository | AnswerRepository', function() {
 
 
-  describe('findByChallengeAndAssessment', function () {
+  describe('findByChallengeAndAssessment', function() {
 
     // nominal case
     const inserted_answer_1 = {
@@ -31,7 +31,7 @@ describe('Unit | Repository | AnswerRepository', function () {
       assessmentId: 1
     };
 
-    before(function (done) {
+    before(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer_1, inserted_answer_2, inserted_answer_3]).then(() => {
           done();
@@ -39,11 +39,11 @@ describe('Unit | Repository | AnswerRepository', function () {
       });
     });
 
-    after(function (done) {
+    after(function(done) {
       knex('answers').delete().then(() => {done();});
     });
 
-    it('should find the answer by challenge and assessment and return its in an object', function (done) {
+    it('should find the answer by challenge and assessment and return its in an object', function(done) {
       expect(AnswerRepository.findByChallengeAndAssessment).to.exist;
       AnswerRepository.findByChallengeAndAssessment('challenge_1234', 1234).then(function(foundAnswers) {
         expect(foundAnswers).to.exist;
@@ -54,7 +54,7 @@ describe('Unit | Repository | AnswerRepository', function () {
     });
   });
 
-  describe('findByChallenge', function () {
+  describe('findByChallenge', function() {
 
     const inserted_answer_1 = {
       value: '1',
@@ -79,7 +79,7 @@ describe('Unit | Repository | AnswerRepository', function () {
       assessmentId: 1
     };
 
-    before(function (done) {
+    before(function(done) {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer_1, inserted_answer_2, inserted_answer_3]).then(() => {
           done();
@@ -87,11 +87,11 @@ describe('Unit | Repository | AnswerRepository', function () {
       });
     });
 
-    after(function (done) {
+    after(function(done) {
       knex('answers').delete().then(() => {done();});
     });
 
-    it('should find all answers by challenge', function (done) {
+    it('should find all answers by challenge', function(done) {
 
       expect(AnswerRepository.findByChallenge).to.exist;
 

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -109,7 +109,6 @@ describe('Unit | Repository | challenge-repository', function() {
       });
     });
 
-
   });
 
   /*

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -8,18 +8,18 @@ function _buildChallenge(id, instruction, proposals) {
   return { id, instruction, proposals };
 }
 
-describe('Unit | Repository | challenge-repository', function () {
+describe('Unit | Repository | challenge-repository', function() {
 
   let getRecord;
   let getRecords;
 
-  beforeEach(function () {
+  beforeEach(function() {
     cache.flushAll();
     getRecord = sinon.stub(airtable, 'getRecord');
     getRecords = sinon.stub(airtable, 'getRecords');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     cache.flushAll();
     getRecord.restore();
     getRecords.restore();
@@ -29,7 +29,7 @@ describe('Unit | Repository | challenge-repository', function () {
    * #list
    */
 
-  describe('#list', function () {
+  describe('#list', function() {
 
     const cacheKey = 'challenge-repository_list';
     const challenges = [
@@ -38,7 +38,7 @@ describe('Unit | Repository | challenge-repository', function () {
       _buildChallenge('challenge_id_3', 'Instruction #3', 'Proposals #3')
     ];
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -54,7 +54,7 @@ describe('Unit | Repository | challenge-repository', function () {
       done();
     });
 
-    it('should resolve with the callenges directly retrieved from the cache without calling airtable when the challenge has been cached', function (done) {
+    it('should resolve with the callenges directly retrieved from the cache without calling airtable when the challenge has been cached', function(done) {
       // given
       getRecords.resolves(true);
       cache.set(cacheKey, challenges);
@@ -68,13 +68,13 @@ describe('Unit | Repository | challenge-repository', function () {
       done();
     });
 
-    describe('when challenges have not been previsously cached', function () {
+    describe('when challenges have not been previsously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecords.resolves(challenges);
       });
 
-      it('should resolve with the challenges fetched from airtable', function (done) {
+      it('should resolve with the challenges fetched from airtable', function(done) {
         // when
         const result = challengeRepository.list();
 
@@ -83,7 +83,7 @@ describe('Unit | Repository | challenge-repository', function () {
         done();
       });
 
-      it('should cache the challenge fetched from airtable', function (done) {
+      it('should cache the challenge fetched from airtable', function(done) {
         // when
         challengeRepository.list().then(() => {
 
@@ -95,7 +95,7 @@ describe('Unit | Repository | challenge-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // given
         const expectedQuery = {};
 
@@ -116,13 +116,13 @@ describe('Unit | Repository | challenge-repository', function () {
    * #get
    */
 
-  describe('#get', function () {
+  describe('#get', function() {
 
     const challengeId = 'challengeId';
     const cacheKey = `challenge-repository_get_${challengeId}`;
     const challenge = { foo: 'bar' };
 
-    it('should resolve with the challenge directly retrieved from the cache without calling airtable when the challenge has been cached', function () {
+    it('should resolve with the challenge directly retrieved from the cache without calling airtable when the challenge has been cached', function() {
       // given
       getRecord.resolves(true);
       cache.set(cacheKey, challenge);
@@ -135,7 +135,7 @@ describe('Unit | Repository | challenge-repository', function () {
       return expect(result).to.eventually.deep.equal(challenge);
     });
 
-    it('should reject with an error when the cache throw an error', function () {
+    it('should reject with an error when the cache throw an error', function() {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -150,13 +150,13 @@ describe('Unit | Repository | challenge-repository', function () {
       return expect(result).to.eventually.be.rejectedWith(cacheErrorMessage);
     });
 
-    describe('when the challenge was not previously cached', function () {
+    describe('when the challenge was not previously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecord.resolves(challenge);
       });
 
-      it('should resolve with the challenges fetched from airtable', function (done) {
+      it('should resolve with the challenges fetched from airtable', function(done) {
         // when
         const result = challengeRepository.get(challengeId);
 
@@ -165,7 +165,7 @@ describe('Unit | Repository | challenge-repository', function () {
         done();
       });
 
-      it('should cache the challenge fetched from airtable', function (done) {
+      it('should cache the challenge fetched from airtable', function(done) {
         // when
         challengeRepository.get(challengeId).then(() => {
 
@@ -177,7 +177,7 @@ describe('Unit | Repository | challenge-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // when
         challengeRepository.get(challengeId).then(() => {
 
@@ -193,12 +193,12 @@ describe('Unit | Repository | challenge-repository', function () {
    * #refresh
    */
 
-  describe('#refresh', function () {
+  describe('#refresh', function() {
 
     const challengeId = 'challenge_id';
     const cacheKey = `challenge-repository_get_${challengeId}`;
 
-    it('should reject with an error when the cache throw an error', function () {
+    it('should reject with an error when the cache throw an error', function() {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'del', (key, callback) => {
@@ -213,7 +213,7 @@ describe('Unit | Repository | challenge-repository', function () {
       return expect(result).to.eventually.be.rejectedWith(cacheErrorMessage);
     });
 
-    it('should resolve with the challenge fetched from airtable when the challenge was not previously cached', function () {
+    it('should resolve with the challenge fetched from airtable when the challenge was not previously cached', function() {
       // given
       const challenge = {
         id: challengeId,
@@ -229,7 +229,7 @@ describe('Unit | Repository | challenge-repository', function () {
       return expect(result).to.eventually.deep.equal(challenge);
     });
 
-    it('should replace the old challenge by the new one in cache', function () {
+    it('should replace the old challenge by the new one in cache', function() {
       // given
       const oldCourse = {
         id: challengeId,

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -8,18 +8,18 @@ function _buildCourse(id, name, description) {
   return { id, name, description };
 }
 
-describe('Unit | Repository | course-repository', function () {
+describe('Unit | Repository | course-repository', function() {
 
   let getRecord;
   let getRecords;
 
-  beforeEach(function () {
+  beforeEach(function() {
     cache.flushAll();
     getRecord = sinon.stub(airtable, 'getRecord');
     getRecords = sinon.stub(airtable, 'getRecords');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     cache.flushAll();
     getRecord.restore();
     getRecords.restore();
@@ -29,13 +29,13 @@ describe('Unit | Repository | course-repository', function () {
    * #get
    */
 
-  describe('#get', function () {
+  describe('#get', function() {
 
     const courseId = 'courseId';
     const cacheKey = `course-repository_get_${courseId}`;
     const course = { foo: 'bar' };
 
-    it('should resolve with the course directly retrieved from the cache without calling airtable when the course has been cached', function (done) {
+    it('should resolve with the course directly retrieved from the cache without calling airtable when the course has been cached', function(done) {
       // given
       getRecord.resolves(true);
       cache.set(cacheKey, course);
@@ -49,7 +49,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -65,13 +65,13 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    describe('when the course was not previously cached', function () {
+    describe('when the course was not previously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecord.resolves(course);
       });
 
-      it('should resolve with the courses fetched from Airtable', function (done) {
+      it('should resolve with the courses fetched from Airtable', function(done) {
         // when
         const result = courseRepository.get(courseId);
 
@@ -80,7 +80,7 @@ describe('Unit | Repository | course-repository', function () {
         done();
       });
 
-      it('should cache the course fetched from Airtable', function (done) {
+      it('should cache the course fetched from Airtable', function(done) {
         // when
         courseRepository.get(courseId).then(() => {
 
@@ -92,7 +92,7 @@ describe('Unit | Repository | course-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // when
         courseRepository.get(courseId).then(() => {
 
@@ -108,12 +108,12 @@ describe('Unit | Repository | course-repository', function () {
    * #refresh
    */
 
-  describe('#refresh', function () {
+  describe('#refresh', function() {
 
     const courseId = 'course_id';
     const cacheKey = `course-repository_get_${courseId}`;
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'del', (key, callback) => {
@@ -129,7 +129,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should resolve with the course fetched from airtable when the course was not previously cached', function (done) {
+    it('should resolve with the course fetched from airtable when the course was not previously cached', function(done) {
       // given
       const course = {
         id: courseId,
@@ -146,7 +146,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should replace the old course by the new one in cache', function () {
+    it('should replace the old course by the new one in cache', function() {
       // given
       const oldCourse = {
         id: courseId,
@@ -176,7 +176,7 @@ describe('Unit | Repository | course-repository', function () {
    * #getProgressionCourses
    */
 
-  describe('#getProgressionCourses', function () {
+  describe('#getProgressionCourses', function() {
 
     const cacheKey = 'course-repository_getProgressionTests';
     const courses = [
@@ -185,7 +185,7 @@ describe('Unit | Repository | course-repository', function () {
       _buildCourse('course_id_3', 'Course #3', 'Desc. #3')
     ];
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -201,7 +201,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should resolve with the course directly retrieved from the cache without calling airtable when the course has been cached', function (done) {
+    it('should resolve with the course directly retrieved from the cache without calling airtable when the course has been cached', function(done) {
       // given
       getRecords.resolves(true);
       cache.set(cacheKey, courses);
@@ -215,13 +215,13 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    describe('when courses have not been previsously cached', function () {
+    describe('when courses have not been previsously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecords.resolves(courses);
       });
 
-      it('should resolve with the courses fetched from Airtable', function (done) {
+      it('should resolve with the courses fetched from Airtable', function(done) {
         // when
         const result = courseRepository.getProgressionCourses();
 
@@ -230,7 +230,7 @@ describe('Unit | Repository | course-repository', function () {
         done();
       });
 
-      it('should cache the course fetched from Airtable', function (done) {
+      it('should cache the course fetched from Airtable', function(done) {
         // when
         courseRepository.getProgressionCourses().then(() => {
 
@@ -242,7 +242,7 @@ describe('Unit | Repository | course-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // given
         const expectedQuery = {
           filterByFormula: '{Statut} = "Publié"',
@@ -265,7 +265,7 @@ describe('Unit | Repository | course-repository', function () {
    * #getCoursesOfTheWeek
    */
 
-  describe('#getCoursesOfTheWeek', function () {
+  describe('#getCoursesOfTheWeek', function() {
 
     const cacheKey = 'course-repository_getCoursesOfTheWeek';
     const courses = [
@@ -274,7 +274,7 @@ describe('Unit | Repository | course-repository', function () {
       _buildCourse('course_id_3', 'Course #3', 'Desc. #3')
     ];
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -290,7 +290,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should resolve with the courses directly retrieved from the cache without calling airtable when the course has been cached', function (done) {
+    it('should resolve with the courses directly retrieved from the cache without calling airtable when the course has been cached', function(done) {
       // given
       getRecords.resolves(true);
       cache.set(cacheKey, courses);
@@ -304,13 +304,13 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    describe('when courses have not been previsously cached', function () {
+    describe('when courses have not been previsously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecords.resolves(courses);
       });
 
-      it('should resolve with the courses fetched from Airtable', function (done) {
+      it('should resolve with the courses fetched from Airtable', function(done) {
         // when
         const result = courseRepository.getCoursesOfTheWeek();
 
@@ -319,7 +319,7 @@ describe('Unit | Repository | course-repository', function () {
         done();
       });
 
-      it('should cache the course fetched from Airtable', function (done) {
+      it('should cache the course fetched from Airtable', function(done) {
         // when
         courseRepository.getCoursesOfTheWeek().then(() => {
 
@@ -331,7 +331,7 @@ describe('Unit | Repository | course-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // given
         const expectedQuery = {
           filterByFormula: '{Statut} = "Publié"',
@@ -354,7 +354,7 @@ describe('Unit | Repository | course-repository', function () {
    * #getAdaptiveCourses
    */
 
-  describe('#getAdaptiveCourses', function () {
+  describe('#getAdaptiveCourses', function() {
 
     const cacheKey = 'course-repository_getAdaptiveCourses';
     const courses = [
@@ -363,7 +363,7 @@ describe('Unit | Repository | course-repository', function () {
       _buildCourse('course_id_3', 'Course #3', 'Desc. #3')
     ];
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -379,7 +379,7 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    it('should resolve with the courses directly retrieved from the cache without calling airtable when the course has been cached', function (done) {
+    it('should resolve with the courses directly retrieved from the cache without calling airtable when the course has been cached', function(done) {
       // given
       getRecords.resolves(true);
       cache.set(cacheKey, courses);
@@ -393,13 +393,13 @@ describe('Unit | Repository | course-repository', function () {
       done();
     });
 
-    describe('when courses have not been previsously cached', function () {
+    describe('when courses have not been previsously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecords.resolves(courses);
       });
 
-      it('should resolve with the courses fetched from Airtable', function (done) {
+      it('should resolve with the courses fetched from Airtable', function(done) {
         // when
         const result = courseRepository.getAdaptiveCourses();
 
@@ -408,7 +408,7 @@ describe('Unit | Repository | course-repository', function () {
         done();
       });
 
-      it('should cache the course fetched from Airtable', function (done) {
+      it('should cache the course fetched from Airtable', function(done) {
         // when
         courseRepository.getAdaptiveCourses().then(() => {
 
@@ -420,7 +420,7 @@ describe('Unit | Repository | course-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // given
         const expectedQuery = {
           filterByFormula: '{Statut} = "Publié"',
@@ -444,7 +444,7 @@ describe('Unit | Repository | course-repository', function () {
 
   describe('#refreshAll', function() {
 
-    it('should resolve with true when the clean succeeds', function (done) {
+    it('should resolve with true when the clean succeeds', function(done) {
       // given
       sinon.stub(cache, 'del', (key, callback) => {
         callback();

--- a/api/tests/unit/infrastructure/repositories/solution-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/solution-repository_test.js
@@ -4,18 +4,18 @@ const cache = require('../../../../lib/infrastructure/cache');
 const solutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');
 const solutionSerializer = require('../../../../lib/infrastructure/serializers/airtable/solution-serializer');
 
-describe('Unit | Repository | solution-repository', function () {
+describe('Unit | Repository | solution-repository', function() {
 
   let getRecord;
   let getRecords;
 
-  beforeEach(function () {
+  beforeEach(function() {
     cache.flushAll();
     getRecord = sinon.stub(airtable, 'getRecord');
     getRecords = sinon.stub(airtable, 'getRecords');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     cache.flushAll();
     getRecord.restore();
     getRecords.restore();
@@ -25,13 +25,13 @@ describe('Unit | Repository | solution-repository', function () {
    * #get
    */
 
-  describe('#get', function () {
+  describe('#get', function() {
 
     const challengeId = 'challengeId';
     const cacheKey = `solution-repository_get_${challengeId}`;
     const solution = { foo: 'bar' };
 
-    it('should resolve with the solution directly retrieved from the cache without calling airtable when the solution has been cached', function () {
+    it('should resolve with the solution directly retrieved from the cache without calling airtable when the solution has been cached', function() {
       // given
       getRecord.resolves(true);
       cache.set(cacheKey, solution);
@@ -44,7 +44,7 @@ describe('Unit | Repository | solution-repository', function () {
       return expect(result).to.eventually.deep.equal(solution);
     });
 
-    it('should reject with an error when the cache throw an error', function () {
+    it('should reject with an error when the cache throw an error', function() {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'get', (key, callback) => {
@@ -59,13 +59,13 @@ describe('Unit | Repository | solution-repository', function () {
       return expect(result).to.eventually.be.rejectedWith(cacheErrorMessage);
     });
 
-    describe('when the solution was not previously cached', function () {
+    describe('when the solution was not previously cached', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         getRecord.resolves(solution);
       });
 
-      it('should resolve with the challenges fetched from airtable', function (done) {
+      it('should resolve with the challenges fetched from airtable', function(done) {
         // when
         const result = solutionRepository.get(challengeId);
 
@@ -74,7 +74,7 @@ describe('Unit | Repository | solution-repository', function () {
         done();
       });
 
-      it('should cache the solution fetched from airtable', function (done) {
+      it('should cache the solution fetched from airtable', function(done) {
         // when
         solutionRepository.get(challengeId).then(() => {
 
@@ -86,7 +86,7 @@ describe('Unit | Repository | solution-repository', function () {
         });
       });
 
-      it('should query correctly airtable', function (done) {
+      it('should query correctly airtable', function(done) {
         // when
         solutionRepository.get(challengeId).then(() => {
 
@@ -102,12 +102,12 @@ describe('Unit | Repository | solution-repository', function () {
    * #refresh
    */
 
-  describe('#refresh', function () {
+  describe('#refresh', function() {
 
     const challengeId = 'challenge_id';
     const cacheKey = `solution-repository_get_${challengeId}`;
 
-    it('should reject with an error when the cache throw an error', function (done) {
+    it('should reject with an error when the cache throw an error', function(done) {
       // given
       const cacheErrorMessage = 'Cache error';
       sinon.stub(cache, 'del', (key, callback) => {
@@ -123,7 +123,7 @@ describe('Unit | Repository | solution-repository', function () {
       done();
     });
 
-    it('should resolve with the solution fetched from airtable when the solution was not previously cached', function (done) {
+    it('should resolve with the solution fetched from airtable when the solution was not previously cached', function(done) {
       // given
       const solution = {
         id: challengeId,
@@ -139,7 +139,7 @@ describe('Unit | Repository | solution-repository', function () {
       done();
     });
 
-    it('should replace the old solution by the new one in cache', function (done) {
+    it('should replace the old solution by the new one in cache', function(done) {
       // given
       const oldCourse = {
         id: challengeId,

--- a/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
@@ -121,7 +121,6 @@ describe('Unit | Serializer | challenge-serializer', function() {
       expect(challenge.attachments[1]).to.equal(attachment_2.url);
     });
 
-
     // XXX : Pay attention to boolean negation : hasntInternetAllowed, instead of hasInternetAllowed,
     // it is because the nominal case is : user is allowed to use internet.
     // we need a boolean to detect the corner case where internet is NOT allowed. Currently Internet and tools are allowed

--- a/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
@@ -1,11 +1,11 @@
 const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/challenge-serializer');
 
-describe('Unit | Serializer | challenge-serializer', function () {
+describe('Unit | Serializer | challenge-serializer', function() {
 
-  describe('#deserialize', function () {
+  describe('#deserialize', function() {
 
-    it('should convert record "id" into "id" property', function () {
+    it('should convert record "id" into "id" property', function() {
       // given
       const airtableRecord = { id: 'rec123', fields: {} };
 
@@ -23,7 +23,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
 
     ].forEach(({ airtableField, modelProperty }) => {
 
-      it(`should convert record '${airtableField}' field into '${modelProperty}' property`, function () {
+      it(`should convert record '${airtableField}' field into '${modelProperty}' property`, function() {
         // given
         const fields = [];
         fields[airtableField] = `${modelProperty}_value`;
@@ -38,7 +38,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
 
     });
 
-    it('should convert record "Illustration de la consigne" into "illustrationUrl"" property', function () {
+    it('should convert record "Illustration de la consigne" into "illustrationUrl"" property', function() {
       // given
       const airtableRecord = {
         fields: {
@@ -55,7 +55,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
       expect(challenge.illustrationUrl).to.equal(airtableRecord.fields['Illustration de la consigne'][0].url);
     });
 
-    it('should not return "attachments" property when challenge has no attachment', function () {
+    it('should not return "attachments" property when challenge has no attachment', function() {
       // given
       const airtableRecord = { fields: {} };
 
@@ -66,7 +66,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
       expect(challenge.attachments).to.not.exist;
     });
 
-    it('should convert record "Pièce jointe" into an array of 1 element when challenge has one attachment', function () {
+    it('should convert record "Pièce jointe" into an array of 1 element when challenge has one attachment', function() {
       // given
       const attachment = {
         url: 'https://dl.airtable.com/MurPbtCWS9cjyjGmYAMw_PIX_couleur_remplissage.pptx'
@@ -81,7 +81,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
       expect(challenge.attachments[0]).to.equal(attachment.url);
     });
 
-    it('should convert record "Pièce jointe" into an array of 2 elements when challenge has multiple attachments', function () {
+    it('should convert record "Pièce jointe" into an array of 2 elements when challenge has multiple attachments', function() {
       // given
       const attachmentDocx = {
         url: 'https://dl.airtable.com/MurPbtCWS9cjyjGmYAMw_PIX_couleur_remplissage.docx'
@@ -125,9 +125,9 @@ describe('Unit | Serializer | challenge-serializer', function () {
     // XXX : Pay attention to boolean negation : hasntInternetAllowed, instead of hasInternetAllowed,
     // it is because the nominal case is : user is allowed to use internet.
     // we need a boolean to detect the corner case where internet is NOT allowed. Currently Internet and tools are allowed
-    describe('should convert field "Internet et outils" into \'hasntInternetAllowed\' boolean property', function () {
+    describe('should convert field "Internet et outils" into \'hasntInternetAllowed\' boolean property', function() {
 
-      it('should return true if  field "Internet et outils" equal to "Non"', function () {
+      it('should return true if  field "Internet et outils" equal to "Non"', function() {
         // given
         const airtableRecord = {
           fields: {
@@ -142,7 +142,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
         expect(challenge.hasntInternetAllowed).to.equal(true);
       });
 
-      it('should return false if  field "Internet et outils" equal to "Oui"', function () {
+      it('should return false if  field "Internet et outils" equal to "Oui"', function() {
         // given
         const airtableRecord = {
           fields: {
@@ -157,7 +157,7 @@ describe('Unit | Serializer | challenge-serializer', function () {
         expect(challenge.hasntInternetAllowed).to.equal(false);
       });
 
-      it('should not be defined if field "Internet et outils" is not defined', function () {
+      it('should not be defined if field "Internet et outils" is not defined', function() {
         // given
         const airtableRecord = {
           fields: {}

--- a/api/tests/unit/infrastructure/serializers/airtable/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/course-serializer_test.js
@@ -1,11 +1,11 @@
 const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/course-serializer');
 
-describe('Unit | Serializer | course-serializer', function () {
+describe('Unit | Serializer | course-serializer', function() {
 
-  describe('#deserialize', function () {
+  describe('#deserialize', function() {
 
-    it('should convert record "id" into "id" property', function () {
+    it('should convert record "id" into "id" property', function() {
       // given
       const airtableRecord = { id: 'rec123', fields: {} };
 
@@ -23,7 +23,7 @@ describe('Unit | Serializer | course-serializer', function () {
       { airtableField: 'Adaptatif ?', modelProperty: 'isAdaptive' }
     ].forEach(({ airtableField, modelProperty }) => {
 
-      it(`should convert record '${airtableField}' field into '${modelProperty}' property`, function () {
+      it(`should convert record '${airtableField}' field into '${modelProperty}' property`, function() {
         // given
         const fields = [];
         fields[airtableField] = `${modelProperty}_value`;

--- a/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
@@ -88,7 +88,6 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.false;
       });
 
-
       it('Should set false to deactivations, when "désactiver T1" is false and "T1 - Espaces, casse & accents" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T1' : false, 'T1 - Espaces, casse & accents': 'Désactivé'} };
@@ -154,9 +153,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.true;
       });
 
-
     });
-
 
     describe('Treatments options management', () => {
 

--- a/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
@@ -37,9 +37,9 @@ describe('Unit | Serializer | solution-serializer', () => {
 
     });
 
-    describe('Deactivations field', function () {
+    describe('Deactivations field', function() {
 
-      it('should contain deactivations field as Object', function () {
+      it('should contain deactivations field as Object', function() {
         // given
         const airtableRecord = { fields: {} };
 
@@ -51,7 +51,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations).to.be.an('object');
       });
 
-      it('should contain t1, t2 and t3', function () {
+      it('should contain t1, t2 and t3', function() {
         // given
         const airtableRecord = { fields: {} };
 
@@ -62,7 +62,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations).to.include.keys('t1', 't2', 't3');
       });
 
-      it('should enable treatments by default (no value for fields t1, t2, t3 in airtable )', function () {
+      it('should enable treatments by default (no value for fields t1, t2, t3 in airtable )', function() {
         // given
         const airtableRecord = { fields: {} };
 
@@ -75,7 +75,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.false;
       });
 
-      it('should set true to deactivations, when "désactiver T1" is true and "T1 - Espaces, casse & accents" is Désactivé and transmitted from Airtable', function () {
+      it('should set true to deactivations, when "désactiver T1" is true and "T1 - Espaces, casse & accents" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T1' : true, 'T1 - Espaces, casse & accents': 'Désactivé'} };
 
@@ -89,7 +89,7 @@ describe('Unit | Serializer | solution-serializer', () => {
       });
 
 
-      it('Should set false to deactivations, when "désactiver T1" is false and "T1 - Espaces, casse & accents" is Désactivé and transmitted from Airtable', function () {
+      it('Should set false to deactivations, when "désactiver T1" is false and "T1 - Espaces, casse & accents" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T1' : false, 'T1 - Espaces, casse & accents': 'Désactivé'} };
 
@@ -102,7 +102,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.false;
       });
 
-      it('should set true to deactivations, when "désactiver T2" is true and "T2 - Ponctuation" is Désactivé and transmitted from Airtable', function () {
+      it('should set true to deactivations, when "désactiver T2" is true and "T2 - Ponctuation" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T2' : true, 'T2 - Ponctuation': 'Désactivé'} };
 
@@ -115,7 +115,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.false;
       });
 
-      it('should set true to deactivations, when "désactiver T2" is false and "T2 - Ponctuation" is Désactivé and transmitted from Airtable', function () {
+      it('should set true to deactivations, when "désactiver T2" is false and "T2 - Ponctuation" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T2' : false, 'T2 - Ponctuation': 'Désactivé'} };
 
@@ -128,7 +128,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.false;
       });
 
-      it('should set true to deactivations, when "désactiver T3" is true and "T3 - Distance d\'édition" is Désactivé and transmitted from Airtable', function () {
+      it('should set true to deactivations, when "désactiver T3" is true and "T3 - Distance d\'édition" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T3' : true, 'T3 - Distance d\'édition': 'Désactivé'} };
 
@@ -141,7 +141,7 @@ describe('Unit | Serializer | solution-serializer', () => {
         expect(solution.deactivations.t3).to.be.true;
       });
 
-      it('should set true to deactivations, when "désactiver T3" is false and "T3 - Distance d\'édition" is Désactivé and transmitted from Airtable', function () {
+      it('should set true to deactivations, when "désactiver T3" is false and "T3 - Distance d\'édition" is Désactivé and transmitted from Airtable', function() {
         // given
         const airtableRecord = { fields: {'désactiver T3' : false, 'T3 - Distance d\'édition': 'Désactivé'} };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -15,7 +15,6 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
     challengeId: 'challenge_id'
   });
 
-
   const jsonAnswer = {
     data: {
       type: 'answer',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/answer-serializer');
 const Answer = require('../../../../../lib/domain/models/data/answer');
 
-describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
+describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
 
   const modelObject = new Answer({
     id: 'answer_id',
@@ -44,9 +44,9 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
     }
   };
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert an Answer model object into JSON API data', function () {
+    it('should convert an Answer model object into JSON API data', function() {
       // when
       const json = serializer.serialize(modelObject);
 
@@ -56,9 +56,9 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
 
   });
 
-  describe('#deserialize()', function () {
+  describe('#deserialize()', function() {
 
-    it('should convert JSON API data into an Answer model object', function () {
+    it('should convert JSON API data into an Answer model object', function() {
       // when
       const answer = serializer.deserialize(jsonAnswer);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const Assessment = require('../../../../../lib/domain/models/data/assessment');
 
-describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
+describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
 
   const modelObject = new Assessment({
     id: 'assessment_id',
@@ -34,9 +34,9 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
     }
   };
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert an Assessment model object into JSON API data', function () {
+    it('should convert an Assessment model object into JSON API data', function() {
       // when
       const json = serializer.serialize(modelObject);
 
@@ -46,9 +46,9 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
 
   });
 
-  describe('#deserialize()', function () {
+  describe('#deserialize()', function() {
 
-    it('should convert JSON API data into an Assessment model object', function () {
+    it('should convert JSON API data into an Assessment model object', function() {
       // when
       const assessment = serializer.deserialize(jsonAssessment);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -2,11 +2,11 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
 const Challenge = require('../../../../../lib/domain/models/referential/challenge');
 
-describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
+describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert a Challenge model object into JSON API data', function () {
+    it('should convert a Challenge model object into JSON API data', function() {
 
       const challenge = new Challenge();
       challenge.id = 'challenge_id';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -2,11 +2,11 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/course-serializer');
 const Course = require('../../../../../lib/domain/models/referential/course');
 
-describe('Unit | Serializer | JSONAPI | course-serializer', function () {
+describe('Unit | Serializer | JSONAPI | course-serializer', function() {
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert a Course model object (with challenges order inverted) into JSON API data (with challenges order in right order)', function () {
+    it('should convert a Course model object (with challenges order inverted) into JSON API data (with challenges order in right order)', function() {
       const course = new Course();
       course.id = 'course_id';
       course.name = 'Name of the course';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/feedback-serializer');
 const Feedback = require('../../../../../lib/domain/models/data/feedback');
 
-describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
+describe('Unit | Serializer | JSONAPI | feedback-serializer', function() {
 
   const modelObject = new Feedback({
     id: 'feedback_id',
@@ -37,9 +37,9 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
     }
   };
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert a Feedback model object into JSON API data', function () {
+    it('should convert a Feedback model object into JSON API data', function() {
       // when
       const json = serializer.serialize(modelObject);
 
@@ -49,9 +49,9 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
 
   });
 
-  describe('#deserialize()', function () {
+  describe('#deserialize()', function() {
 
-    it('should convert JSON API data into a Feedback model object', function () {
+    it('should convert JSON API data into a Feedback model object', function() {
       // when
       const feedback = serializer.deserialize(jsonFeedback);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
@@ -2,7 +2,6 @@ const {describe, it, expect} = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/follower-serializer');
 const Follower = require('../../../../../lib/domain/models/data/follower');
 
-
 describe('Unit | Serializer | follower-serializer', function() {
   describe('#deserialize', function() {
     it('should convert JSON API data into a Follower model object', function() {
@@ -46,6 +45,5 @@ describe('Unit | Serializer | follower-serializer', function() {
     });
 
   });
-
 
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
@@ -3,9 +3,9 @@ const serializer = require('../../../../../lib/infrastructure/serializers/jsonap
 const Follower = require('../../../../../lib/domain/models/data/follower');
 
 
-describe('Unit | Serializer | follower-serializer', function () {
-  describe('#deserialize', function () {
-    it('should convert JSON API data into a Follower model object', function () {
+describe('Unit | Serializer | follower-serializer', function() {
+  describe('#deserialize', function() {
+    it('should convert JSON API data into a Follower model object', function() {
       const followerModelObject = new Follower({email: 'brm+1@pix.fr'});
       const jsonFollower = {
         data: {
@@ -25,8 +25,8 @@ describe('Unit | Serializer | follower-serializer', function () {
 
   });
 
-  describe('#serialize', function () {
-    it('should convert Follower Model Object into a JSON API', function () {
+  describe('#serialize', function() {
+    it('should convert Follower Model Object into a JSON API', function() {
       const followerObject = new Follower({email: 'shi@fu.me', id: '1'});
       const jsonApiFollower = {
         data: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/solution-serializer_test.js
@@ -2,11 +2,11 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/solution-serializer');
 const Solution = require('../../../../../lib/domain/models/referential/solution');
 
-describe('Unit | Serializer | JSONAPI | solution-serializer', function () {
+describe('Unit | Serializer | JSONAPI | solution-serializer', function() {
 
-  describe('#serialize()', function () {
+  describe('#serialize()', function() {
 
-    it('should convert a Solution model object into JSON API data', function () {
+    it('should convert a Solution model object into JSON API data', function() {
 
       const solution = new Solution();
       solution.id = 'solution_id';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,7 +1,7 @@
 const { describe, it, expect, beforeEach } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 
-describe('Unit | Serializer | JSONAPI | user-serializer', function () {
+describe('Unit | Serializer | JSONAPI | user-serializer', function() {
 
   let jsonUser;
 
@@ -20,9 +20,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
     };
   });
 
-  describe('#deserialize()', function () {
+  describe('#deserialize()', function() {
 
-    it('should convert JSON API data into an User model object', function () {
+    it('should convert JSON API data into an User model object', function() {
       // When
       const user = serializer.deserialize(jsonUser);
 
@@ -33,7 +33,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
       expect(user.get('password')).to.equal('');
     });
 
-    it('should contain an ID attribute', function () {
+    it('should contain an ID attribute', function() {
       // Given
       jsonUser.data.id = '42';
 
@@ -44,7 +44,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
       expect(user.get('id')).to.equal('42');
     });
 
-    it('should not contain an ID attribute when not given', function () {
+    it('should not contain an ID attribute when not given', function() {
       // When
       const user = serializer.deserialize(jsonUser);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,6 +1,5 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { describe, it, expect, beforeEach } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
-const User = require('../../../../../lib/domain/models/data/user');
 
 describe('Unit | Serializer | JSONAPI | user-serializer', function () {
 
@@ -11,10 +10,10 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
       data: {
         type: 'user',
         attributes: {
-          firstName: "Luke",
-          lastName: "Skywalker",
-          email: "lskywalker@deathstar.empire",
-          password: ""
+          firstName: 'Luke',
+          lastName: 'Skywalker',
+          email: 'lskywalker@deathstar.empire',
+          password: ''
         },
         relationships: {}
       }
@@ -29,9 +28,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
 
       // Then
       expect(user.get('firstName')).to.equal('Luke');
-      expect(user.get('lastName')).to.equal("Skywalker");
-      expect(user.get('email')).to.equal("lskywalker@deathstar.empire");
-      expect(user.get('password')).to.equal("");
+      expect(user.get('lastName')).to.equal('Skywalker');
+      expect(user.get('email')).to.equal('lskywalker@deathstar.empire');
+      expect(user.get('password')).to.equal('');
     });
 
     it('should contain an ID attribute', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
@@ -53,7 +53,6 @@ describe('Unit | Serializer | JSONAPI | validation-error-serializer', () => {
       });
     });
 
-
     it('should format a validation error into a JSON spec when multiple errors', () => {
       // Given
       const invalidObject = new DummyObject({
@@ -96,7 +95,5 @@ describe('Unit | Serializer | JSONAPI | validation-error-serializer', () => {
     });
 
   });
-
-
 
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
@@ -1,8 +1,7 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { describe, it, expect, before } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 
 const Bookshelf = require('../../../../../lib/infrastructure/bookshelf');
-const validator = require('validator');
 
 describe('Unit | Serializer | JSONAPI | validation-error-serializer', () => {
 
@@ -30,14 +29,14 @@ describe('Unit | Serializer | JSONAPI | validation-error-serializer', () => {
         email: 'testThatIsNotAnEmail'
       });
       const expectedFormattedJSON = {
-        "errors": [
+        'errors': [
           {
-            "status": "400",
-            "title":  "Invalid Attribute",
-            "details": "Not a valid email address",
-            "source": { "pointer": "/data/attributes/email" },
-            "meta": {
-              "field": "email"
+            'status': '400',
+            'title':  'Invalid Attribute',
+            'details': 'Not a valid email address',
+            'source': { 'pointer': '/data/attributes/email' },
+            'meta': {
+              'field': 'email'
             }
           }
         ]
@@ -59,27 +58,27 @@ describe('Unit | Serializer | JSONAPI | validation-error-serializer', () => {
       // Given
       const invalidObject = new DummyObject({
         email: 'test@example.net',
-        age: "200"
+        age: '200'
       });
 
       const expectedFormattedJSON = {
-        "errors": [
+        'errors': [
           {
-            "status": "400",
-            "title":  "Invalid Attribute",
-            "details": "You cant be so old",
-            "source": { "pointer": "/data/attributes/age" },
-            "meta": {
-              "field": "age"
+            'status': '400',
+            'title':  'Invalid Attribute',
+            'details': 'You cant be so old',
+            'source': { 'pointer': '/data/attributes/age' },
+            'meta': {
+              'field': 'age'
             }
           },
           {
-            "status": "400",
-            "title":  "Invalid Attribute",
-            "details": "Age can only be two digits",
-            "source": { "pointer": "/data/attributes/age" },
-            "meta": {
-              "field": "age"
+            'status': '400',
+            'title':  'Invalid Attribute',
+            'details': 'Age can only be two digits',
+            'source': { 'pointer': '/data/attributes/age' },
+            'meta': {
+              'field': 'age'
             }
           }
         ]

--- a/api/tests/unit/infrastructure/utils/lodash-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/lodash-utils_test.js
@@ -2,90 +2,90 @@ const { describe, it, expect } = require('../../../test-helper');
 const original_lodash = require('lodash');
 const _ = require('../../../../lib/infrastructure/utils/lodash-utils');
 
-describe('Unit | Utils | lodash-utils', function () {
+describe('Unit | Utils | lodash-utils', function() {
 
-  describe('#scope', function () {
-    it('should not affect original version of lodash', function () {
+  describe('#scope', function() {
+    it('should not affect original version of lodash', function() {
       expect(original_lodash.elementAfter).not.to.exist;
       expect(_.elementAfter).to.exist;
     });
   });
 
-  describe('#elementAfter', function () {
-    it('for a given array and element in array (but not the last one), should return the element after the one provided', function () {
+  describe('#elementAfter', function() {
+    it('for a given array and element in array (but not the last one), should return the element after the one provided', function() {
       expect(_.elementAfter(['a', 'b', 'c', 'd'], 'a')).to.equal('b');
       expect(_.elementAfter(['a', 'b', 'c', 'd'], 'b')).to.equal('c');
       expect(_.elementAfter(['a', 'b', 'c', 'd'], 'c')).to.equal('d');
     });
-    it('for a given array and the LAST element in array, should return undefined', function () {
+    it('for a given array and the LAST element in array, should return undefined', function() {
       expect(_.elementAfter(['a', 'b', 'c', 'd'], 'd')).to.equal(undefined);
     });
-    it('for a given array and an element NOT in array, should return undefined', function () {
+    it('for a given array and an element NOT in array, should return undefined', function() {
       expect(_.elementAfter(['a', 'b', 'c', 'd'], 'z')).to.equal(undefined);
     });
-    it('for an empty array, should return undefined', function () {
+    it('for an empty array, should return undefined', function() {
       expect(_.elementAfter([], 'z')).to.equal(undefined);
     });
-    it('if first arg is not an array, should return undefined', function () {
+    it('if first arg is not an array, should return undefined', function() {
       expect(_.elementAfter(new Date(), 'a')).to.equal(undefined);
     });
-    it('if last arg is missing, should return undefined', function () {
+    it('if last arg is missing, should return undefined', function() {
       expect(_.elementAfter(['a', 'b', 'c', 'd'])).to.equal(undefined);
     });
-    it('if both args are is missing, should return undefined', function () {
+    it('if both args are is missing, should return undefined', function() {
       expect(_.elementAfter()).to.equal(undefined);
     });
   });
 
-  describe('#areCSVequivalent', function () {
-    it('when no arg are given, should return false', function () {
+  describe('#areCSVequivalent', function() {
+    it('when no arg are given, should return false', function() {
       expect(_.areCSVequivalent()).to.equal(false);
     });
-    it('when two arg are given, but are not string, should return false', function () {
+    it('when two arg are given, but are not string, should return false', function() {
       expect(_.areCSVequivalent(['1,2,3'], ['1,2,3'])).to.equal(false);
       expect(_.areCSVequivalent(new Date(), new Date())).to.equal(false);
     });
-    it('when two string are the same, should return true', function () {
+    it('when two string are the same, should return true', function() {
       expect(_.areCSVequivalent('1,2,3', '1,2,3')).to.equal(true);
       expect(_.areCSVequivalent('azerty', 'azerty')).to.equal(true);
     });
-    it('when element are the same but in different order, should return true', function () {
+    it('when element are the same but in different order, should return true', function() {
       expect(_.areCSVequivalent('1,2,3', '3,1,2')).to.equal(true);
     });
-    it('when element have space around values, should return true', function () {
+    it('when element have space around values, should return true', function() {
       expect(_.areCSVequivalent('2 , blabla, 1', 'blabla ,1,2')).to.equal(true);
     });
 
   });
 
-  describe('#ensureString', function () {
-    it('when no input, return an empty String', function () {
+  describe('#ensureString', function() {
+    it('when no input, return an empty String', function() {
       expect(_.ensureString()).to.equal('');
     });
-    it('when input is explicitly undefined, return an empty String', function () {
+    it('when input is explicitly undefined, return an empty String', function() {
       expect(_.ensureString(undefined)).to.equal('');
     });
-    it('when input is explicitly null, return an empty String', function () {
+    it('when input is explicitly null, return an empty String', function() {
       expect(_.ensureString(null)).to.equal('');
     });
-    it('when input is a number (typeof meaning), it returns a toString() version of the input', function () {
+    it('when input is a number (typeof meaning), it returns a toString() version of the input', function() {
       expect(_.ensureString(42)).to.equal('42');
     });
-    it('when input is a string (typeof meaning), it returns a toString() version of the input', function () {
+    it('when input is a string (typeof meaning), it returns a toString() version of the input', function() {
       expect(_.ensureString('42')).to.equal('42');
     });
-    it('when input is an object (typeof meaning), it returns a toString() version of the input', function () {
+    it('when input is an object (typeof meaning), it returns a toString() version of the input', function() {
       expect(_.ensureString(/[aeiou]+/g)).to.equal('/[aeiou]+/g');
     });
-    it('when input is an boolean (typeof meaning), it returns a toString() version of the input', function () {
+    it('when input is an boolean (typeof meaning), it returns a toString() version of the input', function() {
       expect(_.ensureString(true)).to.equal('true');
     });
 
   });
 
-  describe('#isBlank', function () {
+  describe('#isBlank', function() {
 
-    it('should return true if string is undefined', function () {
+    it('should return true if string is undefined', function() {
       expect(_.isBlank()).to.be.true;
     });
 
@@ -97,8 +97,8 @@ describe('Unit | Utils | lodash-utils', function () {
       '\t',
       '\r\n',
       '\n'
-    ].forEach(function (string) {
-      it(`should return true if string is "${string}"`, function () {
+    ].forEach(function(string) {
+      it(`should return true if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.true;
       });
     });
@@ -109,8 +109,8 @@ describe('Unit | Utils | lodash-utils', function () {
       'a ',
       ' a ',
       '\ta\ta'
-    ].forEach(function (string) {
-      it(`should return false if string is "${string}"`, function () {
+    ].forEach(function(string) {
+      it(`should return false if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.false;
       });
     });

--- a/live/app/adapters/solution.js
+++ b/live/app/adapters/solution.js
@@ -5,13 +5,13 @@ import RSVP from 'rsvp';
 export default ApplicationAdapter.extend({
 
   queryRecord(modelName, clazz, query) {
-    return Ember.$.getJSON( `${this.host}/${this.namespace}/assessments/${query.assessmentId}/solutions/${query.answerId}`, (data) => {
+    return Ember.$.getJSON(`${this.host}/${this.namespace}/assessments/${query.assessmentId}/solutions/${query.answerId}`, (data) => {
       return RSVP.resolve(data);
     });
   },
   // refresh cache
   refreshRecord(modelName, clazz) {
-    return Ember.$.post( `${this.host}/${this.namespace}/challenges/${clazz.challengeId}/solution`, (data) => {
+    return Ember.$.post(`${this.host}/${this.namespace}/challenges/${clazz.challengeId}/solution`, (data) => {
       return RSVP.resolve(data);
     });
   }

--- a/live/app/components/challenge-actions.js
+++ b/live/app/components/challenge-actions.js
@@ -6,10 +6,10 @@ export default Ember.Component.extend({
 
   actions: {
 
-    skip: function () {
+    skip: function() {
       this.sendAction('skip');
     },
-    validate: function () {
+    validate: function() {
       this.sendAction('validate');
     }
   }

--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -34,15 +34,15 @@ const ChallengeItemGeneric = Ember.Component.extend({
     Ember.run.cancel(timer);
   },
 
-  hasUserConfirmWarning: Ember.computed('challenge', function () {
+  hasUserConfirmWarning: Ember.computed('challenge', function() {
     return false;
   }),
 
-  hasChallengeTimer: Ember.computed('challenge', function () {
+  hasChallengeTimer: Ember.computed('challenge', function() {
     return this.hasTimerDefined();
   }),
 
-  canDisplayFeedbackPanel: Ember.computed('_hasUserAknowledgedTimingWarning', function () {
+  canDisplayFeedbackPanel: Ember.computed('_hasUserAknowledgedTimingWarning', function() {
     return !this.hasTimerDefined() || (this.hasTimerDefined() && this.get('_hasUserAknowledgedTimingWarning'));
   }),
 
@@ -65,7 +65,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
 
   _tick() {
     if (ENV.APP.isChallengeTimerEnable) {
-      const timer = Ember.run.later(this, function () {
+      const timer = Ember.run.later(this, function() {
         const elapsedTime = this.get('_elapsedTime');
         this.set('_elapsedTime', elapsedTime + 1);
         this.notifyPropertyChange('_elapsedTime');
@@ -78,7 +78,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
 
   actions: {
 
-    validate: callOnlyOnce(function () {
+    validate: callOnlyOnce(function() {
       if (this._hasError()) {
         this.set('errorMessage', this._getErrorMessage());
         return this.sendAction('onError', this.get('errorMessage'));
@@ -88,7 +88,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
       this.set('_hasUserAknowledgedTimingWarning', false);
     }),
 
-    skip: callOnlyOnce(function () {
+    skip: callOnlyOnce(function() {
       this.set('errorMessage', null);
       this.sendAction('onValidated', this.get('challenge'), this.get('assessment'), '#ABAND#', this._getTimeout(), this._getElapsedTime());
       this.set('_hasUserAknowledgedTimingWarning', false);

--- a/live/app/components/challenge-item-generic.js
+++ b/live/app/components/challenge-item-generic.js
@@ -46,7 +46,7 @@ const ChallengeItemGeneric = Ember.Component.extend({
     return !this.hasTimerDefined() || (this.hasTimerDefined() && this.get('_hasUserAknowledgedTimingWarning'));
   }),
 
-  hasTimerDefined(){
+  hasTimerDefined() {
     return _.isInteger(this.get('challenge.timer'));
   },
 
@@ -54,16 +54,16 @@ const ChallengeItemGeneric = Ember.Component.extend({
     return $('.timeout-jauge-remaining').attr('data-spent');
   },
 
-  _getElapsedTime(){
+  _getElapsedTime() {
     return this.get('_elapsedTime');
   },
 
-  _start(){
+  _start() {
     this.set('_elapsedTime', 0);
     this._tick();
   },
 
-  _tick(){
+  _tick() {
     if (ENV.APP.isChallengeTimerEnable) {
       const timer = Ember.run.later(this, function () {
         const elapsedTime = this.get('_elapsedTime');

--- a/live/app/components/challenge-item-qcm.js
+++ b/live/app/components/challenge-item-qcm.js
@@ -2,7 +2,7 @@ import ChallengeItemGeneric from './challenge-item-generic';
 
 const ChallengeItemQcm = ChallengeItemGeneric.extend({
 
-  _hasError: function () {
+  _hasError: function() {
     return this._getAnswerValue().length < 1;
   },
 
@@ -10,7 +10,7 @@ const ChallengeItemQcm = ChallengeItemGeneric.extend({
   // This is not "the Ember way", however it makes code easier to read,
   // and moreover, is a much more robust solution when you need to test it properly.
   _getAnswerValue() {
-    return this.$('.challenge-proposals input:checkbox:checked').map(function () {return this.name;}).get().join(',');
+    return this.$('.challenge-proposals input:checkbox:checked').map(function() {return this.name;}).get().join(',');
   },
 
   _getErrorMessage() {

--- a/live/app/components/challenge-item-qcu.js
+++ b/live/app/components/challenge-item-qcu.js
@@ -2,7 +2,7 @@ import ChallengeItemGeneric from './challenge-item-generic';
 
 const ChallengeItemQcu = ChallengeItemGeneric.extend({
 
-  _hasError: function () {
+  _hasError: function() {
     return this._getAnswerValue().length < 1;
   },
 
@@ -10,7 +10,7 @@ const ChallengeItemQcu = ChallengeItemGeneric.extend({
   // This is not "the Ember way", however it makes code easier to read,
   // and moreover, it is a much more robust solution when you need to test it properly.
   _getAnswerValue() {
-    return this.$('.challenge-proposals input:radio:checked').map(function () {
+    return this.$('.challenge-proposals input:radio:checked').map(function() {
       return this.name;
     }).get().join('');
   },
@@ -20,7 +20,7 @@ const ChallengeItemQcu = ChallengeItemGeneric.extend({
   },
 
   actions: {
-    answerChanged: function () {
+    answerChanged: function() {
       this.set('errorMessage', null);
     }
   }

--- a/live/app/components/challenge-item-qroc.js
+++ b/live/app/components/challenge-item-qroc.js
@@ -2,7 +2,7 @@ import ChallengeItemGeneric from './challenge-item-generic';
 
 const ChallengeItemQroc = ChallengeItemGeneric.extend({
 
-  _hasError: function () {
+  _hasError: function() {
     return this._getAnswerValue().length < 1;
   },
 

--- a/live/app/components/challenge-item-qrocm.js
+++ b/live/app/components/challenge-item-qrocm.js
@@ -5,7 +5,7 @@ import ChallengeItemGeneric from './challenge-item-generic';
 
 const ChallengeItemQrocm = ChallengeItemGeneric.extend({
 
-  _hasError: function () {
+  _hasError: function() {
     const allAnswers = this._getRawAnswerValue(); // ex. {"logiciel1":"word", "logiciel2":"excel", "logiciel3":""}
     const hasAtLeastOneAnswer = _(allAnswers).hasSomeTruthyProps();
     return _.isFalsy(hasAtLeastOneAnswer);
@@ -20,7 +20,7 @@ const ChallengeItemQrocm = ChallengeItemGeneric.extend({
   // and moreover, is a much more robust solution when you need to test it properly.
   _getRawAnswerValue() {
     const result = {};
-    $('.challenge-proposals input').each(function (index, element) {
+    $('.challenge-proposals input').each(function(index, element) {
       result[$(element).attr('name')] = $(element).val();
     });
     return result;

--- a/live/app/components/challenge-statement.js
+++ b/live/app/components/challenge-statement.js
@@ -6,11 +6,11 @@ export default  Ember.Component.extend({
 
   challenge: null,
 
-  selectedAttachmentUrl: Ember.computed('challenge.attachments', function () {
+  selectedAttachmentUrl: Ember.computed('challenge.attachments', function() {
     return this.get('challenge.attachments.firstObject');
   }),
 
-  attachmentsData: Ember.computed('challenge.attachements', function () {
+  attachmentsData: Ember.computed('challenge.attachements', function() {
     return this.get('challenge.attachments');
   }),
 

--- a/live/app/components/comparison-window.js
+++ b/live/app/components/comparison-window.js
@@ -61,7 +61,7 @@ export default Ember.Component.extend({
   isAssessmentChallengeTypeQrocmInd: Ember.computed.equal('challenge.type', 'QROCM-ind'),
   isAssessmentChallengeTypeQrocmDep: Ember.computed.equal('challenge.type', 'QROCM-dep'),
 
-  resultItem: Ember.computed('answer.result', function () {
+  resultItem: Ember.computed('answer.result', function() {
     let resultItem = contentReference['default'];
     const answerStatus = this.get('answer.result');
 

--- a/live/app/components/course-item.js
+++ b/live/app/components/course-item.js
@@ -9,7 +9,7 @@ const CourseItem = Ember.Component.extend({
   attributeBindings: ['tabindex'],
   tabindex: 0,
 
-  imageUrl: Ember.computed('course', function () {
+  imageUrl: Ember.computed('course', function() {
     const imageUrl = this.get('course.imageUrl');
     return imageUrl ? imageUrl : '/images/course-default-image.png';
   }),

--- a/live/app/components/course-list.js
+++ b/live/app/components/course-list.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import ENV from 'pix-live/config/environment';
 
-
 function _userNotAlreadyWarnedAboutMobileIncompleteSupport(that) {
   return that._isMobile() && !localStorage.getItem('pix-mobile-warning');
 }

--- a/live/app/components/course-list.js
+++ b/live/app/components/course-list.js
@@ -25,7 +25,7 @@ const CourseList = Ember.Component.extend({
 
   classNames: ['course-list'],
 
-  filteredCourses: Ember.computed('courses.[]', function () {
+  filteredCourses: Ember.computed('courses.[]', function() {
     const courses = this.get('courses');
     let filteredCourses = [];
 
@@ -39,23 +39,23 @@ const CourseList = Ember.Component.extend({
     return filteredCourses;
   }),
 
-  didInsertElement () {
+  didInsertElement() {
     const that = this;
-    Ember.run.scheduleOnce('afterRender', this, function () {
-      $('button[data-confirm]').click(function () {
+    Ember.run.scheduleOnce('afterRender', this, function() {
+      $('button[data-confirm]').click(function() {
         $('#js-modal-mobile').modal('hide');
         that.sendAction('startCourse', that.get('selectedCourse'));
       });
     });
 
     if (ENV.APP.isMobileSimulationEnabled) {
-      this.$().on('simulateMobileScreen', function () {
+      this.$().on('simulateMobileScreen', function() {
         that.set('isSimulatedMobileScreen', 'true');
       });
     }
   },
 
-  _isMobile () {
+  _isMobile() {
     if (ENV.APP.isMobileSimulationEnabled) {
       return this.get('isSimulatedMobileScreen');
     }

--- a/live/app/components/feedback-panel.js
+++ b/live/app/components/feedback-panel.js
@@ -36,7 +36,7 @@ export default Ember.Component.extend({
     this.set('_status', this._getDefaultStatus());
   },
 
-  _closeForm(){
+  _closeForm() {
     this.set('_status', FORM_CLOSED);
     this.set('_error', null);
   },

--- a/live/app/components/follower-form.js
+++ b/live/app/components/follower-form.js
@@ -51,7 +51,7 @@ export default Ember.Component.extend({
   }),
 
   actions: {
-    submit(){
+    submit() {
       this.set('status', 'pending');
       const email = (this.get('_followerEmail')) ? this.get('_followerEmail').trim() : '';
       if (!isEmailValid(email)) {

--- a/live/app/components/follower-form.js
+++ b/live/app/components/follower-form.js
@@ -3,7 +3,7 @@ import config from 'pix-live/config/environment';
 import isEmailValid from 'pix-live/utils/email-validator';
 
 function hideMessageDiv(context) {
-  Ember.run.later(function () {
+  Ember.run.later(function() {
     context.set('status', 'empty');
     context.set('errorType', 'invalid');
   }, config.APP.MESSAGE_DISPLAY_DURATION);
@@ -37,16 +37,16 @@ export default Ember.Component.extend({
   hasSuccess: Ember.computed.equal('status', 'success'),
   hasMessage: Ember.computed.or('hasError', 'hasSuccess'),
 
-  messageClassName: Ember.computed('status', function () {
+  messageClassName: Ember.computed('status', function() {
     return (this.get('status') === 'error') ? 'has-error' : 'has-success';
   }),
 
-  infoMessage: Ember.computed('hasError', function () {
+  infoMessage: Ember.computed('hasError', function() {
     const currentErrorType = this.get('errorType');
     return (this.get('hasError')) ? this.get('messages.error')[currentErrorType] : this.get('messages.success');
   }),
 
-  submitButtonText: Ember.computed('status', function () {
+  submitButtonText: Ember.computed('status', function() {
     return (this.get('status') === 'pending') ? 'envoi en cours' : 's\'inscrire';
   }),
 

--- a/live/app/components/modal-mobile.js
+++ b/live/app/components/modal-mobile.js
@@ -2,15 +2,15 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
-  didInsertElement: function () {
+  didInsertElement: function() {
 
     // XXX : we hack here Bootstrap,
     // because we need a display:flex to center the modal
     // since bootstrap insert an inlined-style display:block
     // we have to remove this property once the modal renders.
-    Ember.run.scheduleOnce('afterRender', this, function () {
-      $('#js-modal-mobile').on('shown.bs.modal', function () {
-        $('#js-modal-mobile').attr('style', function (i, style) {
+    Ember.run.scheduleOnce('afterRender', this, function() {
+      $('#js-modal-mobile').on('shown.bs.modal', function() {
+        $('#js-modal-mobile').attr('style', function(i, style) {
           return style.replace(/display[^;]+;?/g, '');
         });
       });

--- a/live/app/components/qcm-solution-panel.js
+++ b/live/app/components/qcm-solution-panel.js
@@ -11,12 +11,12 @@ export default Ember.Component.extend({
   solution: null,
   challenge: null,
 
-  solutionArray: Ember.computed('solution', function () {
+  solutionArray: Ember.computed('solution', function() {
     const solution = this.get('solution.value');
     return _.isNonEmptyString(solution) ? valueAsArrayOfBoolean(solution) : [];
   }),
 
-  labeledCheckboxes: Ember.computed('answer', function () {
+  labeledCheckboxes: Ember.computed('answer', function() {
     const answer = this.get('answer.value');
     let checkboxes  = [];
     if (_.isNonEmptyString(answer)) {

--- a/live/app/components/qcm-solution-panel.js
+++ b/live/app/components/qcm-solution-panel.js
@@ -4,7 +4,6 @@ import valueAsArrayOfBoolean from 'pix-live/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'pix-live/utils/proposals-as-array';
 import _ from 'pix-live/utils/lodash-custom';
 
-
 export default Ember.Component.extend({
   classNames: ['qcm-solution-panel'],
   answer: null,

--- a/live/app/components/qcu-solution-panel.js
+++ b/live/app/components/qcu-solution-panel.js
@@ -4,7 +4,6 @@ import valueAsArrayOfBoolean from 'pix-live/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'pix-live/utils/proposals-as-array';
 import _ from 'pix-live/utils/lodash-custom';
 
-
 export default Ember.Component.extend({
   classNames: ['qcu-solution-panel'],
   answer: null,

--- a/live/app/components/qcu-solution-panel.js
+++ b/live/app/components/qcu-solution-panel.js
@@ -11,12 +11,12 @@ export default Ember.Component.extend({
   solution: null,
   challenge: null,
 
-  solutionArray: Ember.computed('solution', function () {
+  solutionArray: Ember.computed('solution', function() {
     const solution = this.get('solution.value');
     return _.isNonEmptyString(solution) ? valueAsArrayOfBoolean(solution) : [];
   }),
 
-  labeledRadios: Ember.computed('answer', function () {
+  labeledRadios: Ember.computed('answer', function() {
     const answer = this.get('answer.value');
     let radiosArray = [];
     if (_.isNonEmptyString(answer)) {

--- a/live/app/components/qroc-proposal.js
+++ b/live/app/components/qroc-proposal.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
     return answer.indexOf('#ABAND#') > -1? '' : answer;
   }),
 
-  didInsertElement: function () {
+  didInsertElement: function() {
     // XXX : jQuery handler here is far more powerful than declaring event in template helper.
     // It avoids to loose time with 'oh that handy jQuery event is missing',
     // or "How the hell did they construct input helper ?"

--- a/live/app/components/qroc-proposal.js
+++ b/live/app/components/qroc-proposal.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
 
   classNames: ['qroc-proposal'],
 
-  userAnswer : Ember.computed('answerValue', function(){
+  userAnswer : Ember.computed('answerValue', function() {
     const answer = this.get('answerValue') || '';
     return answer.indexOf('#ABAND#') > -1? '' : answer;
   }),

--- a/live/app/components/qroc-solution-panel.js
+++ b/live/app/components/qroc-solution-panel.js
@@ -11,15 +11,15 @@ export default Ember.Component.extend({
   answer: null,
   solution: null,
 
-  inputClass: Ember.computed('answer.result', function () {
+  inputClass: Ember.computed('answer.result', function() {
     return classByResultValue[this.get('answer.result')] || '';
   }),
 
-  isResultOk: Ember.computed('answer', function () {
+  isResultOk: Ember.computed('answer', function() {
     return this.get('answer.result') === 'ok';
   }),
 
-  answerToDisplay: Ember.computed('answer', function () {
+  answerToDisplay: Ember.computed('answer', function() {
     const answer = this.get('answer.value');
     if (answer === '#ABAND#') {
       return 'Pas de réponse';
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
     return answer;
   }),
 
-  solutionToDisplay: Ember.computed('solution.value', function () {
+  solutionToDisplay: Ember.computed('solution.value', function() {
     const solutionVariants = this.get('solution.value');
     if (!solutionVariants) {
       return '';

--- a/live/app/components/qrocm-ind-solution-panel.js
+++ b/live/app/components/qrocm-ind-solution-panel.js
@@ -24,7 +24,7 @@ function _computeInputClass(answerOutcome) {
 
 const QrocmIndSolutionPanel = Ember.Component.extend({
 
-  inputFields: Ember.computed('challenge.proposals', 'answer.value', 'solution.value', function () {
+  inputFields: Ember.computed('challenge.proposals', 'answer.value', 'solution.value', function() {
 
     const labels = labelsAsObject(this.get('challenge.proposals'));
     const answers = answersAsObject(this.get('answer.value'), _.keys(labels));

--- a/live/app/components/qrocm-ind-solution-panel.js
+++ b/live/app/components/qrocm-ind-solution-panel.js
@@ -55,6 +55,5 @@ const QrocmIndSolutionPanel = Ember.Component.extend({
 
 });
 
-
 export default QrocmIndSolutionPanel;
 

--- a/live/app/components/qrocm-proposal.js
+++ b/live/app/components/qrocm-proposal.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   classNames: ['qrocm-proposal'],
 
-  didInsertElement: function () {
+  didInsertElement: function() {
     // XXX : jQuery handler here is far more powerful than declaring event in template helper.
     // It avoids to loose time with 'oh that handy jQuery event is missing',
     // or "How the hell did they construct input helper ?"

--- a/live/app/components/result-item.js
+++ b/live/app/components/result-item.js
@@ -79,5 +79,4 @@ const resultItem = Ember.Component.extend({
   }
 });
 
-
 export default resultItem;

--- a/live/app/components/result-item.js
+++ b/live/app/components/result-item.js
@@ -52,17 +52,17 @@ const resultItem = Ember.Component.extend({
   classNames: ['result-item'],
   didRender() {
     this._super(...arguments);
-    Ember.run.debounce(this, function () {
+    Ember.run.debounce(this, function() {
       $('[data-toggle="tooltip"]').tooltip();
     }, timeOutAfterRender);
   },
 
-  resultItemContent: Ember.computed('answer.result', function () {
+  resultItemContent: Ember.computed('answer.result', function() {
     if (!this.get('answer.result')) return;
     return contentReference[this.get('answer.result')] || contentReference['default'];
   }),
 
-  validationImplementedForChallengeType: Ember.computed('answer.challenge.type', function () {
+  validationImplementedForChallengeType: Ember.computed('answer.challenge.type', function() {
     const implementedTypes = ['QCM', 'QROC', 'QCU', 'QROCM-ind'];
     const challengeType = this.get('answer.challenge.type');
     return implementedTypes.includes(challengeType);

--- a/live/app/components/result-item.js
+++ b/live/app/components/result-item.js
@@ -69,7 +69,7 @@ const resultItem = Ember.Component.extend({
   }),
 
   actions: {
-    openComparisonPopin(){
+    openComparisonPopin() {
       const assessmentId = this.get('answer.assessment.id');
       const answerId = this.get('answer.id');
       const index = this.get('index') + 1;

--- a/live/app/components/timeout-jauge.js
+++ b/live/app/components/timeout-jauge.js
@@ -8,7 +8,7 @@ const computed = Ember.computed;
 const run = Ember.run;
 
 // see http://stackoverflow.com/a/37770048/2595513
-function fmtMSS (s) {return (s-(s%=60))/60+(9<s?':':':0')+s;}
+function fmtMSS(s) {return (s-(s%=60))/60+(9<s?':':':0')+s;}
 
 
 export default Ember.Component.extend({
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
   allotedTime: null,
 
 
-  _totalTime: Ember.computed('allotedTime', function () {
+  _totalTime: Ember.computed('allotedTime', function() {
     const actualAllotedTime = get(this, 'allotedTime');
     if (!_.isNumeric(actualAllotedTime)) {
       return 0;

--- a/live/app/components/timeout-jauge.js
+++ b/live/app/components/timeout-jauge.js
@@ -10,11 +10,9 @@ const run = Ember.run;
 // see http://stackoverflow.com/a/37770048/2595513
 function fmtMSS(s) {return (s-(s%=60))/60+(9<s?':':':0')+s;}
 
-
 export default Ember.Component.extend({
 
   allotedTime: null,
-
 
   _totalTime: Ember.computed('allotedTime', function() {
     const actualAllotedTime = get(this, 'allotedTime');
@@ -27,7 +25,6 @@ export default Ember.Component.extend({
   _timer: null,
   _elapsedTime: null,
   _currentTime: Date.now(),
-
 
   remainingSeconds: computed('_elapsedTime', function() {
     return _.round((get(this, '_totalTime') - get(this, '_elapsedTime')) / 1000);
@@ -84,7 +81,6 @@ export default Ember.Component.extend({
       set(this, '_timer', run.later(this, this._tick, _tickInterval));
     }
   },
-
 
   init() {
     this._super(...arguments);

--- a/live/app/components/warning-page.js
+++ b/live/app/components/warning-page.js
@@ -49,11 +49,11 @@ function _formatTimeForButton(time) {
 
 export default Ember.Component.extend({
 
-  allocatedHumanTime: Ember.computed('time', function () {
+  allocatedHumanTime: Ember.computed('time', function() {
     return _formatTimeForText(this.get('time'));
   }),
 
-  allocatedTime: Ember.computed('time', function () {
+  allocatedTime: Ember.computed('time', function() {
     return _formatTimeForButton(this.get('time'));
   }),
 

--- a/live/app/helpers/or.js
+++ b/live/app/helpers/or.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import _ from 'pix-live/utils/lodash-custom';
 
-function _isATruthyValue(value){
+function _isATruthyValue(value) {
   return _.isTruthy(value) && value === true;
 }
 

--- a/live/app/initializers/ajax-interceptor.js
+++ b/live/app/initializers/ajax-interceptor.js
@@ -3,7 +3,7 @@ import ENV from 'pix-live/config/environment';
 export function initialize(/* application */) {
   // XXX : Small hack, huge reward : we can now assert in tests what is the content of outgoing requests.
   if (ENV.environment === 'test') {
-    $(document).ajaxComplete(function (event, xhr, settings) {
+    $(document).ajaxComplete(function(event, xhr, settings) {
       if ('POST' === settings.type) {
         localStorage.setItem('miragePostUrl', JSON.stringify({
           url: '/api' + settings.url.split('api')[1],

--- a/live/app/models/answer/value-as-array-of-boolean-mixin.js
+++ b/live/app/models/answer/value-as-array-of-boolean-mixin.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
   /*
   * Convert "1,2,4" into [true, true, false, true]
   */
-  _valueAsArrayOfBoolean: Ember.computed('value', function () {
+  _valueAsArrayOfBoolean: Ember.computed('value', function() {
     return _.chain(this.get('value'))                                    // in the worst case : ',4, 2 , 2,1,  ,'
     .checkPoint((e) => _.isString(e) ? e : '')                           // check if string
     .split(',')                                                          // now ['', '4', ' 2 ', ' 2', '1', '  ', '']

--- a/live/app/models/answer/value-as-array-of-string-mixin.js
+++ b/live/app/models/answer/value-as-array-of-string-mixin.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
 
-  _valuesAsMap: Ember.computed('value', function () {
+  _valuesAsMap: Ember.computed('value', function() {
     try {
       return jsyaml.load(this.get('value'));
     } catch (e) {

--- a/live/app/models/challenge/proposals-as-array-mixin.js
+++ b/live/app/models/challenge/proposals-as-array-mixin.js
@@ -12,7 +12,6 @@ function calculate(proposals) {
 export default Ember.Mixin.create({
   _proposalsAsArray: Ember.computed('proposals', function() {
 
-
     const proposals = this.get('proposals');
     const DEFAULT_RETURN_VALUE = [];
 
@@ -23,5 +22,4 @@ export default Ember.Mixin.create({
     return calculate(proposals);
   })
 });
-
 

--- a/live/app/models/challenge/proposals-as-array-mixin.js
+++ b/live/app/models/challenge/proposals-as-array-mixin.js
@@ -10,7 +10,7 @@ function calculate(proposals) {
 }
 
 export default Ember.Mixin.create({
-  _proposalsAsArray: Ember.computed('proposals', function () {
+  _proposalsAsArray: Ember.computed('proposals', function() {
 
 
     const proposals = this.get('proposals');

--- a/live/app/models/challenge/proposals-as-blocks-mixin.js
+++ b/live/app/models/challenge/proposals-as-blocks-mixin.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create({
   // see proposals-as-block-mixin-test.js to understand how it works
 
   // eslint-disable-next-line complexity
-  _proposalsAsBlocks: Ember.computed('proposals', function () {
+  _proposalsAsBlocks: Ember.computed('proposals', function() {
 
     const proposals = this.get('proposals');
     if (Ember.isEmpty(proposals)) {

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -28,7 +28,7 @@ if (config.environment === 'integration' || config.environment === 'staging' || 
   });
 }
 
-export default Router.map(function () {
+export default Router.map(function() {
   this.route('index', { path: '/' });
   this.route('courses');
   this.route('placement-tests');

--- a/live/app/routes/assessments/get-comparison.js
+++ b/live/app/routes/assessments/get-comparison.js
@@ -2,7 +2,6 @@ import ModalRouteMixin from 'ember-routable-modal/mixins/route';
 import RSVP from 'rsvp';
 import BaseRoute from 'pix-live/routes/base-route';
 
-
 export default BaseRoute.extend(ModalRouteMixin, {
 
   model(params) {
@@ -26,6 +25,5 @@ export default BaseRoute.extend(ModalRouteMixin, {
     });
 
   },
-
 
 });

--- a/live/app/routes/assessments/get-results.js
+++ b/live/app/routes/assessments/get-results.js
@@ -15,7 +15,7 @@ export default BaseRoute.extend({
   },
 
   actions: {
-    openComparison: function (assessment_id, answer_id, index) {
+    openComparison: function(assessment_id, answer_id, index) {
       this.transitionTo('assessments.get-comparison', assessment_id, answer_id, index);
     }
   }

--- a/live/app/routes/challenges/get-preview.js
+++ b/live/app/routes/challenges/get-preview.js
@@ -1,7 +1,6 @@
 import _ from 'pix-live/utils/lodash-custom';
 import BaseRoute from 'pix-live/routes/base-route';
 
-
 export default BaseRoute.extend({
 
   model(params) {

--- a/live/app/routes/courses/get-challenge-preview.js
+++ b/live/app/routes/courses/get-challenge-preview.js
@@ -14,7 +14,7 @@ export default BaseRoute.extend({
       challenge: store.findRecord('challenge', params.challenge_id)
     };
 
-    return RSVP.hash(promises).then(function (results) {
+    return RSVP.hash(promises).then(function(results) {
 
       const challenge = results.challenge;
       const course = RSVP.resolve(results.course);
@@ -40,7 +40,7 @@ export default BaseRoute.extend({
 
   },
 
-  serialize: function (model) {
+  serialize: function(model) {
     return model.assessment.get('course').then((course) => {
       return {
         course_id: course.id,

--- a/live/app/routes/courses/get-challenge-preview.js
+++ b/live/app/routes/courses/get-challenge-preview.js
@@ -34,7 +34,6 @@ export default BaseRoute.extend({
   setupController: function(controller, model) {
     this._super(controller, model);
 
-
     const challengeType =  getChallengeType(model.challenge.get('type'));
     controller.set('challengeItemType', 'challenge-item-' + challengeType);
 

--- a/live/app/utils/call-only-once.js
+++ b/live/app/utils/call-only-once.js
@@ -1,7 +1,7 @@
 import config from '../config/environment';
 import _ from 'pix-live/utils/lodash-custom';
 
-export default function callOnlyOnce (targetFunction) {
+export default function callOnlyOnce(targetFunction) {
   if (config.EmberENV.useDelay) {
     return _.throttle(targetFunction, 1000, { leading: true, trailing: false});
   } else {

--- a/live/app/utils/get-challenge-type.js
+++ b/live/app/utils/get-challenge-type.js
@@ -1,6 +1,5 @@
 import _ from './lodash-custom';
 
-
 export default function getChallengeType(challengeTypeFromAirtable) {
   let result = 'qcu'; // qcu by default, no error thrown
   const challengeType = challengeTypeFromAirtable.toUpperCase();

--- a/live/app/utils/labeled-checkboxes.js
+++ b/live/app/utils/labeled-checkboxes.js
@@ -17,7 +17,7 @@ import _ from 'pix-live/utils/lodash-custom';
  *     ['is grass red ?', false],
  *     ['are clouds red ?' false]]
  */
-export default function labeledCheckboxes (proposals, userAnswers) {
+export default function labeledCheckboxes(proposals, userAnswers) {
 
   // accept that user didn't give any answer yet
   const definedUserAnswers = _.isNil(userAnswers) ? [] : userAnswers;

--- a/live/app/utils/labeled-checkboxes.js
+++ b/live/app/utils/labeled-checkboxes.js
@@ -1,6 +1,5 @@
 import _ from 'pix-live/utils/lodash-custom';
 
-
 /*
  * Example :
  * => Input :

--- a/live/app/utils/lodash-custom.js
+++ b/live/app/utils/lodash-custom.js
@@ -5,10 +5,10 @@ _.mixin({
   // Simple alias for includes, last arg fromIndex excluded.
   // Therefore, no test on this function.
   /* istanbul ignore next */
-  isAmongst: function (element, collection) {
+  isAmongst: function(element, collection) {
     return _.includes(collection, element);
   },
-  forceString: function (x) {
+  forceString: function(x) {
     if (_(x).isNonEmptyString()) {
       return x;
     } else {
@@ -17,37 +17,37 @@ _.mixin({
   },
   // See http://stackoverflow.com/a/10834843
   /* istanbul ignore next */
-  isStrictlyPositiveInteger: function (str) {
+  isStrictlyPositiveInteger: function(str) {
     return /^\+?[1-9]\d*$/.test(str);
   },
   // Just an alias, ignore test
   /* istanbul ignore next */
   checkPoint: _.thru,
-  isTrue: function (x) {
+  isTrue: function(x) {
     return x === true;
   },
-  removeFirstElement: function (x) {
+  removeFirstElement: function(x) {
     return _.drop(x, 1);
   },
-  isArrayOfString: function (x) {
+  isArrayOfString: function(x) {
     return _.isArray(x) && _.every(x, _.isString);
   },
-  isNotString: function (x) {
+  isNotString: function(x) {
     return !_.isString(x);
   },
-  isNotArrayOfString: function (x) {
+  isNotArrayOfString: function(x) {
     return !_.isArrayOfString(x);
   },
-  isNotArray: function (x) {
+  isNotArray: function(x) {
     return !_.isArray(x);
   },
-  isArrayOfBoolean: function (x) {
+  isArrayOfBoolean: function(x) {
     return _.isArray(x) && _.every(x, _.isBoolean);
   },
-  isNotArrayOfBoolean: function (x) {
+  isNotArrayOfBoolean: function(x) {
     return !_.isArrayOfBoolean(x);
   },
-  isTruthy: function (x) {
+  isTruthy: function(x) {
     return x !== false                     // not the boolean false
       && x !== 0                           // not the number 0
       && x !== undefined                   // not an undefined value
@@ -59,24 +59,24 @@ _.mixin({
   },
   // Not enough value to test a one line function, mainly an alias here.
   /* istanbul ignore next */
-  isFalsy: function (x) {
+  isFalsy: function(x) {
     return !_.isTruthy(x);
   },
-  isNonEmptyString: function (x) {
+  isNonEmptyString: function(x) {
     return _.isString(x) && !_.isEmpty(x);
   },
-  isNonEmptyArray: function (x) {
+  isNonEmptyArray: function(x) {
     return _.isArray(x) && !_.isEmpty(x);
   },
-  hasSomeTruthyProps: function (x) {
+  hasSomeTruthyProps: function(x) {
     if (!_.isObject(x)) return false;
     if (_.isEmpty(x)) return false;
-    return _.some(x, function (value) {
+    return _.some(x, function(value) {
       return _.isTruthy(value);
     });
   },
 
-  isNotInteger: function (x) {
+  isNotInteger: function(x) {
     return !_.isInteger(x);
   },
 

--- a/live/app/utils/result-details-as-object.js
+++ b/live/app/utils/result-details-as-object.js
@@ -2,7 +2,7 @@
 
 export default function resultDetailsAsObject(yamlResultDetails) {
   let resultDetailsAsObject = {};
-  if (yamlResultDetails !== 'null\n'){
+  if (yamlResultDetails !== 'null\n') {
     resultDetailsAsObject = jsyaml.safeLoad(yamlResultDetails);
   }
   return resultDetailsAsObject;

--- a/live/mirage/config.js
+++ b/live/mirage/config.js
@@ -14,7 +14,7 @@ import postFollowers                     from './routes/post-followers';
 import postFeedbacks from './routes/post-feedbacks';
 import postRefreshSolution from './routes/post-refresh-solution';
 
-export default function () {
+export default function() {
   this.logging = false;
   this.passthrough('/write-coverage');
   this.post('https://fonts.googleapis.com/**', () => {});

--- a/live/mirage/routes/get-answer-by-challenge-and-assessment.js
+++ b/live/mirage/routes/get-answer-by-challenge-and-assessment.js
@@ -8,7 +8,7 @@ import refQrocmAnswer  from '../data/answers/ref-qrocm-answer';
 import refTimedAnswer  from '../data/answers/ref-timed-answer';
 import refTimedAnswerBis  from '../data/answers/ref-timed-answer-bis';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const allAnswers = [
     refQcuAnswer,

--- a/live/mirage/routes/get-answer-by-challenge-and-assessment.js
+++ b/live/mirage/routes/get-answer-by-challenge-and-assessment.js
@@ -45,5 +45,4 @@ export default function(schema, request) {
     throw new Error('404 The answer you required in the fake server does not exist... ' + queryParams);
   }
 
-
 }

--- a/live/mirage/routes/get-answer.js
+++ b/live/mirage/routes/get-answer.js
@@ -8,7 +8,7 @@ import refQrocmAnswer from '../data/answers/ref-qrocm-answer';
 import refTimedAnswer from '../data/answers/ref-timed-answer';
 import refTimedAnswerBis from '../data/answers/ref-timed-answer-bis';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const allAnswers = [
     refQcuAnswer,
@@ -20,7 +20,7 @@ export default function (schema, request) {
     refTimedAnswerBis
   ];
 
-  const answers = _.map(allAnswers, function (oneAnswer) {
+  const answers = _.map(allAnswers, function(oneAnswer) {
     return { id: oneAnswer.data.id, obj: oneAnswer };
   });
 

--- a/live/mirage/routes/get-assessment-solutions.js
+++ b/live/mirage/routes/get-assessment-solutions.js
@@ -1,7 +1,7 @@
 import refSolution from '../data/solutions/ref-solution';
 import refQcuSolution from '../data/solutions/ref-qcu-solution';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   return (request.params.answerId === 'ref_answer_qcu_id') ? refQcuSolution : refSolution;
 

--- a/live/mirage/routes/get-assessment.js
+++ b/live/mirage/routes/get-assessment.js
@@ -2,14 +2,14 @@ import _ from 'pix-live/utils/lodash-custom';
 import refAssessment from '../data/assessments/ref-assessment';
 import refAssessmentTimedChallenges from '../data/assessments/ref-assessment-timed-challenges';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const allAssessments = [
     refAssessment,
     refAssessmentTimedChallenges
   ];
 
-  const assessments = _.map(allAssessments, function (oneAssessment) {
+  const assessments = _.map(allAssessments, function(oneAssessment) {
     return { id: oneAssessment.data.id, obj: oneAssessment };
   });
 

--- a/live/mirage/routes/get-challenge.js
+++ b/live/mirage/routes/get-challenge.js
@@ -8,7 +8,7 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 import refTimedChallengeFull from '../data/challenges/ref-timed-challenge';
 import refTimedChallengeBisFull from '../data/challenges/ref-timed-challenge-bis';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
 
   const allChallenges = [
@@ -21,7 +21,7 @@ export default function (schema, request) {
     refTimedChallengeBisFull
   ];
 
-  const challenges = _.map(allChallenges, function (oneChallenge) {
+  const challenges = _.map(allChallenges, function(oneChallenge) {
     return { id: oneChallenge.data.id, obj: oneChallenge };
   });
 

--- a/live/mirage/routes/get-challenge.js
+++ b/live/mirage/routes/get-challenge.js
@@ -10,7 +10,6 @@ import refTimedChallengeBisFull from '../data/challenges/ref-timed-challenge-bis
 
 export default function(schema, request) {
 
-
   const allChallenges = [
     refQcmChallengeFull,
     refQcuChallengeFull,

--- a/live/mirage/routes/get-challenges.js
+++ b/live/mirage/routes/get-challenges.js
@@ -6,7 +6,7 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 import refTimedChallengeFull from '../data/challenges/ref-timed-challenge';
 import refTimedChallengeBisFull from '../data/challenges/ref-timed-challenge-bis';
 
-export default function () {
+export default function() {
 
   return {
     data: [

--- a/live/mirage/routes/get-course.js
+++ b/live/mirage/routes/get-course.js
@@ -4,7 +4,7 @@ import refCourse from '../data/courses/ref-course';
 import highlightedCourse from '../data/courses/highlighted-course';
 import courseWithTimedChallenge from '../data/courses/ref-course-timed-challenges';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const allCourses = [
     refCourse,
@@ -12,7 +12,7 @@ export default function (schema, request) {
     courseWithTimedChallenge
   ];
 
-  const courses = _.map(allCourses, function (oneCourse) {
+  const courses = _.map(allCourses, function(oneCourse) {
     return { id: oneCourse.data.id, obj: oneCourse };
   });
 

--- a/live/mirage/routes/get-courses-of-the-week.js
+++ b/live/mirage/routes/get-courses-of-the-week.js
@@ -1,5 +1,5 @@
 import highlightedCourse from '../data/courses/highlighted-course';
 
-export default function () {
+export default function() {
   return { data: [highlightedCourse.data] };
 }

--- a/live/mirage/routes/get-courses.js
+++ b/live/mirage/routes/get-courses.js
@@ -1,7 +1,7 @@
 import refCourse from '../data/courses/ref-course';
 import courseOfTheWeek from '../data/courses/highlighted-course';
 
-export default function (schema, request) {
+export default function(schema, request) {
   const courses = [refCourse.data];
 
   if (request.queryParams && request.queryParams.isCourseOfTheWeek) {

--- a/live/mirage/routes/get-next-challenge.js
+++ b/live/mirage/routes/get-next-challenge.js
@@ -6,7 +6,6 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 
 import refTimedChallengeBis from '../data/challenges/ref-timed-challenge-bis';
 
-
 export default function(schema, request) {
 
   // case 1 : we're trying to reach the first challenge for a given assessment
@@ -31,7 +30,6 @@ export default function(schema, request) {
 
     'ref_timed_challenge_id': refTimedChallengeBis,
     'ref_timed_challenge_bis_id': 'null',
-
 
   };
 

--- a/live/mirage/routes/get-next-challenge.js
+++ b/live/mirage/routes/get-next-challenge.js
@@ -7,7 +7,7 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 import refTimedChallengeBis from '../data/challenges/ref-timed-challenge-bis';
 
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   // case 1 : we're trying to reach the first challenge for a given assessment
   if (!request.params.challengeId) {

--- a/live/mirage/routes/post-answers.js
+++ b/live/mirage/routes/post-answers.js
@@ -18,7 +18,7 @@ import refQrocmAnswer from '../data/answers/ref-qrocm-answer';
 import refTimedAnswer from '../data/answers/ref-timed-answer';
 import refTimedAnswerBis from '../data/answers/ref-timed-answer-bis';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const answer = JSON.parse(request.requestBody);
   const challengeId = answer.data.relationships.challenge.data.id;
@@ -43,7 +43,7 @@ export default function (schema, request) {
     refTimedAnswerBis
   ];
 
-  const answers = _.map(allChallenges, function (oneChallenge, index) {
+  const answers = _.map(allChallenges, function(oneChallenge, index) {
     return { id: oneChallenge.data.id, obj: allAnswers[index] };
   });
 

--- a/live/mirage/routes/post-answers.js
+++ b/live/mirage/routes/post-answers.js
@@ -8,7 +8,6 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 import refTimedChallenge from '../data/challenges/ref-timed-challenge';
 import refTimedChallengeBis from '../data/challenges/ref-timed-challenge-bis';
 
-
 // answers
 import refQcuAnswer from '../data/answers/ref-qcu-answer';
 import refQruAnswer from '../data/answers/ref-qru-answer';

--- a/live/mirage/routes/post-assessments.js
+++ b/live/mirage/routes/post-assessments.js
@@ -2,7 +2,7 @@ import _ from 'pix-live/utils/lodash-custom';
 
 import refAssessment from '../data/assessments/ref-assessment';
 
-export default function (schema, request) {
+export default function(schema, request) {
 
   const answer = JSON.parse(request.requestBody);
   const courseId = answer.data.relationships.course.data.id;
@@ -11,7 +11,7 @@ export default function (schema, request) {
     refAssessment
   ];
 
-  const assessments = _.map(allAssessments, function (oneAssessment) {
+  const assessments = _.map(allAssessments, function(oneAssessment) {
     return { id: oneAssessment.data.relationships.course.data.id, obj: oneAssessment };
   });
 

--- a/live/mirage/routes/post-feedbacks.js
+++ b/live/mirage/routes/post-feedbacks.js
@@ -1,5 +1,5 @@
 import refFeedback from '../data/feedbacks/ref-feedback';
 
-export default function () {
+export default function() {
   return refFeedback;
 }

--- a/live/mirage/routes/post-followers.js
+++ b/live/mirage/routes/post-followers.js
@@ -1,6 +1,6 @@
 import follower from '../data/followers';
 
-export default function () {
+export default function() {
 
   return follower;
 }

--- a/live/mirage/routes/post-refresh-solution.js
+++ b/live/mirage/routes/post-refresh-solution.js
@@ -1,6 +1,5 @@
 export default function() {
 
-
   return 'ok';
 
 }

--- a/live/mirage/routes/post-refresh-solution.js
+++ b/live/mirage/routes/post-refresh-solution.js
@@ -1,4 +1,4 @@
-export default function () {
+export default function() {
 
 
   return 'ok';

--- a/live/package.json
+++ b/live/package.json
@@ -64,6 +64,7 @@
     "clean": "rm -rf tmp dist bower_components node_modules",
     "start": "ember server",
     "test": "ember test",
+    "lint": "./node_modules/.bin/eslint app mirage tests",
     "coverage:check": "COVERAGE=true ember test",
     "coverage:convert": "node scripts/lcov-path-converter",
     "coverage:rename": "mv coverage/lcov.info ../coverage/live_lcov.info",

--- a/live/tests/acceptance/a1-page-accueil-test.js
+++ b/live/tests/acceptance/a1-page-accueil-test.js
@@ -3,100 +3,100 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | a1 - La page d\'accueil', function () {
+describe('Acceptance | a1 - La page d\'accueil', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
     visit('/');
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  it('a1.0 est accessible depuis "/"', function () {
+  it('a1.0 est accessible depuis "/"', function() {
     expect(currentURL()).to.equal('/');
   });
 
-  describe('contient une section "Hero"', function () {
+  describe('contient une section "Hero"', function() {
 
-    it('a1.0 avec la barre de navigation', function () {
+    it('a1.0 avec la barre de navigation', function() {
       findWithAssert('.index-page-hero__navbar-header');
     });
 
-    it('a1.1 avec un titre', function () {
+    it('a1.1 avec un titre', function() {
       const $title = findWithAssert('.index-page-hero__title');
       expect($title.text().trim()).to.equal('Développez vos compétences numériques');
     });
 
-    it('a1.2 avec un descriptif', function () {
+    it('a1.2 avec un descriptif', function() {
       const $description = findWithAssert('.index-page-hero__description');
       expect($description.text().trim()).to.equal('PIX est un projet public de plateforme en ligne d’évaluation et de certification des compétences numériques, en cours de développement.');
     });
   });
 
-  describe('contient une section "Challenges"', function () {
+  describe('contient une section "Challenges"', function() {
 
-    it('a1.3 cachée si aucun test n\'est remonté', function () {
+    it('a1.3 cachée si aucun test n\'est remonté', function() {
       // FIXME find a way to test this correctly
     });
 
-    it('a1.4 visible si au moins 1 test est remonté', function () {
+    it('a1.4 visible si au moins 1 test est remonté', function() {
       // FIXME find a way to test this correctly
     });
 
-    it('a1.6 avec un titre', function () {
+    it('a1.6 avec un titre', function() {
       const $title = findWithAssert('.index-page-challenges__presentation-title');
       expect($title.text().trim()).to.equal('Le défi Pix de la semaine');
     });
 
-    it('a1.7 avec un texte descriptif', function () {
+    it('a1.7 avec un texte descriptif', function() {
       const $description = findWithAssert('.index-page-challenges__presentation-text');
       expect($description.text().trim()).to.equal('Chaque semaine, testez vos compétences numériques sur un nouveau sujet.');
     });
 
-    it('a1.8 qui affiche 2 tests maximum', function () {
+    it('a1.8 qui affiche 2 tests maximum', function() {
       // FIXME find a way to test this correctly
     });
   });
 
-  describe('contient une section "Courses"', function () {
+  describe('contient une section "Courses"', function() {
 
-    it('a1.9 avec un titre', function () {
+    it('a1.9 avec un titre', function() {
       const $title = findWithAssert('.index-page-courses__title');
       expect($title.text().trim()).to.equal('Découvrez nos épreuves et aidez‑nous à les améliorer !');
     });
 
-    it('a1.10 avec la liste des challenges', function () {
+    it('a1.10 avec la liste des challenges', function() {
       findWithAssert('.index-page-courses__course-list');
     });
   });
 
-  describe('contient une section "Community"', function () {
+  describe('contient une section "Community"', function() {
 
-    it('a1.11 avec un titre', function () {
+    it('a1.11 avec un titre', function() {
       findWithAssert('.index-page-community__title');
     });
 
-    it('a1.12 avec une description', function () {
+    it('a1.12 avec une description', function() {
       findWithAssert('.index-page-community__description');
     });
 
-    it('a1.13 avec le formulaire d\'inscription en tant que béta-testeur', function () {
+    it('a1.13 avec le formulaire d\'inscription en tant que béta-testeur', function() {
       findWithAssert('.index-page-community__form');
     });
 
   });
 
-  describe('contient une section "Features"', function () {
+  describe('contient une section "Features"', function() {
 
-    it('a1.14 avec la liste des featurettes', function () {
+    it('a1.14 avec la liste des featurettes', function() {
       findWithAssert('.index-page-features__list');
     });
 
-    it('a1.15 avec un lien vers la page "projet"', function () {
+    it('a1.15 avec un lien vers la page "projet"', function() {
       findWithAssert('.index-page-features__project-button[href="/projet"]');
     });
   });

--- a/live/tests/acceptance/a4-demarrer-un-test-test.js
+++ b/live/tests/acceptance/a4-demarrer-un-test-test.js
@@ -9,16 +9,16 @@ const URL_OF_FIRST_TEST = '/assessments/ref_assessment_id/challenges/ref_qcm_cha
 const MODAL_SELECTOR = '.modal.fade.js-modal-mobile.in';
 const START_BUTTON = '.course-item__begin-button';
 
-describe('Acceptance | a4 - Démarrer un test |', function () {
+describe('Acceptance | a4 - Démarrer un test |', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
     visit('/');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/a5-voir-liste-tests-adaptatifs-test.js
+++ b/live/tests/acceptance/a5-voir-liste-tests-adaptatifs-test.js
@@ -3,26 +3,26 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | a5 - La page des tests adaptatifs', function () {
+describe('Acceptance | a5 - La page des tests adaptatifs', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
     visit('/placement-tests');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  it('a5.0 est accessible depuis "/placement-tests"', function () {
+  it('a5.0 est accessible depuis "/placement-tests"', function() {
     expect(currentURL()).to.equal('/placement-tests');
   });
 
-  describe('a5.1 contient une section', function () {
+  describe('a5.1 contient une section', function() {
 
-    it('a5.1.1 avec la liste des tests', function () {
+    it('a5.1.1 avec la liste des tests', function() {
       findWithAssert('.placement-tests-page-courses__course-list');
     });
   });

--- a/live/tests/acceptance/b1-epreuve-qcu-test.js
+++ b/live/tests/acceptance/b1-epreuve-qcu-test.js
@@ -7,34 +7,34 @@ import _ from 'pix-live/utils/lodash-custom';
 
 let application;
 
-describe('Acceptance | b1 - Afficher un QCU | ', function () {
+describe('Acceptance | b1 - Afficher un QCU | ', function() {
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  it('b1.1 Une liste de radiobuttons doit s\'afficher', function () {
+  it('b1.1 Une liste de radiobuttons doit s\'afficher', function() {
     const $proposals = $('.input-radio-proposal');
     expect($proposals).to.have.lengthOf(4);
   });
 
-  it('b1.2 Par défaut, le radiobutton de la réponse sauvegardée est affiché', function () {
+  it('b1.2 Par défaut, le radiobutton de la réponse sauvegardée est affiché', function() {
     expect($('.input-radio-proposal:checked')).to.have.lengthOf(1);
   });
 
-  it('b1.3 Une liste ordonnée d\'instruction doit s\'afficher', function () {
+  it('b1.3 Une liste ordonnée d\'instruction doit s\'afficher', function() {
     expect($('.proposal-text:eq(0)').text().trim()).to.equal('1ere possibilite');
     expect($('.proposal-text:eq(1)').text().trim()).to.equal('2eme possibilite');
     expect($('.proposal-text:eq(2)').text().trim()).to.equal('3eme possibilite');
     expect($('.proposal-text:eq(3)').text().trim()).to.equal('4eme possibilite');
   });
 
-  it('b1.4 L\'alerte est affichée si l\'utilisateur valide, mais aucun radiobutton n\'est coché', async function () {
+  it('b1.4 L\'alerte est affichée si l\'utilisateur valide, mais aucun radiobutton n\'est coché', async function() {
 
     // given
     $(':radio').prop('checked', false);
@@ -48,7 +48,7 @@ describe('Acceptance | b1 - Afficher un QCU | ', function () {
     expect($alert.text().trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passer.');
   });
 
-  it('b1.5 Si un utilisateur clique sur un radiobutton, il est le seul coché, et les autres sont décochés', async function () {
+  it('b1.5 Si un utilisateur clique sur un radiobutton, il est le seul coché, et les autres sont décochés', async function() {
 
     // Given
     expect($('.input-radio-proposal:eq(0)').is(':checked')).to.equal(false);
@@ -66,7 +66,7 @@ describe('Acceptance | b1 - Afficher un QCU | ', function () {
     expect($('.input-radio-proposal:eq(3)').is(':checked')).to.equal(false);
   });
 
-  it('b1.6 Si un utilisateur clique sur un radiobutton, et valide l\'épreuve, une demande de sauvegarde de sa réponse est envoyée à l\'API', async function () {
+  it('b1.6 Si un utilisateur clique sur un radiobutton, et valide l\'épreuve, une demande de sauvegarde de sa réponse est envoyée à l\'API', async function() {
     // Given
     resetTestingState();
 

--- a/live/tests/acceptance/b2-epreuve-qcm-test.js
+++ b/live/tests/acceptance/b2-epreuve-qcm-test.js
@@ -10,58 +10,58 @@ function visitTimedChallenge() {
   click('.challenge-item-warning button');
 }
 
-describe('Acceptance | b2 - Afficher un QCM | ', function () {
+describe('Acceptance | b2 - Afficher un QCM | ', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
     visitTimedChallenge();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  it('b2.1 It should render challenge instruction', function () {
+  it('b2.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructionText = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs';
     expect($challengeInstruction.text()).to.equal(instructionText);
   });
 
-  it('b2.2 Le contenu de type [foo](bar) doit être converti sous forme de lien', function () {
+  it('b2.2 Le contenu de type [foo](bar) doit être converti sous forme de lien', function() {
     const $links = findWithAssert('.challenge-statement__instruction a');
     expect($links.length).to.equal(1);
     expect($links.text()).to.equal('plusieurs');
     expect($links.attr('href')).to.equal('http://link.plusieurs.url');
   });
 
-  it('b2.3 Les liens doivent s\'ouvrir dans un nouvel onglet', function () {
+  it('b2.3 Les liens doivent s\'ouvrir dans un nouvel onglet', function() {
     const $links = findWithAssert('.challenge-statement__instruction a');
     expect($links.attr('target')).to.equal('_blank');
   });
 
-  it('b2.4 It should render a list of checkboxes', function () {
+  it('b2.4 It should render a list of checkboxes', function() {
     const $proposals = $('input[type="checkbox"]');
     expect($proposals).to.have.lengthOf(4);
   });
 
-  it('b2.5 By default, already checked checkboxes are checked', function () {
+  it('b2.5 By default, already checked checkboxes are checked', function() {
     expect($('input:checkbox:checked')).to.have.lengthOf(2);
   });
 
-  it('b2.6 It should render an ordered list of instruction', function () {
+  it('b2.6 It should render an ordered list of instruction', function() {
     expect($('.proposal-text:eq(0)').text().trim()).to.equal('possibilite 1, et/ou');
     expect($('.proposal-text:eq(1)').text().trim()).to.equal('possibilite 2, et/ou');
     expect($('.proposal-text:eq(2)').text().trim()).to.equal('possibilite 3, et/ou');
     expect($('.proposal-text:eq(3)').text().trim()).to.equal('possibilite 4');
   });
 
-  it('b2.7 Error alert box should be hidden by default', function () {
+  it('b2.7 Error alert box should be hidden by default', function() {
     expect($('.alert')).to.have.lengthOf(0);
   });
 
-  it('b2.8 Error alert box should be displayed if user validate without checking a checkbox', function () {
+  it('b2.8 Error alert box should be displayed if user validate without checking a checkbox', function() {
     const $validateLink = $('.challenge-actions__action-validate');
     expect($('input:checkbox:checked')).to.have.lengthOf(2);
     $('input:checkbox').prop('checked', false);
@@ -73,7 +73,7 @@ describe('Acceptance | b2 - Afficher un QCM | ', function () {
     });
   });
 
-  it('b2.9 If an user check a checkbox, it is checked', function () {
+  it('b2.9 If an user check a checkbox, it is checked', function() {
     expect($('input:checkbox:checked')).to.have.lengthOf(0);
     $('.input-checkbox-proposal:eq(1)').click();
     andThen(() => {
@@ -81,7 +81,7 @@ describe('Acceptance | b2 - Afficher un QCM | ', function () {
     });
   });
 
-  it('b2.10 If an user check another checkbox, it is checked, the previous checked checkboxes remains checked', function () {
+  it('b2.10 If an user check another checkbox, it is checked, the previous checked checkboxes remains checked', function() {
     expect($('input:checkbox:checked')).to.have.lengthOf(1);
     $('.input-checkbox-proposal:eq(2)').click();
     andThen(() => {
@@ -89,7 +89,7 @@ describe('Acceptance | b2 - Afficher un QCM | ', function () {
     });
   });
 
-  it('b2.11 If an user validate the challenge, the api is request to save the answer of the user', async function () {
+  it('b2.11 If an user validate the challenge, the api is request to save the answer of the user', async function() {
     resetTestingState();
     await click('.challenge-actions__action-validate');
     expect(urlOfLastPostRequest()).to.equal('/api/answers');

--- a/live/tests/acceptance/b3-epreuve-qroc-test.js
+++ b/live/tests/acceptance/b3-epreuve-qroc-test.js
@@ -5,30 +5,30 @@ import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import _ from 'pix-live/utils/lodash-custom';
 
-describe('Acceptance | b3 - Afficher un QROC | ', function () {
+describe('Acceptance | b3 - Afficher un QROC | ', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/challenges/ref_qroc_challenge_id');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  it('b3.1 It should render challenge instruction', function () {
+  it('b3.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre';
     expect($challengeInstruction.text()).to.equal(instructiontext);
   });
 
-  it('b3.2 It should display only one input text as proposal to user', function () {
+  it('b3.2 It should display only one input text as proposal to user', function() {
     expect($('.challenge-response__proposal-input')).to.have.lengthOf(1);
   });
 
-  it('b3.3 Error alert box should be displayed if user validate without writing any answer', function () {
+  it('b3.3 Error alert box should be displayed if user validate without writing any answer', function() {
     fillIn('input[data-uid="qroc-proposal-uid"]', '');
     expect($('.alert')).to.have.lengthOf(0);
     click(findWithAssert('.challenge-actions__action-validate'));
@@ -39,7 +39,7 @@ describe('Acceptance | b3 - Afficher un QROC | ', function () {
     });
   });
 
-  it('b3.4 It should save the answer of the user when user validate', async function () {
+  it('b3.4 It should save the answer of the user when user validate', async function() {
     resetTestingState();
     fillIn('input[data-uid="qroc-proposal-uid"]', 'My New Answer');
     await click('.challenge-actions__action-validate');

--- a/live/tests/acceptance/b4-epreuve-qrocm-test.js
+++ b/live/tests/acceptance/b4-epreuve-qrocm-test.js
@@ -48,5 +48,4 @@ describe('Acceptance | b4 - Afficher un QROCM | ', function() {
     expect(_.get(bodyOfLastPostRequest(), 'data.attributes.value')).to.equal('logiciel1: stuff1\nlogiciel2: stuff2\nlogiciel3: stuff3\n');
   });
 
-
 });

--- a/live/tests/acceptance/b4-epreuve-qrocm-test.js
+++ b/live/tests/acceptance/b4-epreuve-qrocm-test.js
@@ -5,30 +5,30 @@ import destroyApp from '../helpers/destroy-app';
 import {resetTestingState, bodyOfLastPostRequest, urlOfLastPostRequest} from '../helpers/shared-state';
 import _ from 'pix-live/utils/lodash-custom';
 
-describe('Acceptance | b4 - Afficher un QROCM | ', function () {
+describe('Acceptance | b4 - Afficher un QROCM | ', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  it('b4.1 It should render challenge instruction', function () {
+  it('b4.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
     expect($challengeInstruction.text()).to.equal(instructiontext);
   });
 
-  it('b4.2 It should display only one input text as proposal to user', function () {
+  it('b4.2 It should display only one input text as proposal to user', function() {
     expect($('.challenge-response__proposal-input')).to.have.lengthOf(3);
   });
 
-  it('b4.3 Error alert box should be displayed if user validate without checking a checkbox', async function () {
+  it('b4.3 Error alert box should be displayed if user validate without checking a checkbox', async function() {
     // 1st make sure all inputs are cleared
     $(':input').val('');
     // Then try to validate sth
@@ -38,7 +38,7 @@ describe('Acceptance | b4 - Afficher un QROCM | ', function () {
     expect($('.alert').text().trim()).to.equal('Pour valider, saisir au moins une réponse. Sinon, passer.');
   });
 
-  it('b4.4 It should save the answer of the user when user validate', async function () {
+  it('b4.4 It should save the answer of the user when user validate', async function() {
     resetTestingState();
     $(':input:eq(0)').val('stuff1');
     $(':input:eq(1)').val('stuff2');

--- a/live/tests/acceptance/b6-epreuve-pj-test.js
+++ b/live/tests/acceptance/b6-epreuve-pj-test.js
@@ -8,50 +8,50 @@ function visitTimedChallenge() {
   click('.challenge-item-warning button');
 }
 
-describe('Acceptance | b6 - Télécharger une pièce jointe depuis la consigne d\'une épreuve | ', function () {
+describe('Acceptance | b6 - Télécharger une pièce jointe depuis la consigne d\'une épreuve | ', function() {
 
   let application;
 
   const $ATTACHMENT_LINK = $('.challenge-statement__action-link');
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  describe('Quand l\'épreuve contient une pièce jointe en consigne', function () {
+  describe('Quand l\'épreuve contient une pièce jointe en consigne', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       visitTimedChallenge();
     });
 
-    it('b6.1 Il existe un moyen pour télécharger la pièce jointe d\'une épreuve dans la zone de consigne', function () {
+    it('b6.1 Il existe un moyen pour télécharger la pièce jointe d\'une épreuve dans la zone de consigne', function() {
       const $ATTACHMENT_LINK = findWithAssert('.challenge-statement__action-link');
       expect($ATTACHMENT_LINK.length).to.equal(1);
     });
 
-    it('b6.2 Le lien de la pièce jointe pointe vers le bon lien', function () {
+    it('b6.2 Le lien de la pièce jointe pointe vers le bon lien', function() {
       const $ATTACHMENT_LINK = $('.challenge-statement__action-link');
       expect($ATTACHMENT_LINK.text()).to.contains('Télécharger');
       expect($ATTACHMENT_LINK.attr('href')).to.equal('http://example_of_url');
     });
 
-    it('b6.3 Il n\'y a qu\'un seul fichier téléchargeable', function () {
+    it('b6.3 Il n\'y a qu\'un seul fichier téléchargeable', function() {
       const $attachment = findWithAssert('.challenge-statement__action-link');
       expect($attachment.length).to.equal(1);
     });
   });
 
-  describe('Quand l\'épreuve ne contient pas de pièce jointe en consigne', function () {
+  describe('Quand l\'épreuve ne contient pas de pièce jointe en consigne', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       visit('/assessments/ref_assessment_id/challenges/ref_qroc_challenge_id');
     });
 
-    it('b6.4 La section de téléchargement des pièces jointes est cachée', function () {
+    it('b6.4 La section de téléchargement des pièces jointes est cachée', function() {
       // We are in a challenge...
       findWithAssert('.challenge-item');
 

--- a/live/tests/acceptance/b7-epreuve-points-communs-test.js
+++ b/live/tests/acceptance/b7-epreuve-points-communs-test.js
@@ -3,16 +3,16 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function () {
+describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
@@ -20,7 +20,7 @@ describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function 
     expect(findWithAssert('.course-banner__name').text()).to.contains('First Course');
   });
 
-  it('b7.1 L\'instruction de l\'epreuve est affichée', function () {
+  it('b7.1 L\'instruction de l\'epreuve est affichée', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
     expect($challengeInstruction.text()).to.equal(instructiontext);
@@ -38,20 +38,20 @@ describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function 
     expect($links.attr('target')).to.equal('_blank');
   });
 
-  it('b7.3 Un bouton de type "Skip" doit s\'afficher', function () {
+  it('b7.3 Un bouton de type "Skip" doit s\'afficher', function() {
     expect($('.challenge-actions__action-skip')).to.have.lengthOf(1);
   });
 
-  it('b7.4 Un bouton de type "Validate" doit s\'afficher', function () {
+  it('b7.4 Un bouton de type "Validate" doit s\'afficher', function() {
     expect($('.challenge-actions__action-skip')).to.have.lengthOf(1);
   });
 
-  it('b7.5 Il existe un bouton "Revenir à la liste des tests"', function () {
+  it('b7.5 Il existe un bouton "Revenir à la liste des tests"', function() {
     const $courseListButton = findWithAssert('.course-banner__home-link');
     expect($courseListButton.text()).to.equal('Retour à la liste des tests');
   });
 
-  it('b7.6 Quand je clique sur le bouton "Revenir à la liste des tests", je suis redirigé vers l\'index', function () {
+  it('b7.6 Quand je clique sur le bouton "Revenir à la liste des tests", je suis redirigé vers l\'index', function() {
     // when
     click('.course-banner__home-link');
 

--- a/live/tests/acceptance/c1-recapitulatif-test.js
+++ b/live/tests/acceptance/c1-recapitulatif-test.js
@@ -4,28 +4,28 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | c1 - Consulter l\'écran de fin d\'un test ', function () {
+describe('Acceptance | c1 - Consulter l\'écran de fin d\'un test ', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/results');
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  it('c1.0 se fait en accédant à l\'URL /assessments/:assessment_id/results', function () {
+  it('c1.0 se fait en accédant à l\'URL /assessments/:assessment_id/results', function() {
     expect(currentURL()).to.equal('/assessments/ref_assessment_id/results');
   });
 
-  it('c1.1 affiche une liste qui récapitule les réponses', function () {
+  it('c1.1 affiche une liste qui récapitule les réponses', function() {
     findWithAssert('.assessment-results__list');
   });
 
-  it('c1.2 le tableau récapitulatif contient les instructions ', function () {
+  it('c1.2 le tableau récapitulatif contient les instructions ', function() {
     const $proposals = findWithAssert('.result-item');
     expect($proposals.text()).to.contains('Un QCM propose plusieurs choix');
     expect($proposals.text()).to.contains('Un QCU propose plusieurs choix');
@@ -33,7 +33,7 @@ describe('Acceptance | c1 - Consulter l\'écran de fin d\'un test ', function ()
     expect($proposals.text()).to.contains('Un QROCM est une question ouverte');
   });
 
-  it('c1.3 Pour une mauvaise réponse, le tableau récapitulatif donne une indication adéquate', function () {
+  it('c1.3 Pour une mauvaise réponse, le tableau récapitulatif donne une indication adéquate', function() {
     const $cell = findWithAssert('div[data-toggle="tooltip"]:eq(0)');
     expect($cell.attr('data-original-title')).to.equal('Réponse incorrecte');
   });
@@ -42,15 +42,15 @@ describe('Acceptance | c1 - Consulter l\'écran de fin d\'un test ', function ()
     expect(findWithAssert('.course-banner__name').text()).to.contains('First Course');
   });
 
-  it('c1.10 Le bouton "Revenir à la liste des tests" n\'apparaît pas', function () {
+  it('c1.10 Le bouton "Revenir à la liste des tests" n\'apparaît pas', function() {
     expect(find('.course-banner__home-link')).to.have.lengthOf(0);
   });
 
-  it('c1.11. propose un moyen pour revenir à la liste des tests', function () {
+  it('c1.11. propose un moyen pour revenir à la liste des tests', function() {
     findWithAssert('.assessment-results__index-link-container');
   });
 
-  it('c1.12. La bannière est affichée', function () {
+  it('c1.12. La bannière est affichée', function() {
     findWithAssert('.assessment-results__course-banner');
   });
 

--- a/live/tests/acceptance/d1-epreuve-validation-test.js
+++ b/live/tests/acceptance/d1-epreuve-validation-test.js
@@ -8,49 +8,49 @@ function visitTimedChallenge() {
   click('.challenge-item-warning button');
 }
 
-describe('Acceptance | d1 - Valider une épreuve |', function () {
+describe('Acceptance | d1 - Valider une épreuve |', function() {
 
   let application;
   const PROGRESS_BAR_SELECTOR = '.pix-progress-bar';
-  before(function () {
+  before(function() {
     application = startApp();
     visitTimedChallenge();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  it('d1.0a La barre de progression commence à 1, si j\'accède au challenge depuis l\'url directe', function () {
+  it('d1.0a La barre de progression commence à 1, si j\'accède au challenge depuis l\'url directe', function() {
     const $progressBar = findWithAssert(PROGRESS_BAR_SELECTOR);
     expect($progressBar.text().trim()).to.equal('1 / 5');
   });
 
-  it('d1.0b La barre de progression commence à 1, si j\'accède au challenge depuis depuis le lien Airtable', async function () {
+  it('d1.0b La barre de progression commence à 1, si j\'accède au challenge depuis depuis le lien Airtable', async function() {
     await visit('/courses/ref_course_id');
     await click('.challenge-item-warning button');
     const $progressBar = findWithAssert(PROGRESS_BAR_SELECTOR);
     expect($progressBar.text().trim()).to.equal('1 / 5');
   });
 
-  it('d1.1 Je peux valider ma réponse à une épreuve via un bouton "Je valide"', function () {
+  it('d1.1 Je peux valider ma réponse à une épreuve via un bouton "Je valide"', function() {
     expect(findWithAssert('.challenge-actions__action-validate')).to.have.lengthOf(1);
   });
 
-  describe('quand je valide ma réponse à une épreuve', function () {
+  describe('quand je valide ma réponse à une épreuve', function() {
 
-    it('d1.3 Si l\'épreuve que je viens de valider n\'était pas la dernière du test, je suis redirigé vers l\'épreuve suivante', async function () {
+    it('d1.3 Si l\'épreuve que je viens de valider n\'était pas la dernière du test, je suis redirigé vers l\'épreuve suivante', async function() {
       await click('.proposal-text');
       await click('.challenge-actions__action-validate');
       expect(currentURL()).to.contains('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
     });
 
-    it('d1.4 La barre de progression avance d\'une unité, de 1 à 2.', function () {
+    it('d1.4 La barre de progression avance d\'une unité, de 1 à 2.', function() {
       const expectedText = '2';
       expect(findWithAssert('.pix-progress-bar').text()).to.contains(expectedText);
     });
 
-    it('d1.5 Si l\'épreuve que je viens de valider était la dernière du test, je suis redirigé vers la page de fin du test', async function () {
+    it('d1.5 Si l\'épreuve que je viens de valider était la dernière du test, je suis redirigé vers la page de fin du test', async function() {
       await visit('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
       await click('.challenge-response__proposal-input');
       await click('.challenge-actions__action-validate');

--- a/live/tests/acceptance/e1-previsualisation-epreuve-test.js
+++ b/live/tests/acceptance/e1-previsualisation-epreuve-test.js
@@ -5,27 +5,27 @@ import destroyApp from '../helpers/destroy-app';
 import { resetTestingState } from '../helpers/shared-state';
 import _ from 'pix-live/utils/lodash-custom';
 
-describe('Acceptance | e1 - Prévisualiser une épreuve | ', function () {
+describe('Acceptance | e1 - Prévisualiser une épreuve | ', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  describe('e1 - Prévisualiser une épreuve | ', function () {
+  describe('e1 - Prévisualiser une épreuve | ', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       // localStorage.clear();
       resetTestingState();
       visit('/');
     });
 
-    it('e1.1 Il y a une demande de création d\'un assessment avec un course vide', async function () {
+    it('e1.1 Il y a une demande de création d\'un assessment avec un course vide', async function() {
       // Given
       let postOnAssessment = localStorage.getItem('POST_ON_URL_/assessments');
       expect(postOnAssessment).not.to.exist;
@@ -45,7 +45,7 @@ describe('Acceptance | e1 - Prévisualiser une épreuve | ', function () {
       expect(idFirstChars).to.equal('null');
     });
 
-    it('e1.2 On affiche l\'assessment retourné par le serveur', async function () {
+    it('e1.2 On affiche l\'assessment retourné par le serveur', async function() {
 
       // Given
       await visit('/challenges/ref_qcu_challenge_id/preview');
@@ -53,7 +53,7 @@ describe('Acceptance | e1 - Prévisualiser une épreuve | ', function () {
       expect(findWithAssert('.assessment-challenge'));
     });
 
-    it('e1.3 Il y a une demande de rafraichissement du cache des solutions', async function () {
+    it('e1.3 Il y a une demande de rafraichissement du cache des solutions', async function() {
       // Given
       let postOnAssessment = localStorage.getItem('POST_ON_URL_/challenges/ref_qcu_challenge_id/solution');
       expect(postOnAssessment).not.to.exist;

--- a/live/tests/acceptance/f1-previsualisation-test-test.js
+++ b/live/tests/acceptance/f1-previsualisation-test-test.js
@@ -3,47 +3,47 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | f1 - Prévisualisation  d\'un test |', function () {
+describe('Acceptance | f1 - Prévisualisation  d\'un test |', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  describe('Prévisualiser la première page d\'un test |', function () {
+  describe('Prévisualiser la première page d\'un test |', function() {
 
-    before(function () {
+    before(function() {
       visit('/courses/ref_course_id/preview');
     });
 
-    it('f1.1 L\'accès à la preview d\'un test se fait en accédant à l\'URL /courses/:course_id/preview', function () {
+    it('f1.1 L\'accès à la preview d\'un test se fait en accédant à l\'URL /courses/:course_id/preview', function() {
       expect(currentURL()).to.equal('/courses/ref_course_id/preview');
     });
 
     let $preview;
 
-    describe('On affiche', function () {
+    describe('On affiche', function() {
 
-      before(function () {
+      before(function() {
         $preview = findWithAssert('#course-preview');
       });
 
-      it('f1.2 le nom du test', function () {
+      it('f1.2 le nom du test', function() {
         expect($preview.find('.course-name').text()).to.contains('First Course');
       });
 
-      it('f1.3 la description du test', function () {
+      it('f1.3 la description du test', function() {
         const $courseDescription = $preview.find('.course-description');
         const instructionText = 'Contient toutes sortes d\'epreuves avec différentes caractéristiques couvrant tous les cas d\'usage.';
         expect($courseDescription.text()).to.contains(instructionText);
       });
 
-      it('f1.4 un bouton pour démarrer la simulation du test et qui mène à la première question', function () {
+      it('f1.4 un bouton pour démarrer la simulation du test et qui mène à la première question', function() {
         const $playButton = findWithAssert('.simulate-button');
         expect($playButton.text()).to.be.equals('Simuler le test');
         expect($playButton.attr('href')).to.be.equals('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
@@ -51,31 +51,31 @@ describe('Acceptance | f1 - Prévisualisation  d\'un test |', function () {
     });
   });
 
-  describe('Prévisualiser une épreuve dans le cadre d\'un test |', function () {
+  describe('Prévisualiser une épreuve dans le cadre d\'un test |', function() {
 
-    before(function () {
+    before(function() {
       visit('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
     });
 
-    it('f1.5 L\'accès à la preview d\'une épreuve d\'un test se fait en accédant à l\'URL /courses/:course_id/preview/challenges/:challenge_id', function () {
+    it('f1.5 L\'accès à la preview d\'une épreuve d\'un test se fait en accédant à l\'URL /courses/:course_id/preview/challenges/:challenge_id', function() {
       expect(currentURL()).to.equal('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
     });
 
-    describe('On affiche', function () {
+    describe('On affiche', function() {
 
       let $challenge;
 
-      before(function () {
+      before(function() {
         $challenge = findWithAssert('.challenge-preview');
       });
 
-      it('f1.6 la consigne de l\'épreuve', async function () {
+      it('f1.6 la consigne de l\'épreuve', async function() {
         await visit('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
         await click('.challenge-item-warning button');
         expect($challenge.find('.challenge-statement__instruction').html()).to.contain('Un QCM propose plusieurs choix');
       });
 
-      it('f1.7 un bouton pour accéder à l\'épreuve suivante', function () {
+      it('f1.7 un bouton pour accéder à l\'épreuve suivante', function() {
         expect(findWithAssert('.challenge-actions__action-validate').text()).to.contains('Je valide');
       });
     });

--- a/live/tests/acceptance/g1-bandeau-no-internet-no-outils-test.js
+++ b/live/tests/acceptance/g1-bandeau-no-internet-no-outils-test.js
@@ -6,24 +6,24 @@ import destroyApp from '../helpers/destroy-app';
 const CHALLENGE_WITHOUT_INTERNET_NOR_TOOLS_URI = '/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id';
 const CHALLENGE_ALLOWING_INTERNET_OR_TOOS_URI = '/assessments/ref_assessment_id/challenges/ref_qcm_challenge_id';
 
-describe('Acceptance | g1 - Afficahge du bandeau indiquant que l\'usage d\'Internet ou d\'outils est interdit | ', function () {
+describe('Acceptance | g1 - Afficahge du bandeau indiquant que l\'usage d\'Internet ou d\'outils est interdit | ', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  it('g1.1 le bandeau doit être affiché si l\'usage d\'Internet ou d\'outils est interdit dans le cadre de l\'épreuve', async function () {
+  it('g1.1 le bandeau doit être affiché si l\'usage d\'Internet ou d\'outils est interdit dans le cadre de l\'épreuve', async function() {
     await visit(CHALLENGE_WITHOUT_INTERNET_NOR_TOOLS_URI);
     expect($('.challenge-stay__text').text()).to.contains('Vous devez répondre à cette question sans sortir de cette page !');
   });
 
-  it('g1.2 le bandeau ne doit pas être affiché si l\'usage d\'Internet ou d\'outils est autorisé dans le cadre de l\'épreuve', function () {
+  it('g1.2 le bandeau ne doit pas être affiché si l\'usage d\'Internet ou d\'outils est autorisé dans le cadre de l\'épreuve', function() {
     visit(CHALLENGE_ALLOWING_INTERNET_OR_TOOS_URI);
     expect($('.challenge-stay__text')).to.have.lengthOf(0);
   });

--- a/live/tests/acceptance/h1-timeout-jauge-test.js
+++ b/live/tests/acceptance/h1-timeout-jauge-test.js
@@ -25,21 +25,21 @@ function visitTimedChallenge() {
 const TIMED_CHALLENGE_URI = '/assessments/ref_assessment_id/challenges/ref_qcm_challenge_id';
 const CHALLENGE_ITEM_WARNING_BUTTON = '.challenge-item-warning button';
 
-describe('Acceptance | H1 - Timeout Jauge | ', function () {
+describe('Acceptance | H1 - Timeout Jauge | ', function() {
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  describe('Test affichage ou non de la jauge', function () {
+  describe('Test affichage ou non de la jauge', function() {
     //XXX: Deux cas car on test aussi une absence d'affichage
-    it('doit afficher la jauge si exigée par le backend mais ne pas l\'afficher dans le cas contraire ', function () {
+    it('doit afficher la jauge si exigée par le backend mais ne pas l\'afficher dans le cas contraire ', function() {
       visitTimedChallenge();
       andThen(() => {
         expect($('.timeout-jauge')).to.have.lengthOf(1);
@@ -51,7 +51,7 @@ describe('Acceptance | H1 - Timeout Jauge | ', function () {
     });
   });
 
-  describe('Test quand la jauge est affichée', function () {
+  describe('Test quand la jauge est affichée', function() {
 
     beforeEach(function() {
       resetTestingState();
@@ -62,9 +62,9 @@ describe('Acceptance | H1 - Timeout Jauge | ', function () {
       resetTestingState();
     })
     ;
-    describe('Sauvegarde du temps passé | ', function () {
+    describe('Sauvegarde du temps passé | ', function() {
 
-      it('Si l\'utilisateur valide, demande la sauvegarde du temps restant en secondes', function () {
+      it('Si l\'utilisateur valide, demande la sauvegarde du temps restant en secondes', function() {
         visitTimedChallenge();
         andThen(() => {
           const $countDown = findWithAssert('.timeout-jauge-remaining');
@@ -80,7 +80,7 @@ describe('Acceptance | H1 - Timeout Jauge | ', function () {
         });
       });
 
-      it('Si l\'utilisateur ABANDONNE, demande la sauvegarde du temps restant en secondes', function () {
+      it('Si l\'utilisateur ABANDONNE, demande la sauvegarde du temps restant en secondes', function() {
         visitTimedChallenge();
         andThen(() => {
           click(getSkipActionLink());

--- a/live/tests/acceptance/h1-timeout-jauge-test.js
+++ b/live/tests/acceptance/h1-timeout-jauge-test.js
@@ -5,14 +5,12 @@ import destroyApp from '../helpers/destroy-app';
 import {resetTestingState, bodyOfLastPostRequest, urlOfLastPostRequest} from '../helpers/shared-state';
 import _ from 'pix-live/utils/lodash-custom';
 
-
 function getValidateActionLink() {
   return $('.challenge-actions__action-validate');
 }
 function getSkipActionLink() {
   return $('.challenge-actions__action-skip');
 }
-
 
 function visitTimedChallenge() {
   visit(TIMED_CHALLENGE_URI);

--- a/live/tests/acceptance/h2-page-warning-timee-test.js
+++ b/live/tests/acceptance/h2-page-warning-timee-test.js
@@ -91,5 +91,4 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function() {
     });
   });
 
-
 });

--- a/live/tests/acceptance/h2-page-warning-timee-test.js
+++ b/live/tests/acceptance/h2-page-warning-timee-test.js
@@ -7,38 +7,38 @@ const TIMED_CHALLENGE_URL = '/assessments/ref_assessment_id/challenges/ref_qcm_c
 const NOT_TIMED_CHALLENGE_URL = '/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id';
 const CHALLENGE_ITEM_WARNING_BUTTON = '.challenge-item-warning button';
 
-describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
+describe('Acceptance | h2 - Warning prochaine page timée  | ', function() {
 
   let application;
 
-  beforeEach(function () {
+  beforeEach(function() {
     application = startApp();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     destroyApp(application);
   });
 
-  describe('h2- Test affichage ou non de la page avec le warning', function () {
+  describe('h2- Test affichage ou non de la page avec le warning', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       visit(TIMED_CHALLENGE_URL);
     });
 
     //XXX: Deux cas car on test aussi une absence d'affichage
-    it('h2.1- doit cacher le contenu du challenge si l\'épreuve est timée mais l\'afficher dans le cas contraire ', async function () {
+    it('h2.1- doit cacher le contenu du challenge si l\'épreuve est timée mais l\'afficher dans le cas contraire ', async function() {
       expect($('.challenge-statement')).to.have.lengthOf(0);
       await visit(NOT_TIMED_CHALLENGE_URL);
       expect($('.challenge-statement')).to.have.lengthOf(1);
     });
 
-    it('h2.2- doit afficher le warning si l\'épreuve est timée mais ne pas l\'afficher dans le cas contraire ', async function () {
+    it('h2.2- doit afficher le warning si l\'épreuve est timée mais ne pas l\'afficher dans le cas contraire ', async function() {
       expect($('.challenge-item-warning')).to.have.lengthOf(1);
       await visit(NOT_TIMED_CHALLENGE_URL);
       expect($('.challenge-item-warning')).to.have.lengthOf(0);
     });
 
-    it('h2.3- vérifier que le timer n\'est pas démarré automatiquement lorsque l\'épreuve est timée', function () {
+    it('h2.3- vérifier que le timer n\'est pas démarré automatiquement lorsque l\'épreuve est timée', function() {
       expect($('.timeout-jauge')).to.have.lengthOf(0);
     });
 
@@ -48,22 +48,22 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
 
   });
 
-  describe('h2-Test comportement lorsque le bouton de confirmation est cliqué', function () {
+  describe('h2-Test comportement lorsque le bouton de confirmation est cliqué', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       visit(TIMED_CHALLENGE_URL);
       click(CHALLENGE_ITEM_WARNING_BUTTON);
     });
 
-    it('h2.1- vérifier que le warning est caché ', function () {
+    it('h2.1- vérifier que le warning est caché ', function() {
       expect($(CHALLENGE_ITEM_WARNING_BUTTON)).to.have.lengthOf(0);
     });
 
-    it('h2.2- vérifier que le contenu de l\'épreuve est affiché', function () {
+    it('h2.2- vérifier que le contenu de l\'épreuve est affiché', function() {
       expect($('.challenge-statement').css('display')).to.contains('block');
     });
 
-    it('h2.3- vérifier que le timer est démarré ', function () {
+    it('h2.3- vérifier que le timer est démarré ', function() {
       expect($('.timeout-jauge')).to.have.lengthOf(1);
     });
 
@@ -73,12 +73,12 @@ describe('Acceptance | h2 - Warning prochaine page timée  | ', function () {
 
   });
 
-  describe('h2-Affichage de la page warning pour 2 epreuves timées du même types (suite au bug US-424)', function () {
+  describe('h2-Affichage de la page warning pour 2 epreuves timées du même types (suite au bug US-424)', function() {
 
     const ASSESSMENT_WITH_TWO_TIMED_CHALLENGE = '/assessments/ref_timed_challenge_assessment_id/challenges/ref_timed_challenge_id';
     const PASS_BUTTON = '.challenge-actions__action-skip';
 
-    it('doit afficher la \'warning page\' même si deux epreuves du même type et timées s\'enchaînent', async function () {
+    it('doit afficher la \'warning page\' même si deux epreuves du même type et timées s\'enchaînent', async function() {
       // given
       await visit(ASSESSMENT_WITH_TWO_TIMED_CHALLENGE);
       await click(CHALLENGE_ITEM_WARNING_BUTTON);

--- a/live/tests/acceptance/j1-compare-answer-solution-test.js
+++ b/live/tests/acceptance/j1-compare-answer-solution-test.js
@@ -8,7 +8,7 @@ function charCount(str) {
   return str.match(/[a-zA-Z]/g).length;
 }
 
-describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', function () {
+describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', function() {
 
   const RESULT_URL = '/assessments/ref_assessment_id/results';
   const COMPARISON_MODAL_URL = '/assessments/ref_assessment_id/results/compare/ref_answer_qcm_id/1';
@@ -22,16 +22,16 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  describe('j1.1 Affiche sur la ligne de l\'épreuve le mot REPONSE pour un QCM sur l\'écran des résultats', function () {
-    it('j1.1.1 il l\'affiche pour un QCM, un QCU mais pas pour les autres types d\'épreuves' , async function () {
+  describe('j1.1 Affiche sur la ligne de l\'épreuve le mot REPONSE pour un QCM sur l\'écran des résultats', function() {
+    it('j1.1.1 il l\'affiche pour un QCM, un QCU mais pas pour les autres types d\'épreuves' , async function() {
       await visit(RESULT_URL);
       expect($('.result-item:eq(0) .js-correct-answer').text()).to.contain('RÉPONSE'); //QCM
       expect($('.result-item:eq(1) .js-correct-answer').text()).to.contain('RÉPONSE'); //QCU
@@ -41,15 +41,15 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
     });
   });
 
-  describe('j1.2 Accès à la modale', function () {
-    it('j1.2.2 On peut accèder directement à la modale via URL et fermer la modale' , async function () {
+  describe('j1.2 Accès à la modale', function() {
+    it('j1.2.2 On peut accèder directement à la modale via URL et fermer la modale' , async function() {
       await visit(COMPARISON_MODAL_URL);
       expect($('.comparison-window')).to.have.lengthOf(1);
       // XXX test env needs the modal to be closed manually
       await click('.close-button-container');
       expect($('.comparison-window')).to.have.lengthOf(0);
     });
-    it('j1.2.1 Si on clique sur REPONSE la modale s\'ouvre' , async function () {
+    it('j1.2.1 Si on clique sur REPONSE la modale s\'ouvre' , async function() {
       await visit(RESULT_URL);
       expect($('.comparison-window')).to.have.lengthOf(0);
       await click('.result-item__correction__button');
@@ -60,9 +60,9 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
     });
   });
 
-  describe('j1.3 Contenu de la modale : résultat & instruction', function () {
+  describe('j1.3 Contenu de la modale : résultat & instruction', function() {
 
-    it('j1.3.1 Vérification de l\'index, ainsi que l\'image et le texte du résultat dans le header', async function () {
+    it('j1.3.1 Vérification de l\'index, ainsi que l\'image et le texte du résultat dans le header', async function() {
 
       await visit(RESULT_URL);
       expect($(INDEX_OF_RESULT_SELECTOR)).to.have.lengthOf(0);
@@ -79,7 +79,7 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
       expect($('.comparison-window')).to.have.lengthOf(0);
     });
 
-    it('j1.3.2 Vérification de la présence de l\'instruction, texte et image', async function () {
+    it('j1.3.2 Vérification de la présence de l\'instruction, texte et image', async function() {
 
       await visit(RESULT_URL);
       expect($(TEXT_OF_INSTRUCTION_SELECTOR)).to.exist;

--- a/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
+++ b/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', function () {
+describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', function() {
 
   const RESULT_URL = '/assessments/ref_assessment_id/results';
   const COMPARISON_MODAL_URL = '/assessments/ref_assessment_id/results/compare/ref_answer_qroc_id/4';
@@ -18,25 +18,25 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
 
   let application;
 
-  before(function () {
+  before(function() {
     application = startApp();
   });
 
-  after(function () {
+  after(function() {
     destroyApp(application);
   });
 
-  describe('j2.1 Depuis la page résultat', function () {
+  describe('j2.1 Depuis la page résultat', function() {
 
-    before(function () {
+    before(function() {
       visit(RESULT_URL);
     });
 
-    it('affiche le lien REPONSE vers la modale depuis l\'ecran des resultats pour un QROC', async function () {
+    it('affiche le lien REPONSE vers la modale depuis l\'ecran des resultats pour un QROC', async function() {
       expect($('.result-item .js-correct-answer').text()).to.contain('RÉPONSE');
     });
 
-    it('On n\'affiche pas encore la modale, ni son contenu', async function () {
+    it('On n\'affiche pas encore la modale, ni son contenu', async function() {
       expect($('.comparison-window')).to.have.lengthOf(0);
       expect($(INDEX_OF_RESULT_SELECTOR)).to.have.lengthOf(0);
       expect($(SVG_OF_RESULT_SELECTOR)).to.have.lengthOf(0);
@@ -45,34 +45,34 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
 
   });
 
-  describe('j2.2 Contenu de la modale de correction pour un QROC', function () {
+  describe('j2.2 Contenu de la modale de correction pour un QROC', function() {
 
-    before(function () {
+    before(function() {
       visit(COMPARISON_MODAL_URL);
     });
 
-    it('possible d\'accéder à la modale depuis l\'URL', async function () {
+    it('possible d\'accéder à la modale depuis l\'URL', async function() {
       expect($('.comparison-window')).to.have.lengthOf(1);
     });
 
-    it('contient un header', async function () {
+    it('contient un header', async function() {
       expect($(INDEX_OF_RESULT_SELECTOR).text().replace(/\n/g, '').trim()).to.equal('4');
       expect($(SVG_OF_RESULT_SELECTOR)).to.have.lengthOf(1);
     });
 
-    it('contient une instruction', async function () {
+    it('contient une instruction', async function() {
       expect($(TEXT_OF_INSTRUCTION_SELECTOR)).to.have.lengthOf(1);
     });
 
-    it('contient une zone de correction', async function () {
+    it('contient une zone de correction', async function() {
       expect($(CORRECTION_BOX_QROC)).to.have.lengthOf(1);
     });
 
-    it('contient une zone reservé au feedback panel', async function () {
+    it('contient une zone reservé au feedback panel', async function() {
       expect($(FEEDBACK_PANEL)).to.have.lengthOf(1);
     });
 
-    it('on peut fermer la modale', async function () {
+    it('on peut fermer la modale', async function() {
       await click('.close-button-container');
       expect($('.comparison-window')).to.have.lengthOf(0);
     });

--- a/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
+++ b/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
@@ -8,7 +8,6 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
   const RESULT_URL = '/assessments/ref_assessment_id/results';
   const COMPARISON_MODAL_URL = '/assessments/ref_assessment_id/results/compare/ref_answer_qroc_id/4';
 
-
   const TEXT_OF_RESULT_SELECTOR = '.comparison-window__header .comparison-window__title .comparison-window__title-text';
   const SVG_OF_RESULT_SELECTOR = '.comparison-window__header .comparison-window__title svg';
   const INDEX_OF_RESULT_SELECTOR = '.comparison-window__header .comparison-window__result-item-index';

--- a/live/tests/acceptance/l1-signaler-une-epreuve-test.js
+++ b/live/tests/acceptance/l1-signaler-une-epreuve-test.js
@@ -5,7 +5,7 @@ import destroyApp from '../helpers/destroy-app';
 
 const FEEDBACK_FORM = '.feedback-panel__form';
 
-describe('Acceptance | Signaler une épreuve', function () {
+describe('Acceptance | Signaler une épreuve', function() {
 
   let application;
 
@@ -23,13 +23,13 @@ describe('Acceptance | Signaler une épreuve', function () {
     expect(find(FEEDBACK_FORM)).to.have.lengthOf(1);
   }
 
-  describe('l1.1 Depuis une epreuve', function () {
+  describe('l1.1 Depuis une epreuve', function() {
 
-    before(function () {
+    before(function() {
       application = startApp();
     });
 
-    after(function () {
+    after(function() {
       destroyApp(application);
     });
 
@@ -62,13 +62,13 @@ describe('Acceptance | Signaler une épreuve', function () {
     });
   });
 
-  describe('l1.2 Depuis la fenêtre de comparaison', function () {
+  describe('l1.2 Depuis la fenêtre de comparaison', function() {
 
-    before(function () {
+    before(function() {
       application = startApp();
     });
 
-    after(function () {
+    after(function() {
       destroyApp(application);
     });
 

--- a/live/tests/helpers/shared-state.js
+++ b/live/tests/helpers/shared-state.js
@@ -1,5 +1,4 @@
 
-
 export function resetTestingState() {
   localStorage.clear();
 }
@@ -15,5 +14,4 @@ export function urlOfLastPostRequest() {
 export function bodyOfLastPostRequest() {
   return JSON.parse(JSON.parse(localStorage.getItem('miragePostUrl')).body);
 }
-
 

--- a/live/tests/integration/components/challenge-statement-test.js
+++ b/live/tests/integration/components/challenge-statement-test.js
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | ChallengeStatement', function () {
+describe('Integration | Component | ChallengeStatement', function() {
 
   setupComponentTest('challenge-statement', {
     integration: true
@@ -23,10 +23,10 @@ describe('Integration | Component | ChallengeStatement', function () {
    * ------------------------------------------------
    */
 
-  describe('Instruction section:', function () {
+  describe('Instruction section:', function() {
 
     // Inspired from: https://github.com/emberjs/ember-mocha/blob/0790a78d7464655fee0c103d2fa960fa53a056ca/tests/setup-component-test-test.js#L118-L122
-    it('should render challenge instruction if it exists', function () {
+    it('should render challenge instruction if it exists', function() {
       // given
       addChallengeToContext(this, {
         instruction: 'La consigne de mon test'
@@ -39,7 +39,7 @@ describe('Integration | Component | ChallengeStatement', function () {
       expect(Ember.$.trim(this.$('.challenge-statement__instruction').text())).to.equal('La consigne de mon test');
     });
 
-    it('should not render challenge instruction if it does not exist', function () {
+    it('should not render challenge instruction if it does not exist', function() {
       // given
       addChallengeToContext(this, {});
 
@@ -57,8 +57,8 @@ describe('Integration | Component | ChallengeStatement', function () {
    * ------------------------------------------------
    */
 
-  describe('Illustration section', function () {
-    it('should display challenge illustration (and alt) if it exists', function () {
+  describe('Illustration section', function() {
+    it('should display challenge illustration (and alt) if it exists', function() {
       // given
       addChallengeToContext(this, {
         illustrationUrl: 'http://challenge.illustration.url'
@@ -73,7 +73,7 @@ describe('Integration | Component | ChallengeStatement', function () {
       expect($illustration.prop('alt')).to.equal('Illustration de l\'épreuve');
     });
 
-    it('should not display challenge illustration if it does not exist', function () {
+    it('should not display challenge illustration if it does not exist', function() {
       // given
       addChallengeToContext(this, {});
 
@@ -90,9 +90,9 @@ describe('Integration | Component | ChallengeStatement', function () {
    * ------------------------------------------------
    */
 
-  describe('Attachments section:', function () {
+  describe('Attachments section:', function() {
 
-    describe('if challenge has no file', function () {
+    describe('if challenge has no file', function() {
 
       it('should not display attachements section', function() {
         addChallengeToContext(this, {
@@ -108,9 +108,9 @@ describe('Integration | Component | ChallengeStatement', function () {
       });
     });
 
-    describe('if challenge has only one file', function () {
+    describe('if challenge has only one file', function() {
 
-      it('should display only one link button', function () {
+      it('should display only one link button', function() {
         // given
         addChallengeToContext(this, {
           attachments: ['http://challenge.file.url'],
@@ -130,7 +130,7 @@ describe('Integration | Component | ChallengeStatement', function () {
 
     });
 
-    describe('if challenge has multiple files', function () {
+    describe('if challenge has multiple files', function() {
 
       const file1 = 'http://file.1.docx';
       const file2 = 'file.2.odt';

--- a/live/tests/integration/components/comparison-window-test.js
+++ b/live/tests/integration/components/comparison-window-test.js
@@ -7,19 +7,19 @@ import Ember from 'ember';
 const FEEDBACK_FORM = '.feedback-panel__view--form';
 const LINK_OPEN_FORM = '.feedback-panel__view--link';
 
-describe('Integration | Component | comparison-window', function () {
+describe('Integration | Component | comparison-window', function() {
 
   setupComponentTest('comparison-window', {
     integration: true
   });
 
-  describe('rendering', function () {
+  describe('rendering', function() {
 
     let answer;
     let challenge;
     let solution;
 
-    beforeEach(function () {
+    beforeEach(function() {
       answer = Ember.Object.create({ value: '1,2', result: 'ko' });
       challenge = Ember.Object.create({
         instruction: 'This is the instruction',
@@ -37,35 +37,35 @@ describe('Integration | Component | comparison-window', function () {
       this.set('index', '3');
     });
 
-    it('renders', function () {
+    it('renders', function() {
       // when
       this.render(hbs`{{comparison-window answer=answer challenge=challenge solution=solution index=index}}`);
       // then
       expect(this.$()).to.have.lengthOf(1);
     });
 
-    it('should render challenge result in the header', function () {
+    it('should render challenge result in the header', function() {
       // when
       this.render(hbs`{{comparison-window answer=answer challenge=challenge solution=solution index=index}}`);
       // then
       expect(this.$('.comparison-window__header')).to.have.length(1);
     });
 
-    it('should render challenge instruction', function () {
+    it('should render challenge instruction', function() {
       // when
       this.render(hbs`{{comparison-window answer=answer challenge=challenge solution=solution index=index}}`);
       // then
       expect(this.$('.challenge-statement__instruction')).to.have.length(1);
     });
 
-    it('should not render corrected answers when challenge has no type', function () {
+    it('should not render corrected answers when challenge has no type', function() {
       // when
       this.render(hbs`{{comparison-window answer=answer challenge=challenge solution=solution index=index}}`);
       // then
       expect(this.$('.comparison-window__corrected-answers')).to.have.length(0);
     });
 
-    it('should render corrected answers when challenge type is QROC', function () {
+    it('should render corrected answers when challenge type is QROC', function() {
       // given
       challenge = Ember.Object.create({ type: 'QROC' });
       this.set('challenge', challenge);
@@ -75,7 +75,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(this.$('.comparison-window__corrected-answers--qroc')).to.have.length(1);
     });
 
-    it('should render corrected answers when challenge type is QROCM-ind', function () {
+    it('should render corrected answers when challenge type is QROCM-ind', function() {
       // given
       challenge = Ember.Object.create({ type: 'QROCM-ind', proposals: '' });
       solution = Ember.Object.create({ value: '' });
@@ -87,7 +87,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(this.$('.comparison-window__corrected-answers--qrocm')).to.have.length(1);
     });
 
-    it('should render corrected answers when challenge type is QCM', function () {
+    it('should render corrected answers when challenge type is QCM', function() {
       // given
       challenge = Ember.Object.create({ type: 'QCM' });
       this.set('challenge', challenge);
@@ -97,7 +97,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(this.$('.qcm-solution-panel')).to.have.length(1);
     });
 
-    it('should render a feedback panel already opened', function () {
+    it('should render a feedback panel already opened', function() {
       //when
       this.render(hbs`{{comparison-window answer=answer challenge=challenge solution=solution index=index}}`);
       //then
@@ -106,7 +106,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(this.$(LINK_OPEN_FORM)).to.have.lengthOf(0);
     });
 
-    it('should have a max width of 900px and a margin auto in order to quit by clicking beside', function () {
+    it('should have a max width of 900px and a margin auto in order to quit by clicking beside', function() {
       // when
       this.render(hbs`{{comparison-window answer challenge solution index}}`);
       // then

--- a/live/tests/integration/components/corner-ribbon-test.js
+++ b/live/tests/integration/components/corner-ribbon-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { setupComponentTest, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | CornerRibbonComponent', function () {
+describe('Integration | Component | CornerRibbonComponent', function() {
 
   setupComponentTest('corner-ribbon', {
     integration: true

--- a/live/tests/integration/components/course-item-test.js
+++ b/live/tests/integration/components/course-item-test.js
@@ -131,5 +131,4 @@ describe('Integration | Component | course item', function() {
 
   });
 
-
 });

--- a/live/tests/integration/components/course-item-test.js
+++ b/live/tests/integration/components/course-item-test.js
@@ -4,20 +4,20 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | course item', function () {
+describe('Integration | Component | course item', function() {
 
   setupComponentTest('course-item', {
     integration: true
   });
 
-  describe('rendering:', function () {
+  describe('rendering:', function() {
 
-    it('renders', function () {
+    it('renders', function() {
       this.render(hbs`{{course-item}}`);
       expect(this.$()).to.have.length(1);
     });
 
-    it('should render course picture if it is defined', function () {
+    it('should render course picture if it is defined', function() {
       // given
       const course = Ember.Object.create({ imageUrl: 'image_src' });
       this.set('course', course);
@@ -30,7 +30,7 @@ describe('Integration | Component | course item', function () {
       expect($picture.attr('src')).to.equal(course.get('imageUrl'));
     });
 
-    it('should render default picture if course picture is not defined', function () {
+    it('should render default picture if course picture is not defined', function() {
       // given
       const course = Ember.Object.create();
       this.set('course', course);
@@ -43,7 +43,7 @@ describe('Integration | Component | course item', function () {
       expect($picture.attr('src')).to.equal('/images/course-default-image.png');
     });
 
-    it('should render course name', function () {
+    it('should render course name', function() {
       // given
       const course = Ember.Object.create({ name: 'name_value'});
       this.set('course', course);
@@ -56,7 +56,7 @@ describe('Integration | Component | course item', function () {
       expect($name.text().trim()).to.equal(course.get('name'));
     });
 
-    it('should render course description', function () {
+    it('should render course description', function() {
       // given
       const course = Ember.Object.create({ description: 'description_value'});
       this.set('course', course);
@@ -69,7 +69,7 @@ describe('Integration | Component | course item', function () {
       expect($description.text().trim()).to.equal(course.get('description'));
     });
 
-    it('should render the number of challenges', function () {
+    it('should render the number of challenges', function() {
       // given
       const course = Ember.Object.create({ challenges: ['c1', 'c2', 'c3', 'c4']});
       this.set('course', course);
@@ -82,7 +82,7 @@ describe('Integration | Component | course item', function () {
       expect($nbChallenges.text().trim()).to.equal('4 épreuves');
     });
 
-    it('should render a link to begin the course', function () {
+    it('should render a link to begin the course', function() {
       // given
       const course = Ember.Object.create();
       this.set('course', course);
@@ -95,7 +95,7 @@ describe('Integration | Component | course item', function () {
       expect($startAction.text().trim()).to.equal('Commencer');
     });
 
-    it('should render a link containing the course name in title', function () {
+    it('should render a link containing the course name in title', function() {
       // given
       const course = Ember.Object.create({ name: 'My course'});
       this.set('course', course);
@@ -109,9 +109,9 @@ describe('Integration | Component | course item', function () {
     });
   });
 
-  describe('behaviours:', function () {
+  describe('behaviours:', function() {
 
-    it('should send action "startCourse" with course in argument when clicking on "start" button', function () {
+    it('should send action "startCourse" with course in argument when clicking on "start" button', function() {
       // given
       const course = Ember.Object.create({ id: 'course_id'});
       this.set('course', course);

--- a/live/tests/integration/components/course-list-test.js
+++ b/live/tests/integration/components/course-list-test.js
@@ -4,20 +4,20 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | course list', function () {
+describe('Integration | Component | course list', function() {
 
   setupComponentTest('course-list', {
     integration: true
   });
 
-  describe('rendering:', function () {
+  describe('rendering:', function() {
 
-    it('renders', function () {
+    it('renders', function() {
       this.render(hbs`{{course-list}}`);
       expect(this.$()).to.have.length(1);
     });
 
-    it('should render as many course-item as courses elements', function () {
+    it('should render as many course-item as courses elements', function() {
       // given
       const courses = [
         Ember.Object.create({ id: '1' }),

--- a/live/tests/integration/components/feature-item-test.js
+++ b/live/tests/integration/components/feature-item-test.js
@@ -21,7 +21,7 @@ describe('Integration | Component | feature item', function() {
     expect(this.$()).to.have.length(1);
   });
 
-  it('should render an icon', function () {
+  it('should render an icon', function() {
     this.set('feature', feature);
     this.render(hbs`{{feature-item feature=feature}}`);
 
@@ -30,7 +30,7 @@ describe('Integration | Component | feature item', function() {
     expect($icon.attr('src')).to.equal('images/icon-coucou.svg');
   });
 
-  it('should render an title', function () {
+  it('should render an title', function() {
     this.set('feature', feature);
     this.render(hbs`{{feature-item feature=feature}}`);
 
@@ -39,7 +39,7 @@ describe('Integration | Component | feature item', function() {
     expect($title.text().trim()).to.equal(feature.title);
   });
 
-  it('should render an description', function () {
+  it('should render an description', function() {
     this.set('feature', feature);
     this.render(hbs`{{feature-item feature=feature}}`);
 

--- a/live/tests/integration/components/feature-list-test.js
+++ b/live/tests/integration/components/feature-list-test.js
@@ -3,18 +3,18 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | feature list', function () {
+describe('Integration | Component | feature list', function() {
 
   setupComponentTest('feature-list', {
     integration: true
   });
 
-  it('renders', function () {
+  it('renders', function() {
     this.render(hbs`{{feature-list}}`);
     expect(this.$()).to.have.length(1);
   });
 
-  it('should always render 5 feature-items', function () {
+  it('should always render 5 feature-items', function() {
     // when
     this.render(hbs`{{feature-list}}`);
 

--- a/live/tests/integration/components/feedback-panel-test.js
+++ b/live/tests/integration/components/feedback-panel-test.js
@@ -43,15 +43,15 @@ function setContent(component, content) {
   $content.change();
 }
 
-describe('Integration | Component | feedback-panel', function () {
+describe('Integration | Component | feedback-panel', function() {
 
   setupComponentTest('feedback-panel', {
     integration: true
   });
 
-  describe('Default rendering', function () {
+  describe('Default rendering', function() {
 
-    it('should display the feedback Panel', function () {
+    it('should display the feedback Panel', function() {
       // when
       this.render(hbs`{{feedback-panel}}`);
       // then
@@ -61,21 +61,21 @@ describe('Integration | Component | feedback-panel', function () {
 
   });
 
-  describe('Link view (available only when form is closed by default)', function () {
+  describe('Link view (available only when form is closed by default)', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.render(hbs`{{feedback-panel}}`);
     });
 
-    it('should display only the "link" view', function () {
+    it('should display only the "link" view', function() {
       expectLinkViewToBeVisible(this);
     });
 
-    it('the link label should be "Signaler un problème"', function () {
+    it('the link label should be "Signaler un problème"', function() {
       expect(this.$(OPEN_LINK).text()).to.contains('Signaler un problème');
     });
 
-    it('clicking on the open link should hide the "link" view and display the "form" view', function () {
+    it('clicking on the open link should hide the "link" view and display the "form" view', function() {
       // when
       this.$(OPEN_LINK).click();
       // then
@@ -84,7 +84,7 @@ describe('Integration | Component | feedback-panel', function () {
 
   });
 
-  describe('Form view', function () {
+  describe('Form view', function() {
 
     const storeStub = Ember.Service.extend({
       createRecord() {
@@ -104,7 +104,7 @@ describe('Integration | Component | feedback-panel', function () {
     let saveMethodBody;
     let saveMethodUrl;
 
-    beforeEach(function () {
+    beforeEach(function() {
       // configure answer & cie. model object
       const assessment = Ember.Object.extend({ id: 'assessment_id' }).create();
       const challenge = Ember.Object.extend({ id: 'challenge_id' }).create();
@@ -124,29 +124,29 @@ describe('Integration | Component | feedback-panel', function () {
       this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=false}}`);
     });
 
-    it('should display only the "form" view', function () {
+    it('should display only the "form" view', function() {
       expectFormViewToBeVisible(this);
     });
 
-    it('should contain email input field', function () {
+    it('should contain email input field', function() {
       const $email = this.$('input.feedback-panel__field--email');
       expect($email).to.have.lengthOf(1);
       expect($email.attr('placeholder')).to.equal('Votre email (optionnel)');
     });
 
-    it('should contain content textarea field', function () {
+    it('should contain content textarea field', function() {
       const $password = this.$('textarea.feedback-panel__field--content');
       expect($password).to.have.lengthOf(1);
       expect($password.attr('placeholder')).to.equal('Votre message');
     });
 
-    it('should contain "send" button with label "Envoyer" and placeholder "Votre email (optionnel)"', function () {
+    it('should contain "send" button with label "Envoyer" and placeholder "Votre email (optionnel)"', function() {
       const $buttonSend = this.$(BUTTON_SEND);
       expect($buttonSend).to.have.lengthOf(1);
       expect($buttonSend.text()).to.equal('Envoyer');
     });
 
-    it('clicking on "send" button should save the feedback into the store / API and display the "mercix" view', function () {
+    it('clicking on "send" button should save the feedback into the store / API and display the "mercix" view', function() {
       // given
       const EMAIL_VALUE = 'frere-jacques@gai-mail.com';
       setEmail(this, EMAIL_VALUE);
@@ -170,16 +170,16 @@ describe('Integration | Component | feedback-panel', function () {
       });
     });
 
-    it('should not contain "cancel" button if the feedback form is opened by default', function () {
+    it('should not contain "cancel" button if the feedback form is opened by default', function() {
       // then
       const $buttonCancel = this.$(BUTTON_CANCEL);
       expect($buttonCancel).to.have.lengthOf(0);
     });
   });
 
-  describe('#Cancel Button management', function () {
+  describe('#Cancel Button management', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       // configure answer & cie. model object
       const assessment = Ember.Object.extend({ id: 'assessment_id' }).create();
       const challenge = Ember.Object.extend({ id: 'challenge_id' }).create();
@@ -216,7 +216,7 @@ describe('Integration | Component | feedback-panel', function () {
       expect(this.$(BUTTON_CANCEL)).to.have.lengthOf(1);
     });
 
-    it('should contain "cancel" button with label "Annuler" and placeholder "Votre message"', function () {
+    it('should contain "cancel" button with label "Annuler" and placeholder "Votre message"', function() {
       // given
       this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
 
@@ -229,7 +229,7 @@ describe('Integration | Component | feedback-panel', function () {
       expect($buttonCancel.text().trim()).to.equal('Annuler');
     });
 
-    it('clicking on "cancel" button should close the "form" view and and display the "link" view', function () {
+    it('clicking on "cancel" button should close the "form" view and and display the "link" view', function() {
       // given
       this.render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
 
@@ -242,9 +242,9 @@ describe('Integration | Component | feedback-panel', function () {
 
   });
 
-  describe('Error management', function () {
+  describe('Error management', function() {
 
-    it('should display error if "content" is empty', function () {
+    it('should display error if "content" is empty', function() {
       // given
       this.render(hbs`{{feedback-panel collapsible=false}}`);
 
@@ -256,7 +256,7 @@ describe('Integration | Component | feedback-panel', function () {
       expectFormViewToBeVisible(this);
     });
 
-    it('should display error if "content" is blank', function () {
+    it('should display error if "content" is blank', function() {
       // given
       this.render(hbs`{{feedback-panel collapsible=false}}`);
       setContent(this, '');
@@ -269,7 +269,7 @@ describe('Integration | Component | feedback-panel', function () {
       expectFormViewToBeVisible(this);
     });
 
-    it('should display error if "email" is set but invalid', function () {
+    it('should display error if "email" is set but invalid', function() {
       // given
       this.render(hbs`{{feedback-panel collapsible=false}}`);
       setEmail(this, 'wrong_email');
@@ -282,7 +282,7 @@ describe('Integration | Component | feedback-panel', function () {
       expectFormViewToBeVisible(this);
     });
 
-    it('should not display error if "form" view (with error) was closed and re-opened', function () {
+    it('should not display error if "form" view (with error) was closed and re-opened', function() {
       // given
       this.render(hbs`{{feedback-panel}}`);
 

--- a/live/tests/integration/components/follower-form-test.js
+++ b/live/tests/integration/components/follower-form-test.js
@@ -8,7 +8,6 @@ import wait from 'ember-test-helpers/wait';
 const BUTTON_SEND = '.follower-form__button';
 const INPUT_EMAIL = '.follower-email';
 
-
 describe('Integration | Component | follower form', function() {
 
   setupComponentTest('follower-form', {
@@ -80,7 +79,6 @@ describe('Integration | Component | follower form', function() {
         });
       }
     });
-
 
     beforeEach(function() {
       isSaveMethodCalled = false;

--- a/live/tests/integration/components/follower-form-test.js
+++ b/live/tests/integration/components/follower-form-test.js
@@ -20,7 +20,7 @@ describe('Integration | Component | follower form', function() {
     expect(this.$()).to.have.length(1);
   });
 
-  describe('Test Component form', function(){
+  describe('Test Component form', function() {
     it('should render submit button', function () {
       //When
       this.render(hbs`{{follower-form}}`);

--- a/live/tests/integration/components/follower-form-test.js
+++ b/live/tests/integration/components/follower-form-test.js
@@ -21,14 +21,14 @@ describe('Integration | Component | follower form', function() {
   });
 
   describe('Test Component form', function() {
-    it('should render submit button', function () {
+    it('should render submit button', function() {
       //When
       this.render(hbs`{{follower-form}}`);
       //then
       expect(this.$('.follower-form__button').length).to.equal(1);
     });
 
-    it('should return true if input exist', function () {
+    it('should return true if input exist', function() {
       //When
       this.render(hbs`{{follower-form}}`);
       //then
@@ -41,7 +41,7 @@ describe('Integration | Component | follower form', function() {
    FIXME: the tests below do not respect the Ember Way and will not be ok for Ember 2.12 (cf. commit #8d28dd) but we can not fix them now :-(
   */
 
-  describe('Form view', function () {
+  describe('Form view', function() {
 
     let isSaveMethodCalled;
     let saveMethodBody;
@@ -82,13 +82,13 @@ describe('Integration | Component | follower form', function() {
     });
 
 
-    beforeEach(function () {
+    beforeEach(function() {
       isSaveMethodCalled = false;
       saveMethodBody = null;
       saveMethodUrl = null;
     });
 
-    it('clicking on "send" button should save the email of the follower', function () {
+    it('clicking on "send" button should save the email of the follower', function() {
       // given
       // stub store service
       this.register('service:store', storeStub);
@@ -114,7 +114,7 @@ describe('Integration | Component | follower form', function() {
       });
     });
 
-    it('clicking on "send" button should not save the email of the follower cause its already saved', function () {
+    it('clicking on "send" button should not save the email of the follower cause its already saved', function() {
       // given
       this.register('service:store', storeStubRejection);
 

--- a/live/tests/integration/components/navbar-header-test.js
+++ b/live/tests/integration/components/navbar-header-test.js
@@ -17,16 +17,16 @@ describe('Integration | Component | navbar-header', function() {
     expect(this.$()).to.have.length(1);
   });
 
-  it('should display the Pix logo', function () {
+  it('should display the Pix logo', function() {
     expect(this.$('.navbar-header-logo')).to.have.lengthOf(1);
     expect(this.$('.pix-logo')).to.have.lengthOf(1);
   });
 
-  it('should display a link to "project" page', function () {
+  it('should display a link to "project" page', function() {
     expect(this.$('.navbar-header-links__link--project')).to.have.lengthOf(1);
   });
 
-  it('should display a link to "referential" page', function () {
+  it('should display a link to "referential" page', function() {
     expect(this.$('.navbar-header-links__link--competences')).to.have.lengthOf(1);
   });
 

--- a/live/tests/integration/components/pix-logo-test.js
+++ b/live/tests/integration/components/pix-logo-test.js
@@ -9,7 +9,7 @@ describe('Integration | Component | pix logo', function() {
     integration: true
   });
 
-  beforeEach(function () {
+  beforeEach(function() {
     this.render(hbs`{{pix-logo}}`);
   });
 
@@ -17,19 +17,19 @@ describe('Integration | Component | pix logo', function() {
     expect(this.$()).to.have.lengthOf(1);
   });
 
-  it('should display the logo', function () {
+  it('should display the logo', function() {
     expect(this.$('.pix-logo__image').attr('src')).to.equal('/images/pix-logo.svg');
   });
 
-  it('should display "bêta"', function () {
+  it('should display "bêta"', function() {
     expect(this.$().text().trim()).to.equal('Bêta');
   });
 
-  it('should have a textual alternative', function () {
+  it('should have a textual alternative', function() {
     expect(this.$('.pix-logo__image').attr('alt')).to.equal('Le site officiel de PIX, version bêta');
   });
 
-  it('should have a title in the link', function () {
+  it('should have a title in the link', function() {
     expect(this.$('.pix-logo__link').attr('title')).to.equal('Lien vers la page d\'accueil de PIX');
   });
 

--- a/live/tests/integration/components/qcm-proposals-test.js
+++ b/live/tests/integration/components/qcm-proposals-test.js
@@ -3,13 +3,13 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | QcmProposals', function () {
+describe('Integration | Component | QcmProposals', function() {
 
   setupComponentTest('qcm-proposals', {
     integration: true
   });
 
-  it('renders', function () {
+  it('renders', function() {
     this.render(hbs`{{qcm-proposals}}`);
     expect(this.$()).to.have.length(1);
   });

--- a/live/tests/integration/components/qcm-solution-panel-test.js
+++ b/live/tests/integration/components/qcm-solution-panel-test.js
@@ -37,21 +37,21 @@ function charCount(str) {
   return str.match(/[a-zA-Z]/g).length;
 }
 
-describe('Integration | Component | qcm-solution-panel.js', function () {
+describe('Integration | Component | qcm-solution-panel.js', function() {
 
   setupComponentTest('qcm-solution-panel', {
     integration: true
   });
 
-  describe('#Component should renders: ', function () {
+  describe('#Component should renders: ', function() {
 
-    it('Should renders', function () {
+    it('Should renders', function() {
       this.render(hbs`{{qcm-solution-panel}}`);
       expect(this.$()).to.have.length(1);
       expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(0);
     });
 
-    describe('checkbox state', function () {
+    describe('checkbox state', function() {
       const correctAnswer = {
         id: 'answer_id', assessment, challenge, value: '2,4'
       };
@@ -60,7 +60,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
         id: 'answer_id', assessment, challenge, value: '1,4'
       };
 
-      before(function () {
+      before(function() {
         challenge = Ember.Object.create({
           id: 'challenge_id',
           proposals: '-foo\n- bar\n- qix\n- yon',
@@ -110,7 +110,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
         expect($(LABEL_INCORRECT_AND_UNCHECKED).css('text-decoration')).to.equal(CSS_LINETHROUGH_OFF);
       });
 
-      it('QCM, Au moins l\'une des réponse correcte n\'est pas cochée', function () {
+      it('QCM, Au moins l\'une des réponse correcte n\'est pas cochée', function() {
         //Given
         answer = Ember.Object.create(unCorrectAnswer);
 
@@ -129,7 +129,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
         expect($(LABEL_CORRECT_AND_UNCHECKED).css('text-decoration')).to.equal(CSS_LINETHROUGH_OFF);
       });
 
-      it('QCM, au moins l\'une des réponse incorrecte est cochée', function () {
+      it('QCM, au moins l\'une des réponse incorrecte est cochée', function() {
         //Given
         answer = Ember.Object.create(unCorrectAnswer);
 
@@ -151,7 +151,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
 
       });
 
-      it('Aucune case à cocher n\'est cliquable', function () {
+      it('Aucune case à cocher n\'est cliquable', function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -162,7 +162,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
 
         // Then
         const size = $('.comparison-window .qcm-proposal-label__checkbox-picture').length;
-        _.times(size, function (index) {
+        _.times(size, function(index) {
           expect($('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').is(':disabled')).to.equal(true);
         });
       });

--- a/live/tests/integration/components/qcm-solution-panel-test.js
+++ b/live/tests/integration/components/qcm-solution-panel-test.js
@@ -18,7 +18,6 @@ const LABEL_INCORRECT_AND_CHECKED = '.qcm-proposal-label__oracle:eq(0)';
 const CHECKBOX_INCORRECT_AND_UNCHECKED = '.qcm-proposal-label__checkbox-picture:eq(0)';
 const LABEL_INCORRECT_AND_UNCHECKED = '.qcm-proposal-label__oracle:eq(0)';
 
-
 const CSS_BOLD_FONT_WEIGHT = '900';
 const CSS_NORMAL_FONT_WEIGHT = '400';
 

--- a/live/tests/integration/components/qcu-proposals-test.js
+++ b/live/tests/integration/components/qcu-proposals-test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | QcuProposals', function () {
+describe('Integration | Component | QcuProposals', function() {
 
   setupComponentTest('qcu-proposals', {
     integration: true
@@ -12,13 +12,13 @@ describe('Integration | Component | QcuProposals', function () {
   /* Rendering
    ----------------------------------------------------- */
 
-  describe('Rendering', function () {
+  describe('Rendering', function() {
 
     let proposals;
     let answers;
     let answerChangedHandler;
 
-    beforeEach(function () {
+    beforeEach(function() {
       proposals = ['prop 1', 'prop 2', 'prop 3'];
       answers = [false, true, false];
       answerChangedHandler = () => true;
@@ -28,7 +28,7 @@ describe('Integration | Component | QcuProposals', function () {
     // - Ember-mocha: https://github.com/emberjs/ember-mocha#setup-component-tests
     // - Ember: https://guides.emberjs.com/v2.10.0/testing/testing-components
     // -        https://guides.emberjs.com/v2.10.0/tutorial/autocomplete-component/
-    it('should render as much radio buttons as proposals', function () {
+    it('should render as much radio buttons as proposals', function() {
       // given
       this.set('proposals', proposals);
       this.set('answers', answers);

--- a/live/tests/integration/components/qcu-proposals-test.js
+++ b/live/tests/integration/components/qcu-proposals-test.js
@@ -41,8 +41,6 @@ describe('Integration | Component | QcuProposals', function() {
       expect(this.$('.proposal-text')).to.have.lengthOf(proposals.length);
     });
 
-
-
   });
 
 });

--- a/live/tests/integration/components/qcu-solution-panel-test.js
+++ b/live/tests/integration/components/qcu-solution-panel-test.js
@@ -16,7 +16,6 @@ const LABEL_INCORRECT_AND_CHECKED = '.qcu-proposal-label__oracle:eq(2)';
 const RADIO_INCORRECT_AND_UNCHECKED = '.picture-radio-proposal--qcu:eq(0)';
 const LABEL_INCORRECT_AND_UNCHECKED = '.qcu-proposal-label__oracle:eq(0)';
 
-
 const CSS_BOLD_FONT_WEIGHT = '900';
 const CSS_NORMAL_FONT_WEIGHT = '400';
 
@@ -164,9 +163,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         });
       });
 
-
     });
-
 
   });
 

--- a/live/tests/integration/components/qcu-solution-panel-test.js
+++ b/live/tests/integration/components/qcu-solution-panel-test.js
@@ -35,7 +35,7 @@ function charCount(str) {
   return str.match(/[a-zA-Z]/g).length;
 }
 
-describe('Integration | Component | qcu-solution-panel.js', function () {
+describe('Integration | Component | qcu-solution-panel.js', function() {
   setupComponentTest('qcu-solution-panel', {
     integration: true
   });
@@ -48,15 +48,15 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
     id: 'answer_id', assessment, challenge, value: '3'
   };
 
-  describe('#Component should renders: ', function () {
+  describe('#Component should renders: ', function() {
 
-    it('Should renders', function () {
+    it('Should renders', function() {
       this.render(hbs`{{qcu-solution-panel}}`);
       expect(this.$()).to.have.length(1);
       expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(0);
     });
 
-    describe('Radio state', function () {
+    describe('Radio state', function() {
 
       before(function() {
         challenge = Ember.Object.create({
@@ -72,7 +72,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
         answer = Ember.Object.create(correctAnswer);
       });
 
-      it('QCU,la réponse correcte est cochée', function () {
+      it('QCU,la réponse correcte est cochée', function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -91,7 +91,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
         expect($(LABEL_CORRECT_AND_CHECKED).css('text-decoration')).to.equal(CSS_LINETHROUGH_OFF);
       });
 
-      it('QCU, la réponse correcte n\'est pas cochée', function () {
+      it('QCU, la réponse correcte n\'est pas cochée', function() {
         //Given
         answer = Ember.Object.create(unCorrectAnswer);
 
@@ -111,7 +111,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
         expect($(LABEL_CORRECT_AND_UNCHECKED).css('text-decoration')).to.equal(CSS_LINETHROUGH_OFF);
       });
 
-      it('QCU, la réponse incorrecte n\'est pas cochée', function () {
+      it('QCU, la réponse incorrecte n\'est pas cochée', function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -128,7 +128,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
         expect($(LABEL_INCORRECT_AND_UNCHECKED).css('text-decoration')).to.equal(CSS_LINETHROUGH_OFF);
       });
 
-      it('QCU,la réponse incorrecte est cochée', function () {
+      it('QCU,la réponse incorrecte est cochée', function() {
         //Given
         answer = Ember.Object.create(unCorrectAnswer);
 
@@ -148,7 +148,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
 
       });
 
-      it('Aucune case à cocher n\'est cliquable', function () {
+      it('Aucune case à cocher n\'est cliquable', function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -159,7 +159,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
 
         // Then
         const size = $('.comparison-window .qcu-panel__proposal-radio').length;
-        _.times(size, function (index) {
+        _.times(size, function(index) {
           expect($('.comparison-window .qcu-panel__proposal-radio:eq(' + index + ')').is(':disabled')).to.equal(true);
         });
       });

--- a/live/tests/integration/components/qroc-proposal-test.js
+++ b/live/tests/integration/components/qroc-proposal-test.js
@@ -4,13 +4,13 @@ import {describe, it} from 'mocha';
 import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | QrocProposal', function () {
+describe('Integration | Component | QrocProposal', function() {
 
   setupComponentTest('qroc-proposal', {
     integration: true
   });
 
-  beforeEach(function () {
+  beforeEach(function() {
     const block = [];
     block.push(Ember.Object.create({name: 'myInput', input: 'mylabel'}));
     this.set('blocks', block);
@@ -18,12 +18,12 @@ describe('Integration | Component | QrocProposal', function () {
 
   describe('Component behavior when user fill input of challenge:', function() {
 
-    it('renders', function () {
+    it('renders', function() {
       this.render(hbs`{{qroc-proposal}}`);
       expect(this.$()).to.have.length(1);
     });
 
-    it('should display a value when a non-empty value is providing by user', function () {
+    it('should display a value when a non-empty value is providing by user', function() {
       // given
       this.set('answerValue', 'myValue');
       // when
@@ -46,7 +46,7 @@ describe('Integration | Component | QrocProposal', function () {
       {input: '', output: ''}
     ].forEach(({input, output}) => {
 
-      it(`should display '' value ${input} is providing to component`, function () {
+      it(`should display '' value ${input} is providing to component`, function() {
         // given
         this.set('answerValue', input);
         // when

--- a/live/tests/integration/components/qroc-proposal-test.js
+++ b/live/tests/integration/components/qroc-proposal-test.js
@@ -16,7 +16,7 @@ describe('Integration | Component | QrocProposal', function () {
     this.set('blocks', block);
   });
 
-  describe('Component behavior when user fill input of challenge:', function(){
+  describe('Component behavior when user fill input of challenge:', function() {
 
     it('renders', function () {
       this.render(hbs`{{qroc-proposal}}`);
@@ -33,7 +33,7 @@ describe('Integration | Component | QrocProposal', function () {
     });
   });
 
-  describe('Component behavior when user skip challenge:', function(){
+  describe('Component behavior when user skip challenge:', function() {
 
     [
       {input: 'aband', output: 'aband'},

--- a/live/tests/integration/components/qroc-solution-panel-test.js
+++ b/live/tests/integration/components/qroc-solution-panel-test.js
@@ -12,7 +12,6 @@ const SOLUTION_DISPLAY = '.correction-qroc-box__solution-text';
 const RIGHT_ANSWER_GREEN = 'rgb(19, 201, 160)';
 const NO_ANSWER_GREY = 'rgb(62, 65, 73)';
 
-
 describe('Integration | Component | qroc solution panel', function() {
 
   setupComponentTest('qroc-solution-panel', {
@@ -62,7 +61,6 @@ describe('Integration | Component | qroc solution panel', function() {
       const assessment = Ember.Object.create({ id: 'assessment_id' });
       const challenge = Ember.Object.create({ id: 'challenge_id' });
       const answer = Ember.Object.create({ id: 'answer_id', result:'ko', assessment, challenge });
-
 
       this.set('answer', answer);
       this.render(hbs`{{qroc-solution-panel answer=answer}}`);

--- a/live/tests/integration/components/qroc-solution-panel-test.js
+++ b/live/tests/integration/components/qroc-solution-panel-test.js
@@ -13,18 +13,18 @@ const RIGHT_ANSWER_GREEN = 'rgb(19, 201, 160)';
 const NO_ANSWER_GREY = 'rgb(62, 65, 73)';
 
 
-describe('Integration | Component | qroc solution panel', function () {
+describe('Integration | Component | qroc solution panel', function() {
 
   setupComponentTest('qroc-solution-panel', {
     integration: true
   });
 
-  it('renders', function () {
+  it('renders', function() {
     this.render(hbs`{{qroc-solution-panel}}`);
     expect(this.$()).to.have.length(1);
   });
 
-  it('should disabled all inputs', function () {
+  it('should disabled all inputs', function() {
     // given
     this.render(hbs`{{qroc-solution-panel}}`);
     const input = this.$('input');
@@ -32,13 +32,13 @@ describe('Integration | Component | qroc solution panel', function () {
     expect(input).to.be.disabled;
   });
 
-  describe('comparison when the answer is right', function () {
+  describe('comparison when the answer is right', function() {
 
     const assessment = Ember.Object.create({ id: 'assessment_id' });
     const challenge = Ember.Object.create({ id: 'challenge_id' });
     const answer = Ember.Object.create({ id: 'answer_id', result: 'ok', assessment, challenge });
 
-    it('should diplay the answer in bold green and not the solution', function () {
+    it('should diplay the answer in bold green and not the solution', function() {
       // given
       this.set('answer', answer);
       this.render(hbs`{{qroc-solution-panel answer=answer}}`);
@@ -56,9 +56,9 @@ describe('Integration | Component | qroc solution panel', function () {
     });
   });
 
-  describe('comparison when the answer is false', function () {
+  describe('comparison when the answer is false', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       const assessment = Ember.Object.create({ id: 'assessment_id' });
       const challenge = Ember.Object.create({ id: 'challenge_id' });
       const answer = Ember.Object.create({ id: 'answer_id', result:'ko', assessment, challenge });
@@ -68,7 +68,7 @@ describe('Integration | Component | qroc solution panel', function () {
       this.render(hbs`{{qroc-solution-panel answer=answer}}`);
     });
 
-    it('should display the false answer line-through', function () {
+    it('should display the false answer line-through', function() {
       // given
       const answerBlock = this.$(ANSWER_BLOCK);
       const answerInput = this.$(ANSWER_INPUT);
@@ -79,7 +79,7 @@ describe('Integration | Component | qroc solution panel', function () {
 
     });
 
-    it('should display the solution with an arrow and the solution in bold green', function () {
+    it('should display the solution with an arrow and the solution in bold green', function() {
       // given
       const blockSolution = this.$(SOLUTION_BLOCK);
       const blockSolutionText = this.$(SOLUTION_DISPLAY);
@@ -91,9 +91,9 @@ describe('Integration | Component | qroc solution panel', function () {
       expect(blockSolutionText.css('font-weight')).to.be.equal('bold');
     });
 
-    describe('comparison when the answer was not given', function () {
+    describe('comparison when the answer was not given', function() {
 
-      beforeEach(function () {
+      beforeEach(function() {
         const assessment = Ember.Object.create({ id: 'assessment_id' });
         const challenge = Ember.Object.create({ id: 'challenge_id' });
         const answer = Ember.Object.create({ id: 'answer_id', result: 'aband', assessment, challenge });
@@ -103,7 +103,7 @@ describe('Integration | Component | qroc solution panel', function () {
         this.render(hbs`{{qroc-solution-panel answer=answer}}`);
       });
 
-      it('should display PAS DE REPONSE in italic', function () {
+      it('should display PAS DE REPONSE in italic', function() {
         // given
         const answerBlock = this.$(ANSWER_BLOCK);
         const answerInput = this.$(ANSWER_INPUT);

--- a/live/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/live/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -16,7 +16,7 @@ const SOLUTION_TEXT = '.correction-qrocm__solution-text';
 const RIGHT_ANSWER_GREEN = 'rgb(19, 201, 160)';
 const NO_ANSWER_GREY = 'rgb(62, 65, 73)';
 
-describe('Integration | Component | qrocm solution panel', function () {
+describe('Integration | Component | qrocm solution panel', function() {
 
   setupComponentTest('qrocm-ind-solution-panel', {
     integration: true
@@ -33,18 +33,18 @@ describe('Integration | Component | qrocm solution panel', function () {
   });
   const solution = Ember.Object.create({ value: 'key1:\n- rightAnswer1\nkey2:\n- rightAnswer20\n- rightAnswer21\nkey3 :\n- rightAnswer3' });
 
-  beforeEach(function () {
+  beforeEach(function() {
     this.set('answer', answer);
     this.set('solution', solution);
     this.set('challenge', challenge);
   });
 
-  it('renders', function () {
+  it('renders', function() {
     this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
     expect(this.$()).to.have.length(1);
   });
 
-  it('should disabled all inputs', function () {
+  it('should disabled all inputs', function() {
     // given
     this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
     const input = this.$('input');
@@ -52,7 +52,7 @@ describe('Integration | Component | qrocm solution panel', function () {
     expect(input).to.be.disabled;
   });
 
-  it('should contains three labels', function () {
+  it('should contains three labels', function() {
     // given
     this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
     const labels = this.$(LABEL);
@@ -60,11 +60,11 @@ describe('Integration | Component | qrocm solution panel', function () {
     expect(labels).to.have.length(3);
   });
 
-  describe('comparison of a qrocm-ind with a right answer, a wrong answer and one empty answer', function () {
+  describe('comparison of a qrocm-ind with a right answer, a wrong answer and one empty answer', function() {
 
-    describe('right answer display', function () {
+    describe('right answer display', function() {
 
-      it('should display the right answer in green bold', function () {
+      it('should display the right answer in green bold', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const answerBlock = this.$(FIRST_CORRECTION_BLOCK);
@@ -83,7 +83,7 @@ describe('Integration | Component | qrocm solution panel', function () {
         expect(answerInput.css('text-decoration')).to.be.equal('none');
       });
 
-      it('should not display the solution', function () {
+      it('should not display the solution', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const solutionBlock = this.$(FIRST_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK);
@@ -93,9 +93,9 @@ describe('Integration | Component | qrocm solution panel', function () {
       });
     });
 
-    describe('wrong answer display', function () {
+    describe('wrong answer display', function() {
 
-      it('should display the wrong answer in the second div line-throughed bold', function () {
+      it('should display the wrong answer in the second div line-throughed bold', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const answerBlock = this.$(SECOND_CORRECTION_BLOCK);
@@ -112,7 +112,7 @@ describe('Integration | Component | qrocm solution panel', function () {
         expect(answerInput.css('text-decoration')).to.be.equal('line-through');
       });
 
-      it('should display one solution in bold green below the input', function () {
+      it('should display one solution in bold green below the input', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const solutionBlock = this.$(SECOND_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK);
@@ -128,9 +128,9 @@ describe('Integration | Component | qrocm solution panel', function () {
       });
     });
 
-    describe('no answer display', function () {
+    describe('no answer display', function() {
 
-      it('should display the empty answer in the third div with "pas de réponse" in italic', function () {
+      it('should display the empty answer in the third div with "pas de réponse" in italic', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const answerBlock = this.$(THIRD_CORRECTION_BLOCK);
@@ -147,7 +147,7 @@ describe('Integration | Component | qrocm solution panel', function () {
         expect(answerInput.css('text-decoration')).to.be.equal('none');
       });
 
-      it('should display one solution in bold green below the input', function () {
+      it('should display one solution in bold green below the input', function() {
         // given
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
         const solutionBlock = this.$(THIRD_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK);

--- a/live/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/live/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -12,7 +12,6 @@ const LABEL = '.correction-qrocm__label';
 const INPUT = '.correction-qrocm__answer-input';
 const SOLUTION_TEXT = '.correction-qrocm__solution-text';
 
-
 const RIGHT_ANSWER_GREEN = 'rgb(19, 201, 160)';
 const NO_ANSWER_GREY = 'rgb(62, 65, 73)';
 

--- a/live/tests/integration/components/result-item-test.js
+++ b/live/tests/integration/components/result-item-test.js
@@ -29,19 +29,19 @@ const expectedPath = 'M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,2
 
 const expectedChallengeInstruction = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieur...';
 
-describe('Integration | Component | result item', function () {
+describe('Integration | Component | result item', function() {
 
   setupComponentTest('result-item', {
     integration: true
   });
 
-  describe('Component rendering ', function () {
+  describe('Component rendering ', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.set('index', 0);
     });
 
-    it('should exist', function () {
+    it('should exist', function() {
       // given
       this.set('answer', '');
 
@@ -52,7 +52,7 @@ describe('Integration | Component | result item', function () {
       expect(this.$()).to.have.length(1);
     });
 
-    it('component render an index 1 when 0 provided', function () {
+    it('component render an index 1 when 0 provided', function() {
       // given
       this.set('answer', '');
 
@@ -64,7 +64,7 @@ describe('Integration | Component | result item', function () {
       expect(index.trim().replace('\n', '')).to.equal('1');
     });
 
-    it('component render an instruction with no empty content', function () {
+    it('component render an instruction with no empty content', function() {
       // given
       this.set('answer', '');
 
@@ -76,7 +76,7 @@ describe('Integration | Component | result item', function () {
       expect(this.$('.result-item__instruction').text()).to.contain('\n');
     });
 
-    it(`component render an instruction which contain ${expectedChallengeInstruction}`, function () {
+    it(`component render an instruction which contain ${expectedChallengeInstruction}`, function() {
       // given
       this.set('answer', answer);
 
@@ -87,7 +87,7 @@ describe('Integration | Component | result item', function () {
       expect(this.$('.result-item__instruction').text().trim()).to.equal(expectedChallengeInstruction);
     });
 
-    it('component render an button when QCM', function () {
+    it('component render an button when QCM', function() {
       // given
       this.set('answer', answer);
 
@@ -96,7 +96,7 @@ describe('Integration | Component | result item', function () {
       expect(this.$('.result-item__correction__button').text().trim()).to.deep.equal('RÉPONSE');
     });
 
-    it('component render tooltip with title Réponse incorrecte', function () {
+    it('component render tooltip with title Réponse incorrecte', function() {
       // given
       this.set('answer', answer);
 
@@ -107,7 +107,7 @@ describe('Integration | Component | result item', function () {
       expect(this.$('div[data-toggle="tooltip"]').attr('title').trim()).to.equal('Réponse incorrecte');
     });
 
-    it('component render tooltip with svg', function () {
+    it('component render tooltip with svg', function() {
       // given
       this.set('answer', answer);
 

--- a/live/tests/integration/components/scoring-panel-test.js
+++ b/live/tests/integration/components/scoring-panel-test.js
@@ -18,14 +18,14 @@ describe('Integration | Component | scoring panel', function() {
     expect(this.$()).to.have.length(1);
   });
 
-  describe('view without trophy', function () {
+  describe('view without trophy', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.set('assessment', assessmentWithNoTrophy);
       this.render(hbs`{{scoring-panel assessment=assessment}}`);
     });
 
-    it('it should display nothing', function () {
+    it('it should display nothing', function() {
       // then
       expect(this.$('.scoring-panel__trophy')).to.have.lengthOf(0);
       expect(this.$('.scoring-panel__text')).to.have.lengthOf(0);
@@ -33,21 +33,21 @@ describe('Integration | Component | scoring panel', function() {
     });
   });
 
-  describe('view with a trophy', function () {
+  describe('view with a trophy', function() {
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.set('assessment', assessmentWithTrophy);
       this.render(hbs`{{scoring-panel assessment=assessment}}`);
     });
 
-    it('should display the won trophy', function () {
+    it('should display the won trophy', function() {
       // then
       expect(this.$('.scoring-panel__trophy-div')).to.have.lengthOf(1);
       expect(this.$('.scoring-panel__trophy-level')).to.have.lengthOf(1);
       expect(this.$('.scoring-panel__trophy-bêta')).to.have.lengthOf(1);
     });
 
-    it('should display the congratulations', function () {
+    it('should display the congratulations', function() {
       // then
       expect(this.$('.scoring-panel__congrats-course-name')).to.have.lengthOf(1);
       expect(this.$('.scoring-panel__congrats-felicitations')).to.have.lengthOf(1);
@@ -55,7 +55,7 @@ describe('Integration | Component | scoring panel', function() {
       expect(this.$('.scoring-panel__congrats-beta')).to.have.lengthOf(1);
     });
 
-    it('should display the "back to home" button', function () {
+    it('should display the "back to home" button', function() {
       // then
       expect(this.$('.scoring-panel__index-link')).to.have.lengthOf(1);
       expect(this.$('.scoring-panel__index-link-back').text()).to.be.equal('REVENIR À L\'ACCUEIL');

--- a/live/tests/integration/components/timeout-jauge-test.js
+++ b/live/tests/integration/components/timeout-jauge-test.js
@@ -40,5 +40,4 @@ describe('Integration | Component | TimeoutJauge', function() {
 
   });
 
-
 });

--- a/live/tests/integration/components/timeout-jauge-test.js
+++ b/live/tests/integration/components/timeout-jauge-test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | TimeoutJauge', function () {
+describe('Integration | Component | TimeoutJauge', function() {
 
   setupComponentTest('timeout-jauge', {
     integration: true
@@ -11,8 +11,8 @@ describe('Integration | Component | TimeoutJauge', function () {
 
   /* Rendering
   ----------------------------------------------------- */
-  describe('Rendering', function () {
-    it('It renders', function () {
+  describe('Rendering', function() {
+    it('It renders', function() {
       // when
       this.render(hbs`{{timeout-jauge }}`);
 
@@ -20,7 +20,7 @@ describe('Integration | Component | TimeoutJauge', function () {
       expect(this.$('.timeout-jauge')).to.have.lengthOf(1);
     });
 
-    it('It renders a red clock if time is over', function () {
+    it('It renders a red clock if time is over', function() {
       // when
       this.render(hbs`{{timeout-jauge allotedTime=0}}`);
 
@@ -29,7 +29,7 @@ describe('Integration | Component | TimeoutJauge', function () {
       expect(this.$('.svg-timeout-clock-red')).to.have.lengthOf(1);
     });
 
-    it('It renders a black clock if time is not over', function () {
+    it('It renders a black clock if time is not over', function() {
       // when
       this.render(hbs`{{timeout-jauge allotedTime=1}}`);
 

--- a/live/tests/unit/adapters/solution-test.js
+++ b/live/tests/unit/adapters/solution-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Adapters | solution', function () {
+describe('Unit | Adapters | solution', function() {
 
   setupTest('adapter:solution', {});
 
-  it('exists', function () {
+  it('exists', function() {
     const adapter = this.subject();
     expect(adapter).to.be.ok;
   });

--- a/live/tests/unit/components/comparison-window-test.js
+++ b/live/tests/unit/components/comparison-window-test.js
@@ -11,7 +11,7 @@ function _assertResultItemTooltip(resultItem, expected) {
   expect(resultItem.titleTooltip).to.equal(expected);
 }
 
-describe('Unit | Component | comparison-window', function () {
+describe('Unit | Component | comparison-window', function() {
 
   setupTest('component:comparison-window', {});
 
@@ -24,15 +24,15 @@ describe('Unit | Component | comparison-window', function () {
   const challengeQrocmInd = { type: 'QROCM-ind' };
   const challengeQrocmDep = { type: 'QROCM-dep' };
 
-  beforeEach(function () {
+  beforeEach(function() {
     component = this.subject();
     answer = Ember.Object.create();
     component.set('answer', answer);
   });
 
-  describe('#isAssessmentChallengeTypeQroc', function () {
+  describe('#isAssessmentChallengeTypeQroc', function() {
 
-    it('should be true when the challenge is QROC', function () {
+    it('should be true when the challenge is QROC', function() {
       // given
       component.set('challenge', challengeQroc);
       // when
@@ -41,7 +41,7 @@ describe('Unit | Component | comparison-window', function () {
       expect(isAssessmentChallengeTypeQroc).to.be.true;
     });
 
-    it('should be false when the challenge is not QROCM-ind', function () {
+    it('should be false when the challenge is not QROCM-ind', function() {
       // given
       component.set('challenge', challengeQrocmInd);
       // when
@@ -51,9 +51,9 @@ describe('Unit | Component | comparison-window', function () {
     });
   });
 
-  describe('#isAssessmentChallengeTypeQcm', function () {
+  describe('#isAssessmentChallengeTypeQcm', function() {
 
-    it('should be true when the challenge is QCM', function () {
+    it('should be true when the challenge is QCM', function() {
       // given
       component.set('challenge', challengeQcm);
       // when
@@ -62,7 +62,7 @@ describe('Unit | Component | comparison-window', function () {
       expect(isAssessmentChallengeTypeQcm).to.be.true;
     });
 
-    it('should be false when the challenge is not QCM', function () {
+    it('should be false when the challenge is not QCM', function() {
       // given
       component.set('challenge', challengeQroc);
       // when
@@ -72,9 +72,9 @@ describe('Unit | Component | comparison-window', function () {
     });
   });
 
-  describe('#isAssessmentChallengeTypeQrocmInd', function () {
+  describe('#isAssessmentChallengeTypeQrocmInd', function() {
 
-    it('should be true when the challenge is QROCM-ind', function () {
+    it('should be true when the challenge is QROCM-ind', function() {
       // given
       component.set('challenge', challengeQrocmInd);
       // when
@@ -83,7 +83,7 @@ describe('Unit | Component | comparison-window', function () {
       expect(isAssessmentChallengeTypeQrocmInd).to.be.true;
     });
 
-    it('should be true when the challenge is not QROCM-ind', function () {
+    it('should be true when the challenge is not QROCM-ind', function() {
       // given
       component.set('challenge', challengeQroc);
       // when
@@ -93,9 +93,9 @@ describe('Unit | Component | comparison-window', function () {
     });
   });
 
-  describe('#isAssessmentChallengeTypeQrocmDep', function () {
+  describe('#isAssessmentChallengeTypeQrocmDep', function() {
 
-    it('should be true when the challenge is QROCM-dep', function () {
+    it('should be true when the challenge is QROCM-dep', function() {
       // given
       component.set('challenge', challengeQrocmDep);
       // when
@@ -104,7 +104,7 @@ describe('Unit | Component | comparison-window', function () {
       expect(isAssessmentChallengeTypeQrocmDep).to.be.true;
     });
 
-    it('should be true when the challenge is not QROCM-dep', function () {
+    it('should be true when the challenge is not QROCM-dep', function() {
       // given
       component.set('challenge', challengeQroc);
       // when
@@ -116,9 +116,9 @@ describe('Unit | Component | comparison-window', function () {
 
   });
 
-  describe('#resultItem', function () {
+  describe('#resultItem', function() {
 
-    it('should return adapted title and tooltip when validation is unavailable (i.e. empty)', function () {
+    it('should return adapted title and tooltip when validation is unavailable (i.e. empty)', function() {
       // given
       answer.set('result', '');
 
@@ -130,7 +130,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Correction automatique en cours de développement ;)');
     });
 
-    it('should return adapted title and tooltip when validation status is unknown', function () {
+    it('should return adapted title and tooltip when validation status is unknown', function() {
       // given
       answer.set('result', 'xxx');
 
@@ -142,7 +142,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Correction automatique en cours de développement ;)');
     });
 
-    it('should return adapted title and tooltip when validation status is undefined', function () {
+    it('should return adapted title and tooltip when validation status is undefined', function() {
       // given
       let undefined;
       answer.set('result', undefined);
@@ -155,7 +155,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Correction automatique en cours de développement ;)');
     });
 
-    it('should return adapted title and tooltip when result is "ok"', function () {
+    it('should return adapted title and tooltip when result is "ok"', function() {
       // given
       answer.set('result', 'ok');
 
@@ -167,7 +167,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Réponse correcte');
     });
 
-    it('should return adapted title and tooltip when result is "ko"', function () {
+    it('should return adapted title and tooltip when result is "ko"', function() {
       // given
       answer.set('result', 'ko');
 
@@ -179,7 +179,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Réponse incorrecte');
     });
 
-    it('should return adapted title and tooltip when result is "aband"', function () {
+    it('should return adapted title and tooltip when result is "aband"', function() {
       // given
       answer.set('result', 'aband');
 
@@ -191,7 +191,7 @@ describe('Unit | Component | comparison-window', function () {
       _assertResultItemTooltip(resultItem, 'Sans réponse');
     });
 
-    it('should return adapted title and tooltip when result is "partially"', function () {
+    it('should return adapted title and tooltip when result is "partially"', function() {
       // given
       answer.set('result', 'partially');
 
@@ -204,7 +204,7 @@ describe('Unit | Component | comparison-window', function () {
       expect(resultItem.custom).to.be.true;
     });
 
-    it('should return adapted title and tooltip when result is "timedout"', function () {
+    it('should return adapted title and tooltip when result is "timedout"', function() {
       // given
       answer.set('result', 'timedout');
 

--- a/live/tests/unit/components/comparison-window-test.js
+++ b/live/tests/unit/components/comparison-window-test.js
@@ -217,6 +217,5 @@ describe('Unit | Component | comparison-window', function() {
     });
   });
 
-
 });
 

--- a/live/tests/unit/components/course-item-test.js
+++ b/live/tests/unit/components/course-item-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | CourseItemComponent', function () {
+describe('Unit | Component | CourseItemComponent', function() {
 
   setupTest('component:course-item', {});
 
-  describe('Computed property "imageUrl"', function () {
+  describe('Computed property "imageUrl"', function() {
     let component;
 
     const COURSE_WITH_IMAGE = {imageUrl:'any_image.png'};
@@ -22,7 +22,7 @@ describe('Unit | Component | CourseItemComponent', function () {
       component.set('course', COURSE_WITHOUT_IMAGE);
     }
 
-    it('should display the image of the course', function () {
+    it('should display the image of the course', function() {
       // given
       initComponentWithImage.call(this);
 
@@ -34,7 +34,7 @@ describe('Unit | Component | CourseItemComponent', function () {
       expect(imageUrl).to.equal('any_image.png');
     });
 
-    it('should display a default image if no image url is given', function () {
+    it('should display a default image if no image url is given', function() {
       // given
       initComponentWithoutImage.call(this);
 

--- a/live/tests/unit/components/course-list-test.js
+++ b/live/tests/unit/components/course-list-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | course list', function () {
+describe('Unit | Component | course list', function() {
 
   setupTest('component:course-list', {});
 
-  describe('#filteredCourses', function () {
+  describe('#filteredCourses', function() {
 
     let component;
 
@@ -21,11 +21,11 @@ describe('Unit | Component | course list', function () {
       { id: 'course_5' }
     ];
 
-    beforeEach(function () {
+    beforeEach(function() {
       component = this.subject();
     });
 
-    it('should return an empty array when courses are null', function () {
+    it('should return an empty array when courses are null', function() {
       // given
       component.set('courses', null);
 
@@ -36,7 +36,7 @@ describe('Unit | Component | course list', function () {
       expect(result).to.have.lengthOf(0);
     });
 
-    it('should return all courses when limit is not defined', function () {
+    it('should return all courses when limit is not defined', function() {
       // given
       component.set('courses', fiveCoursesArray);
 
@@ -47,7 +47,7 @@ describe('Unit | Component | course list', function () {
       expect(result).to.have.lengthOf(5);
     });
 
-    it('should return only 3 courses on 5 when limit is set to 2', function () {
+    it('should return only 3 courses on 5 when limit is set to 2', function() {
       // given
       component.set('courses', fiveCoursesArray);
       component.set('limit', 3);
@@ -59,7 +59,7 @@ describe('Unit | Component | course list', function () {
       expect(result).to.have.lengthOf(3);
     });
 
-    it('should return only 1 course on 1 when limit is set to 3', function () {
+    it('should return only 1 course on 1 when limit is set to 3', function() {
       // given
       component.set('courses', oneCourseArray);
       component.set('limit', 3);

--- a/live/tests/unit/components/feedback-panel-test.js
+++ b/live/tests/unit/components/feedback-panel-test.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | feedback-panel', function () {
+describe('Unit | Component | feedback-panel', function() {
 
   setupTest('component:feedback-panel', {});
 
-  describe('#isFormClosed', function () {
+  describe('#isFormClosed', function() {
 
-    it('should return true by default', function () {
+    it('should return true by default', function() {
       // given
       const component = this.subject();
 
@@ -19,7 +19,7 @@ describe('Unit | Component | feedback-panel', function () {
       expect(isFormClosed).to.be.true;
     });
 
-    it('should return true if status equals "FORM_CLOSED"', function () {
+    it('should return true if status equals "FORM_CLOSED"', function() {
       // given
       const component = this.subject();
       component.set('_status', 'FORM_CLOSED');
@@ -31,7 +31,7 @@ describe('Unit | Component | feedback-panel', function () {
       expect(isFormClosed).to.be.true;
     });
 
-    it('should return false if status is not equal to "FORM_CLOSED"', function () {
+    it('should return false if status is not equal to "FORM_CLOSED"', function() {
       // given
       const component = this.subject();
       component.set('_status', 'FORM_OPENED');
@@ -44,9 +44,9 @@ describe('Unit | Component | feedback-panel', function () {
     });
   });
 
-  describe('#isFormOpened', function () {
+  describe('#isFormOpened', function() {
 
-    it('should return true if status equals "FORM_OPENED"', function () {
+    it('should return true if status equals "FORM_OPENED"', function() {
       // given
       const component = this.subject();
       component.set('_status', 'FORM_OPENED');
@@ -58,7 +58,7 @@ describe('Unit | Component | feedback-panel', function () {
       expect(isFormClosed).to.be.true;
     });
 
-    it('should return false if status is not equal to "FORM_OPENED"', function () {
+    it('should return false if status is not equal to "FORM_OPENED"', function() {
       // given
       const component = this.subject();
       component.set('_status', 'FORM_CLOSED');
@@ -72,9 +72,9 @@ describe('Unit | Component | feedback-panel', function () {
 
   });
 
-  describe('#_reset', function () {
+  describe('#_reset', function() {
 
-    it('should return empty mail, text, error and back to the default status', function () {
+    it('should return empty mail, text, error and back to the default status', function() {
       // given
       const component = this.subject();
       component.set('collapsible', false);
@@ -94,9 +94,9 @@ describe('Unit | Component | feedback-panel', function () {
     });
   });
 
-  describe('#_closeForm', function () {
+  describe('#_closeForm', function() {
 
-    it('should set status to CLOSED and set errors to null', function () {
+    it('should set status to CLOSED and set errors to null', function() {
       // given
       const component = this.subject();
       component.set('_error', 'une erreur');
@@ -111,7 +111,7 @@ describe('Unit | Component | feedback-panel', function () {
     });
   });
 
-  describe('#_getDefaultStatus', function () {
+  describe('#_getDefaultStatus', function() {
 
     it('should return FORM_CLOSED if has property collapsible at "true"', function() {
       // given

--- a/live/tests/unit/components/follower-form-test.js
+++ b/live/tests/unit/components/follower-form-test.js
@@ -11,12 +11,12 @@ const errorMessages = {
   success: 'Merci pour votre inscription'
 };
 
-describe('Unit | Component | followerComponent', function () {
+describe('Unit | Component | followerComponent', function() {
 
   setupTest('component:follower-form', {});
 
-  describe('#Computed Properties behaviors: ', function () {
-    describe('When status get <error>, computed :', function () {
+  describe('#Computed Properties behaviors: ', function() {
+    describe('When status get <error>, computed :', function() {
       [
         { attribute: 'hasError', expected: true },
         { attribute: 'isPending', expected: false },
@@ -27,7 +27,7 @@ describe('Unit | Component | followerComponent', function () {
         { attribute: 'submitButtonText', expected: 's\'inscrire' },
         { attribute: 'hasMessage', expected: true },
       ].forEach(({ attribute, expected }) => {
-        it(`should return ${expected} when passing ${attribute}`, function () {
+        it(`should return ${expected} when passing ${attribute}`, function() {
           // given
           const component = this.subject();
           // when
@@ -39,7 +39,7 @@ describe('Unit | Component | followerComponent', function () {
       });
     });
 
-    describe('When status get <success>, computed :', function () {
+    describe('When status get <success>, computed :', function() {
       [
         { attribute: 'hasError', expected: false },
         { attribute: 'isPending', expected: false },
@@ -50,7 +50,7 @@ describe('Unit | Component | followerComponent', function () {
         { attribute: 'submitButtonText', expected: 's\'inscrire' },
         { attribute: 'hasMessage', expected: true },
       ].forEach(({ attribute, expected }) => {
-        it(`should return ${expected} when passing ${attribute}`, function () {
+        it(`should return ${expected} when passing ${attribute}`, function() {
           // given
           const component = this.subject();
           // when

--- a/live/tests/unit/components/qcu-proposals-test.js
+++ b/live/tests/unit/components/qcu-proposals-test.js
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | QcuProposalsComponent', function () {
+describe('Unit | Component | QcuProposalsComponent', function() {
 
   setupTest('component:qcu-proposals', {});
 
   /* Computed property "labeledRadios"
    ----------------------------------------------------- */
 
-  describe('Computed property "labeledRadios"', function () {
+  describe('Computed property "labeledRadios"', function() {
 
     const DEFAULT_PROPOSALS = ['prop 1', 'prop 2', 'prop 3'];
     const DEFAULT_ANSWERS = [false, true, false];
@@ -22,7 +22,7 @@ describe('Unit | Component | QcuProposalsComponent', function () {
     let proposals;
     let component;
 
-    beforeEach(function () {
+    beforeEach(function() {
       proposals = DEFAULT_PROPOSALS;
       answers = DEFAULT_ANSWERS;
     });
@@ -40,7 +40,7 @@ describe('Unit | Component | QcuProposalsComponent', function () {
      *
      * => labeledRadios = [['prop 1', false], ['prop 2', true], ['prop 3', false]]
      */
-    it('should return an array of [<proposal_text>, <boolean_answer>]', function () {
+    it('should return an array of [<proposal_text>, <boolean_answer>]', function() {
       // given
       initComponent.call(this);
 
@@ -58,7 +58,7 @@ describe('Unit | Component | QcuProposalsComponent', function () {
       expect(labeledRadios[2][BOOLEAN_ANSWER]).to.equal(DEFAULT_ANSWERS[2]);
     });
 
-    it('should return an array of [<proposal_text>, <boolean_answer>] with as many items than challenge proposals', function () {
+    it('should return an array of [<proposal_text>, <boolean_answer>] with as many items than challenge proposals', function() {
       // given
       proposals = ['prop 1', 'prop 2', 'prop 3', 'prop 4', 'prop 5'];
       initComponent.call(this);
@@ -70,7 +70,7 @@ describe('Unit | Component | QcuProposalsComponent', function () {
       expect(labeledRadios).to.have.lengthOf(proposals.length);
     });
 
-    it('should return an array of [<proposal_text>, <boolean_answer>] with all <boolean_answer> values set to "false" when given answer is "null"', function () {
+    it('should return an array of [<proposal_text>, <boolean_answer>] with all <boolean_answer> values set to "false" when given answer is "null"', function() {
       // given
       answers = null;
       initComponent.call(this);
@@ -82,7 +82,7 @@ describe('Unit | Component | QcuProposalsComponent', function () {
       expect(_.every(labeledRadios, (labeledRadio) => labeledRadio[1] === false)).to.be.true;
     });
 
-    it('should return an array of [<proposal_text>, <boolean_answer>] with <boolean_answer> values empty when answer value is not a boolean', function () {
+    it('should return an array of [<proposal_text>, <boolean_answer>] with <boolean_answer> values empty when answer value is not a boolean', function() {
       // given
       answers = [true, undefined, null];
       initComponent.call(this);

--- a/live/tests/unit/components/qroc-solution-panel-test.js
+++ b/live/tests/unit/components/qroc-solution-panel-test.js
@@ -2,16 +2,16 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | qroc-solution-panel', function () {
+describe('Unit | Component | qroc-solution-panel', function() {
 
   setupTest('component:qroc-solution-panel', {});
   const rightAnswer = { result: 'ok' };
   const wrongAnswer = { result: 'ko' };
   //const noAnswer = { result: 'aband' };
 
-  describe('#isResultOk', function () {
+  describe('#isResultOk', function() {
 
-    it('should return true when result is ok', function () {
+    it('should return true when result is ok', function() {
       // given
       const component = this.subject();
       component.set('answer', rightAnswer);
@@ -21,7 +21,7 @@ describe('Unit | Component | qroc-solution-panel', function () {
       expect(isResultOk).to.be.true;
     });
 
-    it('should return true when result is not ok', function () {
+    it('should return true when result is not ok', function() {
       // given
       const component = this.subject();
       component.set('answer', wrongAnswer);
@@ -33,9 +33,9 @@ describe('Unit | Component | qroc-solution-panel', function () {
 
   });
 
-  describe('#answerToDisplay', function () {
+  describe('#answerToDisplay', function() {
 
-    it('should return PAS DE REPONSE if the answer is #ABAND#', function () {
+    it('should return PAS DE REPONSE if the answer is #ABAND#', function() {
       // given
       const answer = {
         value: '#ABAND#'
@@ -48,7 +48,7 @@ describe('Unit | Component | qroc-solution-panel', function () {
       expect(answerToDisplay).to.equal('Pas de réponse');
     });
 
-    it('should return the answer if the answer is not #ABAND#', function () {
+    it('should return the answer if the answer is not #ABAND#', function() {
       // given
       const answer = {
         value: 'La Reponse B'
@@ -62,9 +62,9 @@ describe('Unit | Component | qroc-solution-panel', function () {
     });
   });
 
-  describe('#solutionToDisplay', function () {
+  describe('#solutionToDisplay', function() {
 
-    it('should return the first solution if the solution has some variants', function () {
+    it('should return the first solution if the solution has some variants', function() {
       // given
       const solution = {
         value: 'Reponse\nreponse\nréponse'
@@ -77,7 +77,7 @@ describe('Unit | Component | qroc-solution-panel', function () {
       expect(solutionToDisplay).to.equal('Reponse');
     });
 
-    it('should return the solution', function () {
+    it('should return the solution', function() {
       // given
       const solution = {
         value: 'Reponse'
@@ -90,7 +90,7 @@ describe('Unit | Component | qroc-solution-panel', function () {
       expect(solutionToDisplay).to.equal('Reponse');
     });
 
-    it('should return an empty string if the solution is null', function () {
+    it('should return an empty string if the solution is null', function() {
       // given
       const emptySolution = {
         value: ''
@@ -103,7 +103,7 @@ describe('Unit | Component | qroc-solution-panel', function () {
       expect(solutionToDisplay).to.equal('');
     });
 
-    it('should return an empty string if the solution is an empty String', function () {
+    it('should return an empty string if the solution is an empty String', function() {
       // given
       const solutionNull = {
         value: null

--- a/live/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/live/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | qrocm-solution-panel', function () {
+describe('Unit | Component | qrocm-solution-panel', function() {
 
   setupTest('component:qrocm-ind-solution-panel', {});
 
-  describe('#inputFields', function () {
+  describe('#inputFields', function() {
 
     let challenge;
     let answer;
@@ -26,7 +26,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
       return component.get('inputFields');
     }
 
-    it('should return an array with data to display (case when the answers are right)', function () {
+    it('should return an array with data to display (case when the answers are right)', function() {
       //Given
       challenge = { proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' };
       answer = { value: 'smiley1: \':)\' smiley2: \':(\'', resultDetails: 'smiley1: true\nsmiley2: true' };
@@ -53,7 +53,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
       expect(inputFields).to.be.deep.equal(expectedFieldsData);
     });
 
-    it('should return an array with data to display (case when there is wrong answers)', function () {
+    it('should return an array with data to display (case when there is wrong answers)', function() {
       //Given
       challenge = { proposals: 'Clé USB : ${num1}\n\nCarte mémoire (SD) : ${num2}' };
       answer = { value: 'num1: \'1\' num2: \'2\'', resultDetails: 'num1: false\nnum2: false' };
@@ -80,7 +80,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
 
     });
 
-    it('should return an array with data to display (case when there is some empty answer)', function () {
+    it('should return an array with data to display (case when there is some empty answer)', function() {
       //Given
       challenge = { proposals: 'Clé USB : ${num1}\n\nCarte mémoire (SD) : ${num2}' };
       answer = { value: 'num1: \'\' num2: \'2\'', resultDetails: 'num1: false\nnum2: false' };
@@ -107,7 +107,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
       expect(inputFields).to.be.deep.equal(result);
     });
 
-    it('should return an array with data to display (proposals contains a dash ("-"))', function () {
+    it('should return an array with data to display (proposals contains a dash ("-"))', function() {
       // given
       challenge = { proposals: '- alain@pix.fr : ${num1}\n\n- leonie@pix.fr : ${num2}\n\n- Programme_Pix.pdf : ${num3}\n\n- lucie@pix.fr : ${num4}\n\n- Programme du festival Pix : ${num5}\n\n- jeremy@pix.fr : ${num6}' };
       answer = {
@@ -161,7 +161,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
       expect(inputFields).to.be.deep.equal(result);
     });
 
-    it('should return an array with data to display (proposals are questions)', function () {
+    it('should return an array with data to display (proposals are questions)', function() {
       // given
       challenge = { proposals: '- Combien le dossier "projet PIX" contient-il de dossiers ? ${Num1}\n\n- Combien le dossier "images" contient-il de fichiers ? ${Num2}' };
       answer = { value: 'Num1: \'2\' Num2: \'3\'', resultDetails: 'Num1: false\nNum2: false' };
@@ -188,7 +188,7 @@ describe('Unit | Component | qrocm-solution-panel', function () {
       expect(inputFields).to.be.deep.equal(result);
     });
 
-    it('it should return "Pas de réponse" in each answer if the question was passed', function () {
+    it('it should return "Pas de réponse" in each answer if the question was passed', function() {
       // given
       challenge = { proposals: 'Clé USB : ${num1}\n\nCarte mémoire (SD) : ${num2}' };
       answer = { value: '#ABAND#', resultDetails: 'num1: false\nnum2: false' };

--- a/live/tests/unit/components/result-item-test.js
+++ b/live/tests/unit/components/result-item-test.js
@@ -28,24 +28,24 @@ const answerWithRandomResult = {
   result: 'RANDOM_RESULT'
 };
 
-describe('Unit | Component | result-item-component', function () {
+describe('Unit | Component | result-item-component', function() {
 
   setupTest('component:result-item', {});
 
   let component;
 
-  beforeEach(function () {
+  beforeEach(function() {
     component = this.subject();
   });
 
-  describe('#resultItemContent Computed property - undefined case', function () {
+  describe('#resultItemContent Computed property - undefined case', function() {
     [
       undefinedAnswer,
       answerWithEmptyResult,
       answerWithUndefinedResult,
       answerWithNullResult
-    ].forEach(function (answer) {
-      it(`should returns false when answer provided is: ${answer.name}`, function () {
+    ].forEach(function(answer) {
+      it(`should returns false when answer provided is: ${answer.name}`, function() {
         // when
         component.set('answer', answer);
         // then
@@ -55,15 +55,15 @@ describe('Unit | Component | result-item-component', function () {
 
   });
 
-  describe('#resultItemContent Computed property - defined case', function () {
-    it('should returns true when answer provided with result ok', function () {
+  describe('#resultItemContent Computed property - defined case', function() {
+    it('should returns true when answer provided with result ok', function() {
       // when
       component.set('answer', answerWithOkResult);
       // then
       expect(component.get('resultItemContent.title')).to.equal('Réponse correcte');
     });
 
-    it('should returns true when answer provided with result uncommon value by not null or undefined ', function () {
+    it('should returns true when answer provided with result uncommon value by not null or undefined ', function() {
       // when
       component.set('answer', answerWithRandomResult);
       // then
@@ -71,7 +71,7 @@ describe('Unit | Component | result-item-component', function () {
     });
   });
 
-  describe('#validationImplementedForChallengeType', function () {
+  describe('#validationImplementedForChallengeType', function() {
 
     [
       { challengeType: 'QCM', expected: true },
@@ -79,9 +79,9 @@ describe('Unit | Component | result-item-component', function () {
       { challengeType: 'QROCm-ind', expected: false },
       { challengeType: 'QROCm-dep', expected: false },
       { challengeType: 'QCU', expected: true }
-    ].forEach(function (data) {
+    ].forEach(function(data) {
 
-      it(`should return ${data.expected} when challenge type is ${data.challengeType}`, function () {
+      it(`should return ${data.expected} when challenge type is ${data.challengeType}`, function() {
         // given
         const challenge = Ember.Object.create({ type: data.challengeType });
         const answer = Ember.Object.create({ challenge });

--- a/live/tests/unit/components/scoring-panel-test.js
+++ b/live/tests/unit/components/scoring-panel-test.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | scoring-panel', function () {
+describe('Unit | Component | scoring-panel', function() {
 
   setupTest('component:scoring-panel', {});
 
-  describe('#hasATrophy', function () {
+  describe('#hasATrophy', function() {
 
-    it('should be true when level is more than 0', function () {
+    it('should be true when level is more than 0', function() {
       // given
       const assessmentWithTrophy = { estimatedLevel: 1 };
       const component = this.subject();
@@ -21,7 +21,7 @@ describe('Unit | Component | scoring-panel', function () {
       expect(hasATrophy).to.be.equal(true);
     });
 
-    it('should be false when level is equal to 0', function () {
+    it('should be false when level is equal to 0', function() {
       // given
       const assessmentWithNoTrophy = { estimatedLevel: 0 };
       const component = this.subject();

--- a/live/tests/unit/components/timeout-jauge-test.js
+++ b/live/tests/unit/components/timeout-jauge-test.js
@@ -2,19 +2,19 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | timeout-jauge-component ', function () {
+describe('Unit | Component | timeout-jauge-component ', function() {
 
   setupTest('component:timeout-jauge', {});
 
   let component;
 
-  beforeEach(function () {
+  beforeEach(function() {
     component = this.subject();
   });
 
-  describe('#Test rendering Property', function () {
+  describe('#Test rendering Property', function() {
 
-    describe('#remainingSeconds', function () {
+    describe('#remainingSeconds', function() {
       [
         { allotedTime: new Date(),  _elapsedTime:0,     expected: 0   },
         { allotedTime: '  ',        _elapsedTime:0,     expected: 0   },
@@ -31,7 +31,7 @@ describe('Unit | Component | timeout-jauge-component ', function () {
         { allotedTime: '120',      _elapsedTime:150000, expected: -30 },
       ].forEach((data) => {
 
-        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function () {
+        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function() {
           // given
           component.set('allotedTime', data.allotedTime);
           component.set('_elapsedTime', data._elapsedTime);
@@ -44,7 +44,7 @@ describe('Unit | Component | timeout-jauge-component ', function () {
     });
 
 
-    describe('#remainingTime', function () {
+    describe('#remainingTime', function() {
       [
         { allotedTime: new Date(), _elapsedTime:0, expected: '0:00' },
         { allotedTime: '  ',       _elapsedTime:0, expected: '0:00' },
@@ -61,7 +61,7 @@ describe('Unit | Component | timeout-jauge-component ', function () {
         { allotedTime: '120',      _elapsedTime:150000, expected: '0:00' },
       ].forEach((data) => {
 
-        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function () {
+        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function() {
           // given
           component.set('allotedTime', data.allotedTime);
           component.set('_elapsedTime', data._elapsedTime);
@@ -73,7 +73,7 @@ describe('Unit | Component | timeout-jauge-component ', function () {
       });
     });
 
-    describe('#percentageOfTimeout', function () {
+    describe('#percentageOfTimeout', function() {
       [
         { allotedTime: new Date(), _elapsedTime:4000,    expected: 0 },
         { allotedTime: '  ',       _elapsedTime:4000,    expected: 0 },
@@ -86,7 +86,7 @@ describe('Unit | Component | timeout-jauge-component ', function () {
         { allotedTime: 150,        _elapsedTime:225000,  expected: 150 }
       ].forEach((data) => {
 
-        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function () {
+        it(`should return "${data.expected}" when alloting ${data.allotedTime} and _elapsedTime is ${data._elapsedTime}ms`, function() {
           // given
           component.set('allotedTime', data.allotedTime);
           component.set('_elapsedTime', data._elapsedTime);

--- a/live/tests/unit/components/timeout-jauge-test.js
+++ b/live/tests/unit/components/timeout-jauge-test.js
@@ -43,7 +43,6 @@ describe('Unit | Component | timeout-jauge-component ', function() {
       });
     });
 
-
     describe('#remainingTime', function() {
       [
         { allotedTime: new Date(), _elapsedTime:0, expected: '0:00' },

--- a/live/tests/unit/components/warning-time-page-test.js
+++ b/live/tests/unit/components/warning-time-page-test.js
@@ -2,19 +2,19 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | warning-page-component ', function () {
+describe('Unit | Component | warning-page-component ', function() {
 
   setupTest('component:warning-page', {});
 
   let component;
 
-  beforeEach(function () {
+  beforeEach(function() {
     component = this.subject();
   });
 
-  describe('#Test rendering Property', function () {
+  describe('#Test rendering Property', function() {
 
-    describe('#allocatedTime', function () {
+    describe('#allocatedTime', function() {
       [
         { input: '', expected: 0 },
         { input: ' ', expected: 0 },
@@ -31,7 +31,7 @@ describe('Unit | Component | warning-page-component ', function () {
         { input: 122, expected: '2:02' },
         { input: 130, expected: '2:10' }
       ].forEach((data) => {
-        it(`should return "${data.expected}" when passing ${data.input}`, function () {
+        it(`should return "${data.expected}" when passing ${data.input}`, function() {
           // given
           component.set('time', data.input);
 
@@ -44,7 +44,7 @@ describe('Unit | Component | warning-page-component ', function () {
       });
     });
 
-    describe('#allocatedHumanTime', function () {
+    describe('#allocatedHumanTime', function() {
       [
         { input: '', expected: '' },
         { input: ' ', expected: '' },
@@ -61,7 +61,7 @@ describe('Unit | Component | warning-page-component ', function () {
         { input: 122, expected: '2 minutes et 2 secondes' },
         { input: 130, expected: '2 minutes et 10 secondes' }
       ].forEach((data) => {
-        it(`should return "${data.expected}" when passing ${data.input}`, function () {
+        it(`should return "${data.expected}" when passing ${data.input}`, function() {
           // given
           component.set('time', data.input);
 

--- a/live/tests/unit/helpers/eq-test.js
+++ b/live/tests/unit/helpers/eq-test.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {describe, it} from 'mocha';
 import {eq} from 'pix-live/helpers/eq';
 
-describe('Unit | Helper | Eq', function () {
+describe('Unit | Helper | Eq', function() {
   // Replace this with your real tests.
   [
     {input: '', output: false},
@@ -24,7 +24,7 @@ describe('Unit | Helper | Eq', function () {
     {input: [42, 'undefined'], output: false},
     {input: [42, 42], output: true}
   ].forEach(({input, output}) => {
-    it(`should render ${output} when ${JSON.stringify(input)} provided`, function () {
+    it(`should render ${output} when ${JSON.stringify(input)} provided`, function() {
       //When
       const result = eq(input);
       //then

--- a/live/tests/unit/helpers/extract-extension-test.js
+++ b/live/tests/unit/helpers/extract-extension-test.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { extractExtension } from 'pix-live/helpers/extract-extension';
 
-describe('Unit | Helpers | ExtractExtension', function () {
-  it('works', function () {
+describe('Unit | Helpers | ExtractExtension', function() {
+  it('works', function() {
     expect(extractExtension(['file.url.ext.docx'])).to.equal('docx');
     expect(extractExtension(['file_url_without_extension'])).to.equal('file_url_without_extension');
     expect(extractExtension([''])).to.equal('');

--- a/live/tests/unit/helpers/get-challenge-component-class-test.js
+++ b/live/tests/unit/helpers/get-challenge-component-class-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { getChallengeComponentClass } from 'pix-live/helpers/get-challenge-component-class';
 
-describe('Unit | Helper | get challenge component class', function () {
+describe('Unit | Helper | get challenge component class', function() {
 
   [
     { challengeType: 'QCU', expectedClass: 'challenge-item-qcu' },
@@ -17,7 +17,7 @@ describe('Unit | Helper | get challenge component class', function () {
     { challengeType: 'QROCm-dep', expectedClass: 'challenge-item-qrocm' }
   ].forEach((useCase) => {
 
-    it(`should return component class "${useCase.expectedClass}" when challenge type is "${useCase.challengeType}"`, function () {
+    it(`should return component class "${useCase.expectedClass}" when challenge type is "${useCase.challengeType}"`, function() {
       // given
       const challenge = Ember.Object.create({ type: useCase.challengeType });
       const params = [challenge];

--- a/live/tests/unit/helpers/or-test.js
+++ b/live/tests/unit/helpers/or-test.js
@@ -24,7 +24,7 @@ describe('Unit | Helper | or', function() {
     {input: [true, 'undefined'], output: true},
     {input: [true, true], output: true}
   ].forEach(({input, output}) => {
-    it(`should render ${output} when ${JSON.stringify(input)} provided`, function () {
+    it(`should render ${output} when ${JSON.stringify(input)} provided`, function() {
       //When
       const result = or(input);
       //then

--- a/live/tests/unit/helpers/strip-instruction-test.js
+++ b/live/tests/unit/helpers/strip-instruction-test.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { stripInstruction } from 'pix-live/helpers/strip-instruction';
 
-describe('Unit | Helpers | StripInstructionHelper', function () {
+describe('Unit | Helpers | StripInstructionHelper', function() {
   // Replace this with your real tests.
-  it('works', function () {
+  it('works', function() {
     const result = stripInstruction(['<div class="paragraph"><strong>a bold sentence</strong></div>']);
     expect(result).to.equal('a bold sentence...');
   });

--- a/live/tests/unit/models/answer-test.js
+++ b/live/tests/unit/models/answer-test.js
@@ -3,21 +3,21 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 
-describe('Unit | Model | Answer', function () {
+describe('Unit | Model | Answer', function() {
 
   setupModelTest('answer', {
     needs: ['model:assessment', 'model:challenge']
   });
 
-  it('exists', function () {
+  it('exists', function() {
     const model = this.subject();
     // var store = this.store();
     expect(model).to.be.ok;
   });
 
-  describe('isResultOk', function () {
+  describe('isResultOk', function() {
 
-    it('should return bool', function () {
+    it('should return bool', function() {
       Ember.run(() => {
         // given
         const store = this.store();

--- a/live/tests/unit/models/answer/value-as-array-of-boolean-mixin-test.js
+++ b/live/tests/unit/models/answer/value-as-array-of-boolean-mixin-test.js
@@ -26,4 +26,3 @@ describe('Unit | Model | Value As Array of Boolean Mixin', function() {
   });
 });
 
-

--- a/live/tests/unit/models/answer/value-as-array-of-boolean-mixin-test.js
+++ b/live/tests/unit/models/answer/value-as-array-of-boolean-mixin-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import ValueAsArrayOfBooleanMixin from 'pix-live/models/answer/value-as-array-of-boolean-mixin';
 
-describe('Unit | Model | Value As Array of Boolean Mixin', function () {
+describe('Unit | Model | Value As Array of Boolean Mixin', function() {
 
   const testData = [
     { when: 'Empty String', input: '', expected: [] },
@@ -19,7 +19,7 @@ describe('Unit | Model | Value As Array of Boolean Mixin', function () {
 
   testData.forEach(({ when, input, expected }) => {
 
-    it(`"${when}", example : "${JSON.stringify(input)}" retourne [${expected}]`, function () {
+    it(`"${when}", example : "${JSON.stringify(input)}" retourne [${expected}]`, function() {
       const sut = Challenge.create({ value: input });
       expect(sut.get('_valueAsArrayOfBoolean')).to.deep.equal(expected);
     });

--- a/live/tests/unit/models/challenge-test.js
+++ b/live/tests/unit/models/challenge-test.js
@@ -3,20 +3,20 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 
-describe('Unit | Model | Challenge', function () {
+describe('Unit | Model | Challenge', function() {
 
   setupModelTest('challenge', {
     needs: ['model:course']
   });
 
-  it('exists', function () {
+  it('exists', function() {
     const model = this.subject();
     expect(model).to.be.ok;
   });
 
-  describe('Computed property #hasAttachment', function () {
+  describe('Computed property #hasAttachment', function() {
 
-    it('Should be true when challenge has at least one attachment file', function () {
+    it('Should be true when challenge has at least one attachment file', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -31,7 +31,7 @@ describe('Unit | Model | Challenge', function () {
 
     });
 
-    it('Should be false when challenge has multiple attachment files', function () {
+    it('Should be false when challenge has multiple attachment files', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -47,9 +47,9 @@ describe('Unit | Model | Challenge', function () {
 
   });
 
-  describe('Computed property #hasSingleAttachment', function () {
+  describe('Computed property #hasSingleAttachment', function() {
 
-    it('Should be true when challenge has only one attachment file', function () {
+    it('Should be true when challenge has only one attachment file', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -64,7 +64,7 @@ describe('Unit | Model | Challenge', function () {
 
     });
 
-    it('Should be false when challenge has multiple attachment files', function () {
+    it('Should be false when challenge has multiple attachment files', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -80,9 +80,9 @@ describe('Unit | Model | Challenge', function () {
 
   });
 
-  describe('Computed property #hasMultipleAttachments', function () {
+  describe('Computed property #hasMultipleAttachments', function() {
 
-    it('Should be false when challenge has no attachment file', function () {
+    it('Should be false when challenge has no attachment file', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -97,7 +97,7 @@ describe('Unit | Model | Challenge', function () {
 
     });
 
-    it('Should be false when challenge has only one attachment file', function () {
+    it('Should be false when challenge has only one attachment file', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -112,7 +112,7 @@ describe('Unit | Model | Challenge', function () {
 
     });
 
-    it('Should be true when challenge has multiple attachments files', function () {
+    it('Should be true when challenge has multiple attachments files', function() {
       Ember.run(() => {
         // given
         const store = this.store();

--- a/live/tests/unit/models/challenge/proposals-as-array-mixin-test.js
+++ b/live/tests/unit/models/challenge/proposals-as-array-mixin-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import ProposalsAsArrayMixin from 'pix-live/models/challenge/proposals-as-array-mixin';
 
-describe('Unit | Model | Challenge/Propsals As Array Mixin', function () {
+describe('Unit | Model | Challenge/Propsals As Array Mixin', function() {
 
   const testData = [
     { data: '', expected: [] },
@@ -22,7 +22,7 @@ describe('Unit | Model | Challenge/Propsals As Array Mixin', function () {
 
   testData.forEach(({ data, expected }) => {
 
-    it(`"${data.toString()}" retourne [${expected}]`, function () {
+    it(`"${data.toString()}" retourne [${expected}]`, function() {
       const sut = Challenge.create({ proposals: data });
       expect(sut.get('_proposalsAsArray')).to.deep.equal(expected);
     });

--- a/live/tests/unit/models/challenge/proposals-as-blocks-mixin-test.js
+++ b/live/tests/unit/models/challenge/proposals-as-blocks-mixin-test.js
@@ -4,7 +4,7 @@ import { it } from 'ember-mocha';
 import { expect } from 'chai';
 import ProposalsAsBlocksMixin from 'pix-live/models/challenge/proposals-as-blocks-mixin';
 
-describe('Unit | Model | Challenge/Proposal As Blocks Mixin', function () {
+describe('Unit | Model | Challenge/Proposal As Blocks Mixin', function() {
 
   const testData = [
     { data: '', expected: [] },
@@ -29,9 +29,9 @@ describe('Unit | Model | Challenge/Proposal As Blocks Mixin', function () {
 
   const Challenge = Ember.Object.extend(ProposalsAsBlocksMixin, {});
 
-  testData.forEach(function ({ data, expected }) {
+  testData.forEach(function({ data, expected }) {
 
-    it(`"${data}" retourne ${JSON.stringify(expected)}`, function () {
+    it(`"${data}" retourne ${JSON.stringify(expected)}`, function() {
       const sut = Challenge.create({ proposals: data });
       const blocks = sut.get('_proposalsAsBlocks');
       expect(blocks, JSON.stringify(blocks)).to.deep.equals(expected);

--- a/live/tests/unit/models/course-test.js
+++ b/live/tests/unit/models/course-test.js
@@ -3,20 +3,20 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 
-describe('Unit | Model | Course', function () {
+describe('Unit | Model | Course', function() {
 
   setupModelTest('course', {
     needs: ['model:assessment', 'model:challenge']
   });
 
-  it('exists', function () {
+  it('exists', function() {
     const model = this.subject();
     expect(model).to.be.ok;
   });
 
-  describe('getProgress', function () {
+  describe('getProgress', function() {
 
-    it('currentStep start at 1', function () {
+    it('currentStep start at 1', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -27,7 +27,7 @@ describe('Unit | Model | Course', function () {
       });
     });
 
-    it('maxStep is 2 when there is 2 challenges in the course', function () {
+    it('maxStep is 2 when there is 2 challenges in the course', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -40,7 +40,7 @@ describe('Unit | Model | Course', function () {
       });
     });
 
-    it('currentStep is 2 when there is 2 challenges in the course and called with 2nd test', function () {
+    it('currentStep is 2 when there is 2 challenges in the course and called with 2nd test', function() {
       Ember.run(() => {
         // given
         const store = this.store();
@@ -52,7 +52,7 @@ describe('Unit | Model | Course', function () {
       });
     });
 
-    it('throw an Error when challenge is not part of course', function () {
+    it('throw an Error when challenge is not part of course', function() {
       Ember.run(() => {
         // given
         const store = this.store();

--- a/live/tests/unit/models/feedback-test.js
+++ b/live/tests/unit/models/feedback-test.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 
-describe('Unit | Model | feedback', function () {
+describe('Unit | Model | feedback', function() {
 
   setupModelTest('feedback', {
     needs: ['model:assessment', 'model:challenge']
   });
 
-  it('exists', function () {
+  it('exists', function() {
     const model = this.subject();
     expect(model).to.be.ok;
   });

--- a/live/tests/unit/models/follower-test.js
+++ b/live/tests/unit/models/follower-test.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import {describe, it} from 'mocha';
 import {setupModelTest} from 'ember-mocha';
 
-describe('Follower', function () {
+describe('Follower', function() {
   setupModelTest('follower', {
     // Specify the other units that are required for this test.
     needs: []
   });
 
   // Replace this with your real tests.
-  it('exists', function () {
+  it('exists', function() {
     const model = this.subject();
     // var store = this.store();
     expect(model).to.be.ok;

--- a/live/tests/unit/routes/assessments/get-challenge-test.js
+++ b/live/tests/unit/routes/assessments/get-challenge-test.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Route | Assessments.ChallengeRoute', function () {
+describe('Unit | Route | Assessments.ChallengeRoute', function() {
 
   setupTest('route:assessments.get-challenge', {
     needs: ['service:assessment']
   });
 
-  it('exists', function () {
+  it('exists', function() {
     const route = this.subject();
     expect(route).to.be.ok;
   });

--- a/live/tests/unit/services/assessment-test.js
+++ b/live/tests/unit/services/assessment-test.js
@@ -20,9 +20,9 @@ describe('Unit | Service | AssessmentService', function() {
     return { challenges, assessment };
   }
 
-  describe('#getNextChallenge', function () {
+  describe('#getNextChallenge', function() {
 
-    it('returns a promise', function () {
+    it('returns a promise', function() {
       return Ember.run(() => {
         const store = this.container.lookup('service:store');
         const { challenges, assessment } = instantiateModels(store, [{ id: 1 }, { id: 2 }]);
@@ -31,7 +31,7 @@ describe('Unit | Service | AssessmentService', function() {
       });
     });
 
-    it('return the next challenge when current challenge is not the assessment\'s last one', function () {
+    it('return the next challenge when current challenge is not the assessment\'s last one', function() {
 
       return Ember.run(() => {
         // given
@@ -48,7 +48,7 @@ describe('Unit | Service | AssessmentService', function() {
       });
     });
 
-    it('return the next challenge when current challenge is the assessment\'s latest', function () {
+    it('return the next challenge when current challenge is the assessment\'s latest', function() {
 
       return Ember.run(() => {
         // given
@@ -65,7 +65,7 @@ describe('Unit | Service | AssessmentService', function() {
       });
     });
 
-    it('return challenge model objects well formed', function () {
+    it('return challenge model objects well formed', function() {
 
       return Ember.run(() => {
         // given

--- a/live/tests/unit/services/delay-test.js
+++ b/live/tests/unit/services/delay-test.js
@@ -11,7 +11,7 @@ describe('Unit | Service | DelayService', function() {
     expect(controller).to.be.ok;
   });
 
-  it('has delay#ms() which return a promise', function () {
+  it('has delay#ms() which return a promise', function() {
     const delay = this.subject();
     expect(delay).to.respondsTo('ms');
     const promise = delay.ms(0);

--- a/live/tests/unit/transforms/array-test.js
+++ b/live/tests/unit/transforms/array-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import ArrayTransform from 'pix-live/transforms/array';
 
-describe('Unit | Transformer | Array', function () {
+describe('Unit | Transformer | Array', function() {
 
-  describe('#deserialize', function () {
+  describe('#deserialize', function() {
 
-    it('should return an Array when Array given', function () {
+    it('should return an Array when Array given', function() {
       const transform = new ArrayTransform();
       // given
       const array = ['foo', 'bar', 'yeah'];

--- a/live/tests/unit/utils/answers-as-object-test.js
+++ b/live/tests/unit/utils/answers-as-object-test.js
@@ -4,9 +4,9 @@ import { describe, it } from 'mocha';
 
 describe('Unit | Utility | answers as object', function() {
 
-  describe('#answersAsObject', function () {
+  describe('#answersAsObject', function() {
 
-    it('should return an object of given answers with key of the input', function () {
+    it('should return an object of given answers with key of the input', function() {
       // given
       const answer = {
         value : 'num1: \'4\' num2: \'1\' num3: \'2\' num4: \'3\''
@@ -25,7 +25,7 @@ describe('Unit | Utility | answers as object', function() {
       expect(result).to.deep.equal(expectedResult);
     });
 
-    it('should return an empty object when the answer is aband', function () {
+    it('should return an empty object when the answer is aband', function() {
       // given
       const answer = { value : '#ABAND#' };
       const inputKeys = ['key1', 'key2', 'key3'];

--- a/live/tests/unit/utils/email-validator-test.js
+++ b/live/tests/unit/utils/email-validator-test.js
@@ -2,8 +2,8 @@ import {expect} from 'chai';
 import {describe, it} from 'mocha';
 import isEmailValid from 'pix-live/utils/email-validator';
 
-describe('Unit | Utility | email validator', function () {
-  describe('Invalid emails', function () {
+describe('Unit | Utility | email validator', function() {
+  describe('Invalid emails', function() {
     [
       '',
       ' ',
@@ -14,14 +14,14 @@ describe('Unit | Utility | email validator', function () {
       'INVALID_EMAIL@pix.',
       '@pix.fr',
       '@pix'
-    ].forEach(function (badEmail) {
-      it(`should return false when email is invalid: ${badEmail}`, function () {
+    ].forEach(function(badEmail) {
+      it(`should return false when email is invalid: ${badEmail}`, function() {
         expect(isEmailValid(badEmail)).to.be.false;
       });
     });
   });
 
-  describe('Valid emails', function () {
+  describe('Valid emails', function() {
     [
       'follower@pix.fr',
       'follower@pix.fr ',
@@ -32,8 +32,8 @@ describe('Unit | Utility | email validator', function () {
       'follower+beta@pix.fr',
       'follower+beta@pix.gouv.fr',
       'follower+beta@pix.beta.gouv.fr'
-    ].forEach(function (validEmail) {
-      it(`should return true if provided email is valid: ${validEmail}`, function () {
+    ].forEach(function(validEmail) {
+      it(`should return true if provided email is valid: ${validEmail}`, function() {
         expect(isEmailValid(validEmail)).to.be.true;
       });
     });

--- a/live/tests/unit/utils/labeled-checkboxes-test.js
+++ b/live/tests/unit/utils/labeled-checkboxes-test.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import labeledCheckboxes from 'pix-live/utils/labeled-checkboxes';
 
-describe('Unit | Utility | labeled checkboxes', function () {
+describe('Unit | Utility | labeled checkboxes', function() {
 
-  describe('Success cases', function () {
+  describe('Success cases', function() {
 
     [{
       when: 'nominal case, existing answers',
@@ -57,7 +57,7 @@ describe('Unit | Utility | labeled checkboxes', function () {
       answers: [false, true],
       output: []
     }]
-      .forEach(function (testCase) {
+      .forEach(function(testCase) {
         it('Should reply to proposals'
           + JSON.stringify(testCase.proposals)
           + ' and answers '

--- a/live/tests/unit/utils/labels-as-object-test.js
+++ b/live/tests/unit/utils/labels-as-object-test.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import labelsAsObject from 'pix-live/utils/labels-as-object';
 
 describe('Unit | Utility | labels as object', function() {
-  describe('#labelsAsObject', function () {
+  describe('#labelsAsObject', function() {
 
-    it('should return an object with labels and key on the input 1', function () {
+    it('should return an object with labels and key on the input 1', function() {
       // given
       const challenge = {
         proposals: 'Clé USB : ${num1}\n\n' +
@@ -28,7 +28,7 @@ describe('Unit | Utility | labels as object', function() {
 
     });
 
-    it('should return an object with labels and key on the input 2', function () {
+    it('should return an object with labels and key on the input 2', function() {
       // given
       const challenge = {
         proposals: '- Combien le dossier “projet PIX” contient-il de dossiers ? ${Num1}\n\n' +
@@ -46,7 +46,7 @@ describe('Unit | Utility | labels as object', function() {
       expect(result).to.be.deep.equal(expectedResult);
     });
 
-    it('should return an object with labels and key on the input 3', function () {
+    it('should return an object with labels and key on the input 3', function() {
       // given
       const challenge = {
         proposals: '- alain@pix.fr : ${num1}\n' +
@@ -72,7 +72,7 @@ describe('Unit | Utility | labels as object', function() {
       expect(result).to.be.deep.equal(expectedResult);
     });
 
-    it('should return object with labels and if the key of the input has a placeholder (after #), it does not keep the placeholder', function () {
+    it('should return object with labels and if the key of the input has a placeholder (after #), it does not keep the placeholder', function() {
       // given
       const challenge = {
         proposals: 'Nom du fichier : ${nomfichier}\nTaille (en ko) : ${taille}\nType : ${type}\nDate de modification : ${datemodif#JJ/MM/AAAA}'

--- a/live/tests/unit/utils/lodash-custom-test.js
+++ b/live/tests/unit/utils/lodash-custom-test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import _ from 'pix-live/utils/lodash-custom';
 
-describe('Unit | Utility | lodash custom', function () {
+describe('Unit | Utility | lodash custom', function() {
 
-  describe('#isNonEmptyString', function () {
+  describe('#isNonEmptyString', function() {
 
-    it('when no arg, returns false', function () {
+    it('when no arg, returns false', function() {
       expect(_.isNonEmptyString()).to.equal(false);
     });
 
@@ -17,15 +17,15 @@ describe('Unit | Utility | lodash custom', function () {
       { value: '', expected: false },
       { value: 'abcd', expected: true }
     ].forEach((item) => {
-      it(`should return ${item.expected} when value is ${item.value}`, function () {
+      it(`should return ${item.expected} when value is ${item.value}`, function() {
         expect(_.isNonEmptyString(item.value)).to.equal(item.expected);
       });
     });
   });
 
-  describe('#isNonEmptyArray', function () {
+  describe('#isNonEmptyArray', function() {
 
-    it('when no arg, returns false', function () {
+    it('when no arg, returns false', function() {
       expect(_.isNonEmptyArray()).to.equal(false);
     });
 
@@ -38,15 +38,15 @@ describe('Unit | Utility | lodash custom', function () {
       { value: ['myvalue'], expected: true },
       { value: ['1', null, true], expected: true }
     ].forEach((item) => {
-      it(`should return ${item.expected} when value of array is ${JSON.stringify(item.value)}`, function () {
+      it(`should return ${item.expected} when value of array is ${JSON.stringify(item.value)}`, function() {
         expect(_.isNonEmptyArray(item.value)).to.equal(item.expected);
       });
     });
   });
 
-  describe('#isNotInteger', function () {
+  describe('#isNotInteger', function() {
 
-    it('when no arg, returns false', function () {
+    it('when no arg, returns false', function() {
       expect(_.isNotInteger()).to.equal(true);
     });
 
@@ -60,15 +60,15 @@ describe('Unit | Utility | lodash custom', function () {
       { value: 5, expected: false },
       { value: '5', expected: true }
     ].forEach((item) => {
-      it(`should return ${item.expected} when value is ${item.value}`, function () {
+      it(`should return ${item.expected} when value is ${item.value}`, function() {
         expect(_.isNotInteger(item.value)).to.equal(item.expected);
       });
     });
   });
 
-  describe('#isTruthy', function () {
+  describe('#isTruthy', function() {
 
-    it('when no arg, returns false', function () {
+    it('when no arg, returns false', function() {
       expect(_.isTruthy()).to.equal(false);
     });
 
@@ -86,15 +86,15 @@ describe('Unit | Utility | lodash custom', function () {
       { value: '', expected: false },
       { value: 'foo', expected: true }
     ].forEach((item) => {
-      it(`should return ${item.expected} when value is ${item.value}`, function () {
+      it(`should return ${item.expected} when value is ${item.value}`, function() {
         expect(_.isTruthy(item.value)).to.equal(item.expected);
       });
     });
   });
 
-  describe('#hasSomeTruthyProps', function () {
+  describe('#hasSomeTruthyProps', function() {
 
-    it('when no arg, returns false', function () {
+    it('when no arg, returns false', function() {
       expect(_.hasSomeTruthyProps()).to.equal(false);
     });
 
@@ -114,13 +114,13 @@ describe('Unit | Utility | lodash custom', function () {
       { value: { a: '', b: false }, expected: false },
       { value: { a: 42, b: true }, expected: true }
     ].forEach((item) => {
-      it(`should return ${item.expected} when value is ${item.value}`, function () {
+      it(`should return ${item.expected} when value is ${item.value}`, function() {
         expect(_.hasSomeTruthyProps(item.value)).to.equal(item.expected);
       });
     });
   });
 
-  describe('#isNumeric', function () {
+  describe('#isNumeric', function() {
 
     [
       0,
@@ -137,8 +137,8 @@ describe('Unit | Utility | lodash custom', function () {
       Infinity,
       -Infinity,
       new Number('123')
-    ].forEach(function (n) {
-      it(`should return true when it is already a number type [n=${n}]`, function () {
+    ].forEach(function(n) {
+      it(`should return true when it is already a number type [n=${n}]`, function() {
         expect(_.isNumeric(n)).to.be.true;
       });
     });
@@ -151,8 +151,8 @@ describe('Unit | Utility | lodash custom', function () {
       '-1337.17',
       '0017',
       '00000.017',
-    ].forEach(function (n) {
-      it(`should return true when it is a string that looks like a number [n=${n}]`, function () {
+    ].forEach(function(n) {
+      it(`should return true when it is a string that looks like a number [n=${n}]`, function() {
         expect(_.isNumeric(n)).to.be.true;
       });
     });
@@ -171,12 +171,12 @@ describe('Unit | Utility | lodash custom', function () {
       false,
       [],
       {},
-      function () {
+      function() {
       },
       undefined,
       null,
-    ].forEach(function (n) {
-      it(`should return false when it is a string that does not look like a number [n=${n}]`, function () {
+    ].forEach(function(n) {
+      it(`should return false when it is a string that does not look like a number [n=${n}]`, function() {
         expect(_.isNumeric(n)).to.be.false;
       });
     });

--- a/live/tests/unit/utils/proposals-as-array-test.js
+++ b/live/tests/unit/utils/proposals-as-array-test.js
@@ -17,7 +17,6 @@ describe('Unit | Utility | proposals as array', function() {
     { data: '- foo\n\r\t\n\r\t\n\r\t\n- bar', expected: ['foo', 'bar'] }
   ];
 
-
   testData.forEach(({ data, expected }) => {
 
     it(`"${data.toString()}" retourne [${expected}]`, function() {

--- a/live/tests/unit/utils/proposals-as-array-test.js
+++ b/live/tests/unit/utils/proposals-as-array-test.js
@@ -20,7 +20,7 @@ describe('Unit | Utility | proposals as array', function() {
 
   testData.forEach(({ data, expected }) => {
 
-    it(`"${data.toString()}" retourne [${expected}]`, function () {
+    it(`"${data.toString()}" retourne [${expected}]`, function() {
       expect(proposalsAsArray(data)).to.deep.equal(expected);
     });
   });

--- a/live/tests/unit/utils/result-details-as-object-test.js
+++ b/live/tests/unit/utils/result-details-as-object-test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import resultDetailsAsObject from 'pix-live/utils/result-details-as-object';
 
-
 describe('#resultDetailsAsObject', function() {
 
   it('it should return an object from the yaml String', function() {

--- a/live/tests/unit/utils/result-details-as-object-test.js
+++ b/live/tests/unit/utils/result-details-as-object-test.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import resultDetailsAsObject from 'pix-live/utils/result-details-as-object';
 
 
-describe('#resultDetailsAsObject', function () {
+describe('#resultDetailsAsObject', function() {
 
-  it('it should return an object from the yaml String', function () {
+  it('it should return an object from the yaml String', function() {
     // given
     const resultDetailYaml = 'S1: false\nS2: true\n';
     const expectedObject = {S1 : false, S2 : true};
@@ -15,7 +15,7 @@ describe('#resultDetailsAsObject', function () {
     expect(result).to.deep.equal(expectedObject);
   });
 
-  it('it should return an empty object from the yaml String null\\n', function () {
+  it('it should return an empty object from the yaml String null\\n', function() {
     // given
     const resultDetailYaml = 'null\n';
     const expectedObject = {};

--- a/live/tests/unit/utils/solution-as-object-test.js
+++ b/live/tests/unit/utils/solution-as-object-test.js
@@ -4,9 +4,9 @@ import solutionAsObject from 'pix-live/utils/solution-as-object';
 
 describe('Unit | Utility | solution as object', function() {
 
-  describe('#solutionsAsObject', function () {
+  describe('#solutionsAsObject', function() {
 
-    it('should return an object which contains arrays of the solution for each input', function () {
+    it('should return an object which contains arrays of the solution for each input', function() {
       // given
       const solution = {
         value : 'num1:\n- 4\nnum2:\n- 2\nnum3:\n- 1\nnum4:\n- 3'
@@ -24,7 +24,7 @@ describe('Unit | Utility | solution as object', function() {
       expect(result).to.be.deep.equal(expectedResult);
     });
 
-    it('should return an object which contains arrays of the multiple potentials solution for each input', function () {
+    it('should return an object which contains arrays of the multiple potentials solution for each input', function() {
       // given
       const solution = {
         value : 'num1:\n- 2\nnum2:\n- 3\n- 4\nnum3:\n- 1\n- 5\n- 6'

--- a/live/tests/unit/utils/value-as-array-of-boolean-test.js
+++ b/live/tests/unit/utils/value-as-array-of-boolean-test.js
@@ -16,7 +16,7 @@ describe('Unit | Utility | value as array of boolean', function() {
 
   testData.forEach(({ when, input, expected }) => {
 
-    it(`"${when}", example : "${JSON.stringify(input)}" retourne [${expected}]`, function () {
+    it(`"${when}", example : "${JSON.stringify(input)}" retourne [${expected}]`, function() {
       expect(valueAsArrayOfBoolean(input)).to.deep.equal(expected);
     });
   });


### PR DESCRIPTION
Cette PR rajoute plusieurs avertissements au fichier ESLint.

### [space-before-blocks](http://eslint.org/docs/rules/space-before-blocks)

Transforme `function(){` en `function() {`.

### [space-before-function-paren](http://eslint.org/docs/rules/space-before-function-paren)

Transforme `function (bar) {` en `function(bar) {`.

### [space-in-parens](http://eslint.org/docs/rules/space-in-parens)

Transforme `function( foo, bar )` en `function(foo, bar)`.

### [eol-last](http://eslint.org/docs/rules/eol-last)

Requiert au **minimum** ligne vide à la fin de chaque fichier.

### [no-multiple-empty-lines](http://eslint.org/docs/rules/no-multiple-empty-lines)

Requiert au maximum une ligne vide à la fin de chaque fichier.

## Notes

Je suis preneur d'une review rapide, vu que ce sont beaucoup d'opérations (automatisées avec `eslint --fix`) qui touchent beaucoup de fichiers différents :)