### PR TITLE
[#443] [CLEANUP] Acceptance tests: before → beforeEach

### DIFF
--- a/live/tests/acceptance/a1-page-accueil-test.js
+++ b/live/tests/acceptance/a1-page-accueil-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -7,12 +7,12 @@ describe('Acceptance | a1 - La page d\'accueil', function() {
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
     visit('/');
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/b4-epreuve-qrocm-test.js
+++ b/live/tests/acceptance/b4-epreuve-qrocm-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -7,12 +7,12 @@ describe('Acceptance | b4 - Afficher un QROCM | ', function() {
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/c1-recapitulatif-test.js
+++ b/live/tests/acceptance/c1-recapitulatif-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 
 import startApp from '../helpers/start-app';
@@ -8,12 +8,12 @@ describe('Acceptance | c1 - Consulter l\'écran de fin d\'un test ', function() 
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
     visit('/assessments/ref_assessment_id/results');
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/d1-epreuve-validation-test.js
+++ b/live/tests/acceptance/d1-epreuve-validation-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -8,29 +8,32 @@ function visitTimedChallenge() {
   click('.challenge-item-warning button');
 }
 
+function progressBarText() {
+  const PROGRESS_BAR_SELECTOR = '.pix-progress-bar';
+  return findWithAssert(PROGRESS_BAR_SELECTOR).text().trim();
+}
+
 describe('Acceptance | d1 - Valider une épreuve |', function() {
 
   let application;
-  const PROGRESS_BAR_SELECTOR = '.pix-progress-bar';
-  before(function() {
+
+  beforeEach(function() {
     application = startApp();
     visitTimedChallenge();
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 
   it('d1.0a La barre de progression commence à 1, si j\'accède au challenge depuis l\'url directe', function() {
-    const $progressBar = findWithAssert(PROGRESS_BAR_SELECTOR);
-    expect($progressBar.text().trim()).to.equal('1 / 5');
+    expect(progressBarText()).to.equal('1 / 5');
   });
 
   it('d1.0b La barre de progression commence à 1, si j\'accède au challenge depuis depuis le lien Airtable', async function() {
     await visit('/courses/ref_course_id');
     await click('.challenge-item-warning button');
-    const $progressBar = findWithAssert(PROGRESS_BAR_SELECTOR);
-    expect($progressBar.text().trim()).to.equal('1 / 5');
+    expect(progressBarText()).to.equal('1 / 5');
   });
 
   it('d1.1 Je peux valider ma réponse à une épreuve via un bouton "Je valide"', function() {
@@ -38,16 +41,17 @@ describe('Acceptance | d1 - Valider une épreuve |', function() {
   });
 
   describe('quand je valide ma réponse à une épreuve', function() {
-
-    it('d1.3 Si l\'épreuve que je viens de valider n\'était pas la dernière du test, je suis redirigé vers l\'épreuve suivante', async function() {
+    beforeEach(async function() {
       await click('.proposal-text');
       await click('.challenge-actions__action-validate');
+    });
+
+    it('d1.3 Si l\'épreuve que je viens de valider n\'était pas la dernière du test, je suis redirigé vers l\'épreuve suivante', async function() {
       expect(currentURL()).to.contain('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
     });
 
-    it('d1.4 La barre de progression avance d\'une unité, de 1 à 2.', function() {
-      const expectedText = '2';
-      expect(findWithAssert('.pix-progress-bar').text()).to.contain(expectedText);
+    it('d1.4 La barre de progression avance d\'une unité, de 1 à 2.', async function() {
+      expect(progressBarText()).to.equal('2 / 5');
     });
 
     it('d1.5 Si l\'épreuve que je viens de valider était la dernière du test, je suis redirigé vers la page de fin du test', async function() {

--- a/live/tests/acceptance/f1-previsualisation-test-test.js
+++ b/live/tests/acceptance/f1-previsualisation-test-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -7,17 +7,17 @@ describe('Acceptance | f1 - Prévisualisation  d\'un test |', function() {
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 
   describe('Prévisualiser la première page d\'un test |', function() {
 
-    before(function() {
+    beforeEach(function() {
       visit('/courses/ref_course_id/preview');
     });
 
@@ -29,7 +29,7 @@ describe('Acceptance | f1 - Prévisualisation  d\'un test |', function() {
 
     describe('On affiche', function() {
 
-      before(function() {
+      beforeEach(function() {
         $preview = findWithAssert('#course-preview');
       });
 
@@ -53,8 +53,9 @@ describe('Acceptance | f1 - Prévisualisation  d\'un test |', function() {
 
   describe('Prévisualiser une épreuve dans le cadre d\'un test |', function() {
 
-    before(function() {
-      visit('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
+    beforeEach(async function() {
+      await visit('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
+      await click('.challenge-item-warning button');
     });
 
     it('f1.5 L\'accès à la preview d\'une épreuve d\'un test se fait en accédant à l\'URL /courses/:course_id/preview/challenges/:challenge_id', function() {
@@ -63,20 +64,12 @@ describe('Acceptance | f1 - Prévisualisation  d\'un test |', function() {
 
     describe('On affiche', function() {
 
-      let $challenge;
-
-      before(function() {
-        $challenge = findWithAssert('.challenge-preview');
-      });
-
-      it('f1.6 la consigne de l\'épreuve', async function() {
-        await visit('/courses/ref_course_id/preview/challenges/ref_qcm_challenge_id');
-        await click('.challenge-item-warning button');
-        expect($challenge.find('.challenge-statement__instruction').html()).to.contain('Un QCM propose plusieurs choix');
+      it('f1.6 la consigne de l\'épreuve', function() {
+        expect(findWithAssert('.challenge-preview .challenge-statement__instruction').html()).to.contain('Un QCM propose plusieurs choix');
       });
 
       it('f1.7 un bouton pour accéder à l\'épreuve suivante', function() {
-        expect(findWithAssert('.challenge-actions__action-validate').text()).to.contain('Je valide');
+        expect(findWithAssert('.challenge-preview .challenge-actions__action-validate').text()).to.contain('Je valide');
       });
     });
   });

--- a/live/tests/acceptance/h1-timeout-jauge-test.js
+++ b/live/tests/acceptance/h1-timeout-jauge-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -18,11 +18,11 @@ describe('Acceptance | H1 - Timeout Jauge | ', function() {
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/j1-compare-answer-solution-test.js
+++ b/live/tests/acceptance/j1-compare-answer-solution-test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -21,11 +21,11 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 
@@ -41,17 +41,19 @@ describe('Acceptance | j1 - Comparer réponses et solutions pour un QCM |', func
   });
 
   describe('j1.2 Accès à la modale', function() {
-    it('j1.2.2 On peut accèder directement à la modale via URL et fermer la modale' , async function() {
-      await visit(COMPARISON_MODAL_URL);
+
+    it('j1.2.1 Si on clique sur REPONSE la modale s\'ouvre', async function() {
+      await visit(RESULT_URL);
+      expect($('.comparison-window')).to.have.lengthOf(0);
+      await click('.result-item__correction__button');
       expect($('.comparison-window')).to.have.lengthOf(1);
       // XXX test env needs the modal to be closed manually
       await click('.close-button-container');
       expect($('.comparison-window')).to.have.lengthOf(0);
     });
-    it('j1.2.1 Si on clique sur REPONSE la modale s\'ouvre' , async function() {
-      await visit(RESULT_URL);
-      expect($('.comparison-window')).to.have.lengthOf(0);
-      await click('.result-item__correction__button');
+
+    it('j1.2.2 On peut accèder directement à la modale via URL et fermer la modale', async function() {
+      await visit(COMPARISON_MODAL_URL);
       expect($('.comparison-window')).to.have.lengthOf(1);
       // XXX test env needs the modal to be closed manually
       await click('.close-button-container');

--- a/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
+++ b/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -16,18 +16,18 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
 
   let application;
 
-  before(function() {
+  beforeEach(function() {
     application = startApp();
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 
   describe('j2.1 Depuis la page résultat', function() {
 
-    before(function() {
-      visit(RESULT_URL);
+    beforeEach(async function() {
+      await visit(RESULT_URL);
     });
 
     it('affiche le lien REPONSE vers la modale depuis l\'ecran des resultats pour un QROC', async function() {
@@ -44,8 +44,8 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
 
   describe('j2.2 Contenu de la modale de correction pour un QROC', function() {
 
-    before(function() {
-      visit(COMPARISON_MODAL_URL);
+    beforeEach(async function() {
+      await visit(COMPARISON_MODAL_URL);
     });
 
     it('possible d\'accéder à la modale depuis l\'URL', async function() {

--- a/live/tests/acceptance/k1-competences-page-test.js
+++ b/live/tests/acceptance/k1-competences-page-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -7,15 +7,12 @@ describe('Acceptance | competences page', function() {
 
   let application;
 
-  before(function() {
-    // given
+  beforeEach(function() {
     application = startApp();
-
-    // when
     visit('/competences');
   });
 
-  after(function() {
+  afterEach(function() {
     destroyApp(application);
   });
 

--- a/live/tests/acceptance/l1-signaler-une-epreuve-test.js
+++ b/live/tests/acceptance/l1-signaler-une-epreuve-test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -25,11 +25,11 @@ describe('Acceptance | Signaler une épreuve', function() {
 
   describe('l1.1 Depuis une epreuve', function() {
 
-    before(function() {
+    beforeEach(function() {
       application = startApp();
     });
 
-    after(function() {
+    afterEach(function() {
       destroyApp(application);
     });
 

--- a/live/tests/test-helper.js
+++ b/live/tests/test-helper.js
@@ -5,7 +5,7 @@ import {
 import { mocha } from 'mocha';
 
 mocha.setup({
-  timeout: 2000,
+  timeout: 4000,
   slow: 500,
 });
 


### PR DESCRIPTION
Many acceptance tests were setting up the app once at the beginning of
the test suite (using `before`), running many tests, and destroying it
only once at the end of the whole suite.

This causes tests to be:

- Order-dependant: the app is expected to be in the state left by a previous test ;
- Fragile: the outcome of one test can leak on another.


This PR ensures that the app is re-created from scratch at the
beginning of each acceptance test case.