### PR TITLE
[#438] [INFRA] Améliorer la façon de charger les scénarios pour les tests adaptatifs dans les Review Apps

### DIFF
--- a/api/scripts/add_adaptative_tests.py
+++ b/api/scripts/add_adaptative_tests.py
@@ -1,5 +1,5 @@
 import json, sqlite3, csv, sys
-connection = sqlite3.connect('../api/db/dev.sqlite3')
+connection = sqlite3.connect('../db/dev.sqlite3')
 
 filename = sys.argv[1]
 

--- a/api/scripts/add_adaptive_tests.py
+++ b/api/scripts/add_adaptive_tests.py
@@ -1,5 +1,5 @@
 import json, sqlite3, csv, sys
-connection = sqlite3.connect('../db/dev.sqlite3')
+connection = sqlite3.connect('./db/dev.sqlite3')
 
 filename = sys.argv[1]
 

--- a/cli/pix-cli.sh
+++ b/cli/pix-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PIX_CLI_VERSION="1.2.0"
+PIX_CLI_VERSION="1.3.0"
 
 COMMAND=$1
 
@@ -190,26 +190,54 @@ if [ "$COMMAND" == "placement_tests:list" ]; then
 
   ls ~/placement_tests
 
-  echo ${PIX_CLI_VERSION}
   exit 0
 fi
 
 # pix placement_tests:load <scenarios_file> <app_name>
 # ex: pix placement_tests:load scenarios11.csv 213-connect-to-account
-if [ "$COMMAND" == "placement_tests:list" ]; then
+if [ "$COMMAND" == "placement_tests:load" ]; then
   if [ $# -ne 3 ]; then
     echo "Bad number of arguments. See usage for command $COMMAND."
     exit 1
   fi
 
   SCENARIOS_FILE=$2
+  if [ ! -e ~/placement_tests/$SCENARIOS_FILE ]; then
+    echo "File ~/placement_tests/$SCENARIOS_FILE does not exists."
+    echo "Available adaptive tests scenarios files are:"
+    echo ""
+    ls ~/placement_tests
+    echo ""
+    exit 1
+  fi
+
   APP_NAME=$3
+  dokku apps:list | grep $APP_NAME > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "Application $APP_NAME does not exist."
+    echo "Available applications are:"
+    echo ""
+    dokku apps:list
+    echo ""
+    exit 1
+  fi
 
-  dokku storage:mount $APP_NAME /var/lib/dokku/data/storage/placement_tests:/placement_tests
-  dokku ps:restart $APP_NAME
-  dokku run $APP_NAME ./scripts/add_adaptive_tests.py $SCENARIOS_FILE
+  echo "Check if volume /var/lib/dokku/data/storage/placement_tests is already mounted on application $APP_NAME"
+  dokku run infra-improve-adaptive-tests-integration ls /placement_tests > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "Mount path does not exist."
+    echo "Create mount point for volume /var/lib/dokku/data/storage/placement_tests on /placement_tests."
+    dokku storage:mount $APP_NAME /var/lib/dokku/data/storage/placement_tests:/placement_tests
+    echo "Restart the application in order to take into account the new mount point."
+    dokku ps:restart $APP_NAME
+  else
+    echo "Mount path already set :-)"
+  fi
 
-  echo ${PIX_CLI_VERSION}
+  echo "Load all the given adaptive test scenarios into the application internal database."
+  dokku run $APP_NAME python ./scripts/add_adaptive_tests.py /placement_tests/$SCENARIOS_FILE
+  echo "Scenarios successfully loaded."
+
   exit 0
 fi
 

--- a/cli/pix-cli.sh
+++ b/cli/pix-cli.sh
@@ -15,15 +15,17 @@ if [ "$COMMAND" == "help" ]; then
   echo ""
   echo "Commands:"
   echo ""
-  echo "  help                                          # Display PIX-CLI usage"
-  echo "  db:backup <environment>                       # Export a dump of the postgres service database"
-  echo "  db:restore <environment> <file>               # Restore a database by importing a PostgreSQL dump file"
-  echo "  db:logs <environment>                         # Print the most recent log(s) for the database of the given environment"
-  echo "  app:logs <environment>                        # Show the last log(s) of the given environment"
-  echo "  ssh-keys:add <name> </path/to/key>            # Add a new public key by pipe or path (alias for Dokku command 'ssh-keys:add')"
-  echo "  ssh-keys:list                                 # List of all authorized dokku public ssh keys (alias for Dokku command 'ssh-keys:list')"
-  echo "  ssh-keys:remove <name>                        # Remove SSH public key by name (alias for Dokku command ssh-keys:remove'')"
-  echo "  version                                       # Display current version of PIX-CLI"
+  echo "  help                                              # Display PIX-CLI usage"
+  echo "  db:backup <environment>                           # Export a dump of the postgres service database"
+  echo "  db:restore <environment> <file>                   # Restore a database by importing a PostgreSQL dump file"
+  echo "  db:logs <environment>                             # Print the most recent log(s) for the database of the given environment"
+  echo "  app:logs <environment>                            # Show the last log(s) of the given environment"
+  echo "  ssh-keys:add <name> </path/to/key>                # Add a new public key by pipe or path (alias for Dokku command 'ssh-keys:add')"
+  echo "  ssh-keys:list                                     # List of all authorized dokku public ssh keys (alias for Dokku command 'ssh-keys:list')"
+  echo "  ssh-keys:remove <name>                            # Remove SSH public key by name (alias for Dokku command ssh-keys:remove'')"
+  echo "  placement_tests:list                              # List all the placement tests scenarios files (.csv) available"
+  echo "  placement_tests:load <scenarios_file> <app_name>  # Load into database the given scenarios file into the given Dokku application"
+  echo "  version                                           # Display current version of PIX-CLI"
   echo ""
   exit 0
 fi
@@ -173,6 +175,39 @@ if [ "$COMMAND" == "version" ]; then
     echo "Bad number of arguments. See usage for command $COMMAND."
     exit 1
   fi
+
+  echo ${PIX_CLI_VERSION}
+  exit 0
+fi
+
+# pix placement_tests:list
+# ex: pix placement_tests:list
+if [ "$COMMAND" == "placement_tests:list" ]; then
+  if [ $# -ne 1 ]; then
+    echo "Bad number of arguments. See usage for command $COMMAND."
+    exit 1
+  fi
+
+  ls ~/placement_tests
+
+  echo ${PIX_CLI_VERSION}
+  exit 0
+fi
+
+# pix placement_tests:load <scenarios_file> <app_name>
+# ex: pix placement_tests:load scenarios11.csv 213-connect-to-account
+if [ "$COMMAND" == "placement_tests:list" ]; then
+  if [ $# -ne 3 ]; then
+    echo "Bad number of arguments. See usage for command $COMMAND."
+    exit 1
+  fi
+
+  SCENARIOS_FILE=$2
+  APP_NAME=$3
+
+  dokku storage:mount $APP_NAME /var/lib/dokku/data/storage/placement_tests:/placement_tests
+  dokku ps:restart $APP_NAME
+  dokku run $APP_NAME ./scripts/add_adaptive_tests.py $SCENARIOS_FILE
 
   echo ${PIX_CLI_VERSION}
   exit 0


### PR DESCRIPTION
Cette PR a pour objet de rendre l'équipe plus autonome sur le chargement des scénarios des tests adaptatifs en base pour les Review Apps :

- renommage et déplacement du fichier `scripts/add_scenarios.py` dans `api/scripts/add_placement_tests.py`
- ajout du montage de volume dans le script de déploiement