### PR TITLE
[#417] [CLEANUP] Déclaration de "jsyaml" en tant que variable globale dans ESLint côté front.

### DIFF
--- a/live/.eslintrc
+++ b/live/.eslintrc
@@ -4,3 +4,6 @@ env:
   jquery: true
 parserOptions:
   sourceType: module
+globals:
+  jsyaml: true
+

--- a/live/app/components/challenge-item-qrocm.js
+++ b/live/app/components/challenge-item-qrocm.js
@@ -1,4 +1,3 @@
-/* global jsyaml */
 import _ from 'pix-live/utils/lodash-custom';
 
 import ChallengeItemGeneric from './challenge-item-generic';

--- a/live/app/models/answer/value-as-array-of-string-mixin.js
+++ b/live/app/models/answer/value-as-array-of-string-mixin.js
@@ -1,4 +1,3 @@
-/* global jsyaml */
 import Ember from 'ember';
 
 export default Ember.Mixin.create({

--- a/live/app/utils/answers-as-object.js
+++ b/live/app/utils/answers-as-object.js
@@ -1,5 +1,3 @@
-/* global jsyaml */
-
 export default function answersAsObject(answer, inputKeys) {
   if (answer === '#ABAND#') {
     return inputKeys.reduce((answersObject, key) => {

--- a/live/app/utils/result-details-as-object.js
+++ b/live/app/utils/result-details-as-object.js
@@ -1,5 +1,3 @@
-/* global jsyaml */
-
 export default function resultDetailsAsObject(yamlResultDetails) {
   let resultDetailsAsObject = {};
   if (yamlResultDetails !== 'null\n') {

--- a/live/app/utils/solution-as-object.js
+++ b/live/app/utils/solution-as-object.js
@@ -1,4 +1,3 @@
-/* global jsyaml */
 import _ from 'lodash';
 
 function transformSolutionsToString(solutionsAsObject) {


### PR DESCRIPTION
Cette PR a pour objet de ne plus avoir besoin de déclarer `/* global jsyaml */` chauqe fois qu'on souhaite faire appel à js-yaml pour parser du YAML côté Ember.