### PR TITLE
[#450] [CLEANUP] Met à jour Ember-Data vers la version 2.13

### DIFF
--- a/live/package.json
+++ b/live/package.json
@@ -54,7 +54,7 @@
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-collapsible-panel": "~2.1.1",
-    "ember-data": "~2.12.0",
+    "ember-data": "~2.13.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-lodash": "^4.17.2",

--- a/live/package.json
+++ b/live/package.json
@@ -54,7 +54,7 @@
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-collapsible-panel": "~2.1.1",
-    "ember-data": "2.11.1",
+    "ember-data": "~2.12.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-lodash": "^4.17.2",


### PR DESCRIPTION
On passe de Ember-Data 2.11 à 2.13.

- [Notes de version pour la 2.12](https://www.emberjs.com/blog/2017/03/19/ember-2-12-released.html#toc_ember-data)
- [Notes de version pour la 2.13](https://www.emberjs.com/blog/2017/04/29/ember-2-13-released.html#toc_ember-data)

## Dépend de

- [x] https://github.com/sgmap/pix/pull/448
- [x] https://github.com/sgmap/pix/pull/449

## À tester

Les tests passent. Après il faut vérifier que fonctionnellement tout marche bien dans l'appli :)