### PR TITLE
[#444] [CLEANUP] Result-item: remove tooltip delay

### DIFF
--- a/live/app/components/result-item.js
+++ b/live/app/components/result-item.js
@@ -32,8 +32,6 @@ const contentReference = {
   }
 };
 
-const timeOutAfterRender = 1000; // FIXME: This trigger the tooltip after rendering
-
 export default Ember.Component.extend({
 
   classNames: [ 'result-item' ],
@@ -47,6 +45,10 @@ export default Ember.Component.extend({
     return contentReference[ this.get('answer.result') ] || contentReference[ 'default' ];
   }),
 
+  resultTooltip: Ember.computed('resultItem', function() {
+    return this.get('resultItem') ? this.get('resultItem').tooltip : null;
+  }),
+
   validationImplementedForChallengeType: Ember.computed('answer.challenge.type', function() {
     const implementedTypes = [ 'QCM', 'QROC', 'QCU', 'QROCM-ind' ];
     const challengeType = this.get('answer.challenge.type');
@@ -55,9 +57,13 @@ export default Ember.Component.extend({
 
   didRender() {
     this._super(...arguments);
-    Ember.run.debounce(this, function() {
-      $('[data-toggle="tooltip"]').tooltip();
-    }, timeOutAfterRender);
+
+    const tooltipElement = this.$('[data-toggle="tooltip"]');
+    const tooltipValue = this.get('resultTooltip');
+
+    if (tooltipValue) {
+      tooltipElement.tooltip({ title: tooltipValue });
+    }
   },
 
   actions: {

--- a/live/tests/integration/components/result-item-test.js
+++ b/live/tests/integration/components/result-item-test.js
@@ -93,7 +93,7 @@ describe('Integration | Component | result item', function() {
       expect(this.$('.result-item__correction__button').text().trim()).to.deep.equal('RÉPONSE');
     });
 
-    it('should render tooltip with title Réponse incorrecte', function() {
+    it('should render tooltip for the answer', function() {
       // given
       this.set('answer', answer);
 
@@ -101,7 +101,30 @@ describe('Integration | Component | result item', function() {
       this.render(hbs`{{result-item answer=answer index=index}}`);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('title').trim()).to.equal('Réponse incorrecte');
+      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
+    });
+
+    it('should not render a tooltip when the answer is being retrieved', function() {
+      // given
+      this.set('answer', null);
+
+      // when
+      this.render(hbs`{{result-item answer=answer index=index}}`);
+
+      // then
+      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title')).to.equal(undefined);
+    });
+
+    it('should update the tooltip when the answer is eventually retrieved', function() {
+      // given
+      this.set('answer', null);
+      this.render(hbs`{{result-item answer=answer index=index}}`);
+
+      // when
+      this.set('answer', answer);
+
+      // then
+      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
     });
 
     it('should render tooltip with an image', function() {

--- a/live/tests/test-helper.js
+++ b/live/tests/test-helper.js
@@ -5,7 +5,7 @@ import {
 import { mocha } from 'mocha';
 
 mocha.setup({
-  timeout: 2000,
+  timeout: 1500,
   slow: 500,
 });
 


### PR DESCRIPTION
The `result-item` component currently initializes its tooltip only after a 1s-delay. This is intended to work around an issue where the tooltip text in the DOM is empty, although the value is correctly set on the model.

This workaround has several issues:

- It is fragile. Random delays are never good (and this one is quite brittle, as we will see later) ;
- It makes acceptance tests slow. The acceptance tests runner waits for all requests, promises and timers to be resolved before executing the next step of a test. This means every render adds 1s to the duration of acceptance tests. Some tests take up to 3s because of this.

## The root cause

The actual issue is a sequence of event where:

1. The component is initially rendered with a `null` answer (as the answer is not retrieved yet) ;
2. Therefore, during the initial `didRender`, the tooltip is first initialized with a `null` tooltip ;
3. When the answer is finally available, `didRender` is called again, and the tooltip is initialized with the correct tooltip value ;
4. Unfortunately **Bootstrap’s tooltips can’t be initialized twice**: they will silently keep the initial value.

This is why the workaround _kind-of_ worked: the 1s-delay was enough to wait for the answer being available before initializing the tooltip. Obviously, if the answer took more than 1s to be ready, the tooltip would break.

## The fix

The fix is simply to wait for the answer to be available before initializing the tooltip. This behavior has been unit-tested, and should be robust enough.

It also makes acceptance tests fast again:

- Before this PR: `time ember test` → 1m 15s
- With this PR: `time ember test` → 50s

## Caveats

We only delay the tooltip initialization for empty answers. If an answer is set, and later changes, the tooltip will keep the initial value.

As we don’t need this use case yet, I chose to keep the code simple and well-tested for the cases we actually encounter. It should be easy enough to implement updating tooltips if we ever need it.