### PR TITLE
[#455] [CLEANUP] Corrige les fenêtres modales laissées ouvertes à la fin des tests

### DIFF
--- a/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
+++ b/live/tests/acceptance/j2-compare-answer-solution-qroc-test.js
@@ -48,6 +48,13 @@ describe('Acceptance | j2 - Comparer réponses et solutions pour un QROC | ', fu
       await visit(COMPARISON_MODAL_URL);
     });
 
+    afterEach(async function() {
+      // XXX test env needs the modal to be closed manually
+      if (find('.close-button-container').length > 0) {
+        await click('.close-button-container');
+      }
+    });
+
     it('possible d\'accéder à la modale depuis l\'URL', async function() {
       expect($('.comparison-window')).to.have.lengthOf(1);
     });

--- a/live/tests/acceptance/l1-signaler-une-epreuve-test.js
+++ b/live/tests/acceptance/l1-signaler-une-epreuve-test.js
@@ -23,15 +23,15 @@ describe('Acceptance | Signaler une épreuve', function() {
     expect(find(FEEDBACK_FORM)).to.have.lengthOf(1);
   }
 
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    destroyApp(application);
+  });
+
   describe('l1.1 Depuis une epreuve', function() {
-
-    beforeEach(function() {
-      application = startApp();
-    });
-
-    afterEach(function() {
-      destroyApp(application);
-    });
 
     it('Je peux signaler une épreuve directement', async () => {
       await visit('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
@@ -64,17 +64,11 @@ describe('Acceptance | Signaler une épreuve', function() {
 
   describe('l1.2 Depuis la fenêtre de comparaison', function() {
 
-    before(function() {
-      application = startApp();
-    });
-
-    after(function() {
-      destroyApp(application);
-    });
-
     it('Je peux signaler une épreuve (page de résultat du test)', async () => {
       await visit('/assessments/ref_assessment_id/results/compare/ref_answer_qcm_id/1');
       assertThatFeedbackFormIsOpen();
+      // XXX test env needs the modal to be closed manually
+      await click('.close-button-container');
     });
 
   });

--- a/live/tests/helpers/destroy-app.js
+++ b/live/tests/helpers/destroy-app.js
@@ -5,4 +5,17 @@ export default function destroyApp(application) {
   if (window.server) {
     window.server.shutdown();
   }
+  // Sanity check
+  assertModalIsClosed();
+}
+
+function assertModalIsClosed() {
+  if (document.body.classList.contains('routable-modal--open')) {
+    throw new Error(
+      'The body element still has a `routable-modal--open` class, although the app just has been destroyed. ' +
+      'This probably means that an acceptance test finished while a modal window was still open. ' +
+      'It will cause subtle issues, like the scroll of the test runner window being blocked. ' +
+      'To fix this assertion, please close the modal window manually before the test finishes. '
+    );
+  }
 }

--- a/live/tests/test-helper.js
+++ b/live/tests/test-helper.js
@@ -5,6 +5,17 @@ import {
 import { mocha } from 'mocha';
 
 mocha.setup({
+  // If a test is randomly killed by the timeout duration,
+  // consider this before increasing the timeout:
+  //
+  // - Computers are fast. 1,5s is a long time, even for an acceptance test.
+  //   Why is this test so slow?
+  //
+  // - Can you make the test faster, rather than increasing the timeout?
+  //
+  // - The acceptance test runner waits for all network requests, delayed actions,
+  //   run-loop delays and Promises to be revolved before continuing to the next step.
+  //   Is any code triggering an artifical delay in tests – like `setTimeout` or `Ember.run.later`?
   timeout: 1500,
   slow: 500,
 });


### PR DESCRIPTION
If a modal window is left open at the end of an acceptance test, it will never be closed properly.

One of the effects is that the `routable-modal--open` class will remain set on the `<body>` element, which will cause the window to become unscrollable.

This PR:

- Fixes the tests where a modal window was accidentally left open ;
- Add an assertion at the end of acceptance tests to ensure all modal windows have been closed.

The assertion seems useful: it already caught some cases where the modal was left open :)