### PR TITLE
[#454] [CLEANUP] Corrige les erreurs 404 qui apparaissent lors des tests

### DIFF
--- a/live/app/components/comparison-window.js
+++ b/live/app/components/comparison-window.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import resultIconUrl from 'pix-live/utils/result-icon-url';
 
 const contentReference = {
   ok: {
@@ -95,5 +96,9 @@ export default Ember.Component.extend({
       resultItem = contentReference[ answerStatus ];
     }
     return resultItem;
+  }),
+
+  resultItemIcon: Ember.computed('resultItem', function() {
+    return resultIconUrl(this.get('resultItem.status'));
   })
 });

--- a/live/app/components/result-item.js
+++ b/live/app/components/result-item.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import resultIconUrl from 'pix-live/utils/result-icon-url';
 
 const contentReference = {
   ok: {
@@ -47,6 +48,10 @@ export default Ember.Component.extend({
 
   resultTooltip: Ember.computed('resultItem', function() {
     return this.get('resultItem') ? this.get('resultItem').tooltip : null;
+  }),
+
+  resultItemIcon: Ember.computed('resultItem', function() {
+    return resultIconUrl(this.get('resultItem.status'));
   }),
 
   validationImplementedForChallengeType: Ember.computed('answer.challenge.type', function() {

--- a/live/app/templates/components/app-footer.hbs
+++ b/live/app/templates/components/app-footer.hbs
@@ -9,5 +9,5 @@
 </section>
 
 <section class="app-footer__section app-footer__section--marianne-logo">
-  <img src="{{rootURL}}images/mnsr3.svg" class="app-footer__logo-marianne-img" alt="Logo du Ministère de l'Éducation Nationale, de l'Enseignement Supérieur et de la Recherche">
+  <img src="/images/mnsr3.svg" class="app-footer__logo-marianne-img" alt="Logo du Ministère de l'Éducation Nationale, de l'Enseignement Supérieur et de la Recherche">
 </section>

--- a/live/app/templates/components/comparison-window.hbs
+++ b/live/app/templates/components/comparison-window.hbs
@@ -23,7 +23,7 @@
 
       <div class="comparison-window__title">
         <div data-toggle="tooltip" data-placement="top" title="{{resultItem.tooltip}}">
-          <img class="comparison-window__result-icon comparison-window__result-icon--{{resultItem.status}}" src="/images/answer-validation/icon-{{resultItem.status}}.svg" alt="">
+          <img class="comparison-window__result-icon comparison-window__result-icon--{{resultItem.status}}" src={{resultItemIcon}} alt="">
         </div>
       </div>
       <div class="comparison-window__title-text">{{resultItem.title}}</div>

--- a/live/app/templates/components/feature-item.hbs
+++ b/live/app/templates/components/feature-item.hbs
@@ -1,5 +1,5 @@
 <div class="feature-item__icon-container">
-  <img class="feature-item__icon" src="{{rootURL}}images/features/icon-{{feature.icon}}.svg">
+  <img class="feature-item__icon" src="/images/features/icon-{{feature.icon}}.svg">
 </div>
 <div class="feature-item__title">{{feature.title}}</div>
 <div class="feature-item__description">{{feature.description}}</div>

--- a/live/app/templates/components/result-item.hbs
+++ b/live/app/templates/components/result-item.hbs
@@ -6,7 +6,7 @@
 
 <div class="result-item__icon">
   <div data-toggle="tooltip" data-placement="top" title="{{resultItem.tooltip}}">
-    <img class="result-item__icon-img result-item__icon-img--{{resultItem.status}}" src="/images/answer-validation/icon-{{resultItem.status}}.svg" alt="">
+    <img class="result-item__icon-img result-item__icon-img--{{resultItem.status}}" src={{resultItemIcon}} alt="">
   </div>
 </div>
 

--- a/live/app/utils/result-icon-url.js
+++ b/live/app/utils/result-icon-url.js
@@ -1,0 +1,6 @@
+export default function resultIconUrl(resultStatus) {
+  if (!resultStatus) {
+    return null;
+  }
+  return `/images/answer-validation/icon-${resultStatus}.svg`;
+}

--- a/live/config/environment.js
+++ b/live/config/environment.js
@@ -75,7 +75,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
-    ENV.googleFonts = [];
+    ENV.googleFonts = null;
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.isChallengeTimerEnable = false;
     ENV.APP.MESSAGE_DISPLAY_DURATION = 0;

--- a/live/tests/integration/components/challenge-statement-test.js
+++ b/live/tests/integration/components/challenge-statement-test.js
@@ -61,7 +61,7 @@ describe('Integration | Component | ChallengeStatement', function() {
     it('should display challenge illustration (and alt) if it exists', function() {
       // given
       addChallengeToContext(this, {
-        illustrationUrl: 'http://challenge.illustration.url'
+        illustrationUrl: '/images/pix-logo.svg'
       });
 
       // when
@@ -69,7 +69,7 @@ describe('Integration | Component | ChallengeStatement', function() {
 
       // then
       const $illustration = this.$('.challenge-statement__illustration');
-      expect($illustration.prop('src')).to.equal('http://challenge.illustration.url/');
+      expect($illustration.prop('src')).to.match(/\/images\/pix-logo.svg$/);
       expect($illustration.prop('alt')).to.equal('Illustration de l\'épreuve');
     });
 

--- a/live/tests/integration/components/course-item-test.js
+++ b/live/tests/integration/components/course-item-test.js
@@ -19,7 +19,7 @@ describe('Integration | Component | course item', function() {
 
     it('should render course picture if it is defined', function() {
       // given
-      const course = Ember.Object.create({ imageUrl: 'image_src' });
+      const course = Ember.Object.create({ imageUrl: '/images/pix-logo.svg' });
       this.set('course', course);
 
       // when

--- a/live/tests/integration/components/feature-item-test.js
+++ b/live/tests/integration/components/feature-item-test.js
@@ -10,7 +10,7 @@ describe('Integration | Component | feature item', function() {
   });
 
   const feature = {
-    icon: 'coucou',
+    icon: 'reference',
     title: 'title_value',
     description: 'description_value'
   };
@@ -27,7 +27,7 @@ describe('Integration | Component | feature item', function() {
 
     const $icon = this.$('.feature-item__icon');
     expect($icon).to.exist;
-    expect($icon.attr('src')).to.equal('images/features/icon-coucou.svg');
+    expect($icon.attr('src')).to.equal('/images/features/icon-reference.svg');
   });
 
   it('should render an title', function() {


### PR DESCRIPTION
Cette PR corrige les erreurs 404 qui apparaissent pendant certains tests (intégration ou acceptance).

Ces 404 ne posent pas de problème à proprement parler, mais elles polluent la console lorsqu'on fait tourner les tests dans un navigateur.

## Avant

<img width="826" alt="capture d ecran 2017-07-03 a 17 07 26" src="https://user-images.githubusercontent.com/179923/27799155-6eb883b6-6014-11e7-8ec2-deee945841f5.png">

## Après

<img width="826" alt="capture d ecran 2017-07-03 a 17 08 18" src="https://user-images.githubusercontent.com/179923/27799158-7307521c-6014-11e7-8bb2-ee354dcf7e07.png">

## Pour relire

La PR fait essentiellement des changements aux tests – sauf pour les icônes de résultats, qui concernent aussi l'appli.

Ça devrait se relire assez bien commit-par-commit.