### PR TITLE
[#416] [INFRA] Amélioration de la prise en compte du Markdown dans Ember.

### DIFF
--- a/live/app/templates/components/challenge-statement.hbs
+++ b/live/app/templates/components/challenge-statement.hbs
@@ -1,7 +1,6 @@
 {{#if challenge.instruction}}
   <div class="rounded-panel__row challenge-statement__instruction-section">
-    {{markdown-to-html class="challenge-statement__instruction" extensions='targetBlank'
-                       markdown=challenge.instruction}}
+    {{markdown-to-html class="challenge-statement__instruction" markdown=challenge.instruction}}
   </div>
 {{/if}}
 

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -43,10 +43,7 @@
 
       <div class="rounded-panel comparison-window__instruction">
         <div class="rounded-panel__row ">
-          {{markdown-to-html
-            class="challenge-statement__instruction"
-            extensions='targetBlank'
-            markdown=challenge.instruction}}
+          {{markdown-to-html class="challenge-statement__instruction" markdown=challenge.instruction}}
         </div>
 
         {{#if challenge.illustrationUrl}}

--- a/live/bower.json
+++ b/live/bower.json
@@ -8,8 +8,6 @@
     "animate.css": "^3.5.2",
     "loaders.css": "^0.1.2",
     "raven-js": "^3.8.1",
-    "showdown": "1.4.3",
-    "showdown-target-blank": "^1.0.1",
     "js-yaml": "^3.7.0",
     "lodash": "^4.17.2"
   }

--- a/live/config/environment.js
+++ b/live/config/environment.js
@@ -41,6 +41,10 @@ module.exports = function (environment) {
       'font-src': "'self' fonts.gstatic.com",
       'style-src': "'self' fonts.googleapis.com"
     },
+
+    showdown: {
+      openLinksInNewWindow: true
+    }
   };
 
   if (environment === 'development') {

--- a/live/ember-cli-build.js
+++ b/live/ember-cli-build.js
@@ -35,8 +35,6 @@ module.exports = function (defaults) {
   // along with the exports of each module as its value.
 
   app.import('bower_components/bootstrap/dist/js/bootstrap.js');
-  app.import('bower_components/showdown/dist/showdown.js');
-  app.import('bower_components/showdown-target-blank/dist/showdown-target-blank.js');
   app.import('bower_components/js-yaml/dist/js-yaml.js');
   app.import('bower_components/lodash/dist/lodash.js');
 

--- a/live/package.json
+++ b/live/package.json
@@ -38,7 +38,7 @@
     "ember-cli-release": "0.2.9",
     "ember-cli-sass": "6.1.1",
     "ember-cli-shims": "1.0.2",
-    "ember-cli-showdown": "2.11.0",
+    "ember-cli-showdown": "^3.1.1",
     "ember-cli-sri": "2.1.1",
     "ember-cli-test-loader": "1.1.1",
     "ember-cli-uglify": "1.2.0",
@@ -56,6 +56,7 @@
     "eslint": "3.16.0",
     "loader.js": "4.1.0",
     "phantomjs-prebuilt": "2.1.14",
+    "showdown": "showdownjs/showdown#1bca88f",
     "tap-xunit": "1.7.0"
   },
   "scripts": {

--- a/live/tests/acceptance/b2-epreuve-qcm-test.js
+++ b/live/tests/acceptance/b2-epreuve-qcm-test.js
@@ -26,7 +26,7 @@ describe('Acceptance | b2 - Afficher un QCM | ', function() {
   it('b2.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructionText = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs';
-    expect($challengeInstruction.text()).to.equal(instructionText);
+    expect($challengeInstruction.text().trim()).to.equal(instructionText);
   });
 
   it('b2.2 Le contenu de type [foo](bar) doit être converti sous forme de lien', function() {

--- a/live/tests/acceptance/b3-epreuve-qroc-test.js
+++ b/live/tests/acceptance/b3-epreuve-qroc-test.js
@@ -21,7 +21,7 @@ describe('Acceptance | b3 - Afficher un QROC | ', function() {
   it('b3.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre';
-    expect($challengeInstruction.text()).to.equal(instructiontext);
+    expect($challengeInstruction.text().trim()).to.equal(instructiontext);
   });
 
   it('b3.2 It should display only one input text as proposal to user', function() {

--- a/live/tests/acceptance/b4-epreuve-qrocm-test.js
+++ b/live/tests/acceptance/b4-epreuve-qrocm-test.js
@@ -21,7 +21,7 @@ describe('Acceptance | b4 - Afficher un QROCM | ', function() {
   it('b4.1 It should render challenge instruction', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
-    expect($challengeInstruction.text()).to.equal(instructiontext);
+    expect($challengeInstruction.text().trim()).to.equal(instructiontext);
   });
 
   it('b4.2 It should display only one input text as proposal to user', function() {

--- a/live/tests/acceptance/b7-epreuve-points-communs-test.js
+++ b/live/tests/acceptance/b7-epreuve-points-communs-test.js
@@ -23,7 +23,7 @@ describe('Acceptance | b7 - Points communs a toutes les épreuves | ', function(
   it('b7.1 L\'instruction de l\'epreuve est affichée', function() {
     const $challengeInstruction = $('.challenge-statement__instruction');
     const instructiontext = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
-    expect($challengeInstruction.text()).to.equal(instructiontext);
+    expect($challengeInstruction.text().trim()).to.equal(instructiontext);
   });
 
   it('b7.2a Le contenu de type [foo](bar) doit être converti sous forme de lien', function() {


### PR DESCRIPTION
L'objet de cette PR est d'améliorer notre intégration du moteur de rendu Markdown dans l'app Ember.

- montée de version de ember-cli-showdown
- ajout de la dépendance showdown dans le fichier `package.json` ; on utilise une version non releasée (qui tape sur GitHub) car l'option n'est pas encore présente dans les versions actuelles
- suppression du plugin ember-showdown-target-blank
- configuration dans la config d'environnement (nouveauté Ember 2.11) de l'addon ember-cli-showdown, pour que toutes les liens s'ouvrent par défaut dans un nouvel onglet
- mise à jour des tests pour tenir compte du nouveau fonctionnement qui rajoute un `\n` à la fin du texte markdown-isé (mais pas de nouvelle ligne côté DOM)