### PR TITLE
[#424] [CLEANUP] Corrige des dépréciations dans les tests

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -3,8 +3,6 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
 const App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/live/package.json
+++ b/live/package.json
@@ -61,7 +61,7 @@
     "ember-math-helpers": "^2.1.0",
     "ember-metrics": "^0.10.0",
     "ember-resolver": "^4.1.0",
-    "ember-routable-modal": "^0.3.1",
+    "ember-routable-modal": "dbbk/ember-routable-modal#9839af4",
     "ember-route-action-helper": "^2.0.3",
     "ember-source": "^2.12.2",
     "eslint": "^3.19.0",


### PR DESCRIPTION
### `MODEL_FACTORY_INJECTIONS`

Le comportement activé par `Ember.MODEL_FACTORY_INJECTIONS = true` est maintenant le comportement par défaut.

Ça corrige le message :

```
DEPRECATION: Ember.MODEL_FACTORY_INJECTIONS is no longer required [deprecation id: ember-metal.model_factory_injections] See http://emberjs.com/deprecations/v2.x#toc_code-ember-model-factory-injections for more details.
```

### `ember-routable-modal`

Ember-routable-modal utilisait une manière dépréciée de manipuler le routeur. J'ai [fait une PR](https://github.com/dbbk/ember-routable-modal/pull/4) dans le projet pour corriger ça.

Ça corrige le message :

```
DEPRECATION: [DEPRECATED] Ember will stop passing arguments to component lifecycle hooks. Please change `<pix-live@component:cp-panel::ember6275>#didReceiveAttrs` to stop taking arguments. [deprecation id: ember-views.lifecycle-hook-arguments] See http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks for more details.
```