### PR TITLE
[#421] [CLEANUP] Rend l’appli plus proche du template par défaut

### DIFF
--- a/live/app/router.js
+++ b/live/app/router.js
@@ -28,7 +28,7 @@ if (config.environment === 'integration' || config.environment === 'staging' || 
   });
 }
 
-export default Router.map(function() {
+Router.map(function() {
   this.route('index', { path: '/' });
   this.route('courses');
   this.route('placement-tests');
@@ -47,3 +47,5 @@ export default Router.map(function() {
   this.route('assessments.get-results', { path: '/assessments/:assessment_id/results' });
   this.route('assessments.get-comparison', { path: '/assessments/:assessment_id/results/compare/:answer_id/:index' });
 });
+
+export default Router;

--- a/live/ember-cli-build.js
+++ b/live/ember-cli-build.js
@@ -1,6 +1,5 @@
-/*jshint node:true*/
-/* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+/* eslint-env node */
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 /* postcss plugins */
 

--- a/live/package.json
+++ b/live/package.json
@@ -2,16 +2,29 @@
   "name": "pix-live",
   "version": "1.11.0",
   "description": "Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones.",
-  "private": true,
+  "license": "AGPL-3.0",
+  "author": "SGMAP",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "engines": {
-    "node": ">= 7.7.4"
+  "scripts": {
+    "postinstall": "bower cache clean && bower install",
+    "build": "ember build",
+    "clean": "rm -rf tmp dist bower_components node_modules",
+    "start": "ember server",
+    "test": "ember test",
+    "lint": "./node_modules/.bin/eslint app mirage tests --fix",
+    "coverage:check": "COVERAGE=true ember test",
+    "coverage:convert": "node scripts/lcov-path-converter",
+    "coverage:rename": "mv coverage/lcov.info ../coverage/live_lcov.info",
+    "coverage": "npm run coverage:check && npm run coverage:convert && npm run coverage:rename",
+    "test:watch": "ember test --serve",
+    "ci:test": "COVERAGE=true ember test",
+    "deploy:integration": "./scripts/deploy.sh integration",
+    "deploy:staging": "./scripts/deploy.sh staging",
+    "deploy:production": "./scripts/deploy.sh production"
   },
-  "author": "SGMAP",
-  "license": "AGPL-3.0",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
     "codeclimate-test-reporter": "^0.4.1",
@@ -56,21 +69,8 @@
     "phantomjs-prebuilt": "2.1.14",
     "showdown": "showdownjs/showdown#1bca88f"
   },
-  "scripts": {
-    "postinstall": "bower cache clean && bower install",
-    "build": "ember build",
-    "clean": "rm -rf tmp dist bower_components node_modules",
-    "start": "ember server",
-    "test": "ember test",
-    "lint": "./node_modules/.bin/eslint app mirage tests --fix",
-    "coverage:check": "COVERAGE=true ember test",
-    "coverage:convert": "node scripts/lcov-path-converter",
-    "coverage:rename": "mv coverage/lcov.info ../coverage/live_lcov.info",
-    "coverage": "npm run coverage:check && npm run coverage:convert && npm run coverage:rename",
-    "test:watch": "ember test --serve",
-    "ci:test": "COVERAGE=true ember test",
-    "deploy:integration": "./scripts/deploy.sh integration",
-    "deploy:staging": "./scripts/deploy.sh staging",
-    "deploy:production": "./scripts/deploy.sh production"
-  }
+  "engines": {
+    "node": ">= 7.7.4"
+  },
+  "private": true
 }

--- a/live/testem.js
+++ b/live/testem.js
@@ -1,13 +1,13 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
-  'framework': 'mocha',
-  'test_page': 'tests/index.html?hidepassed',
-  'disable_watching': true,
-  'launch_in_ci': [
-    'PhantomJS'
+  "framework": "mocha",
+  "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
+  "launch_in_ci": [
+    "PhantomJS"
   ],
-  'launch_in_dev': [
-    'PhantomJS',
-    'Chrome'
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
   ]
 };

--- a/live/tests/.eslintrc.js
+++ b/live/tests/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   env: {
-    'embertest': true,
-    'mocha': true
+    embertest: true,
+    mocha: true
   },
   globals: {
     'Showdown': false,

--- a/live/tests/helpers/start-app.js
+++ b/live/tests/helpers/start-app.js
@@ -3,16 +3,13 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let application;
-
   let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
-    application = Application.create(attributes);
+  return Ember.run(() => {
+    const application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
+    return application;
   });
-
-  return application;
 }

--- a/live/tests/index.html
+++ b/live/tests/index.html
@@ -16,9 +16,6 @@
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
-
-
-
   </head>
   <body>
     {{content-for "body"}}


### PR DESCRIPTION
Ça permet d’avoir moins de diff quand on lance `ember init` après une montée de version d’ember-cli. Ça devrait rendre plus simple les montées de version suivantes.