### PR TITLE
[#456] [BUGFIX] Désactivation de l'accélération GPU pour les tests sous Chrome

### DIFF
--- a/live/testem.js
+++ b/live/testem.js
@@ -9,5 +9,8 @@ module.exports = {
   "launch_in_dev": [
     "PhantomJS",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": "--disable-gpu"
+  }
 };


### PR DESCRIPTION
Hardware-acceleration causes Chrome to crash when running tests from the `c1-recapitulatif` suite with the following error:

> Error: Browser disconnected
> 2017-07-03 17:39:11.965 Google Chrome[88347:2533580] NSWindow warning: adding an unknown subview: <FullSizeContentView: 0x7f8481688fe0>.

Disabling hardware-acceleration fixes the issue.

_N.B.: this may be somehow related to this Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=605219_