### PR TITLE
[#553] [FEATURE] Pouvoir saisir son numéro d'étudiant ainsi qu'un code campagne dans le cas d'un partage de profil pour un établissement de type SUP (US-712).

### DIFF
--- a/api/db/migrations/20171005222803_update_snapshots_add_student_and_campaign_code.js
+++ b/api/db/migrations/20171005222803_update_snapshots_add_student_and_campaign_code.js
@@ -1,0 +1,13 @@
+exports.up = (knex) => {
+  return knex.schema.table('snapshots', (table) => {
+    table.string('studentCode', 20);
+    table.string('campaignCode', 20);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table('snapshots', (table) => {
+    table.dropColumn('studentCode');
+    table.dropColumn('campaignCode');
+  });
+};

--- a/api/lib/domain/services/snapshot-service.js
+++ b/api/lib/domain/services/snapshot-service.js
@@ -1,13 +1,16 @@
 const snapshotRepository = require('../../../lib/infrastructure/repositories/snapshot-repository');
 
 module.exports = {
-  create(snapshot) {
+
+  create(snapshot, user, serializedProfile) {
     const snapshotRaw = {
-      organizationId: snapshot.organizationId,
+      organizationId: snapshot.organization.id,
       completionPercentage: snapshot.completionPercentage,
-      userId: snapshot.profile.data.id,
-      score: snapshot.profile.data.attributes['total-pix-score'],
-      profile: JSON.stringify(snapshot.profile)
+      studentCode: snapshot.studentCode,
+      campaignCode: snapshot.campaignCode,
+      userId: user.id,
+      score: serializedProfile.data.attributes['total-pix-score'],
+      profile: JSON.stringify(serializedProfile)
     };
 
     return snapshotRepository

--- a/api/lib/infrastructure/serializers/jsonapi/snapshot-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/snapshot-serializer.js
@@ -1,9 +1,10 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 
-class SnapshotSerializer {
+module.exports = {
+
   serialize(snapshots) {
-    return new JSONAPISerializer('snapshot', {
-      attributes: ['score', 'createdAt', 'completionPercentage', 'user'],
+    return new Serializer('snapshot', {
+      attributes: ['score', 'createdAt', 'completionPercentage', 'user', 'studentCode', 'campaignCode'],
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName']
@@ -15,7 +16,17 @@ class SnapshotSerializer {
         return snapshot;
       }
     }).serialize(snapshots);
-  }
-}
+  },
 
-module.exports = new SnapshotSerializer();
+  deserialize(json) {
+    return new Deserializer({ keyForAttribute: 'camelCase' })
+      .deserialize(json)
+      .then((snapshot => {
+        snapshot.organization = {
+          id: json.data.relationships.organization.data.id
+        };
+        return snapshot;
+      }));
+  }
+
+};

--- a/api/lib/infrastructure/validators/jsonwebtoken-verify.js
+++ b/api/lib/infrastructure/validators/jsonwebtoken-verify.js
@@ -13,11 +13,10 @@ module.exports = {
       }
 
       jsonwebtoken.verify(token, settings.authentication.secret, (err, decoded) => {
-        if(err) {
+        if (err) {
           return reject(new InvalidTokenError());
         }
-        const id = decoded.user_id;
-        resolve(id);
+        resolve(decoded.user_id);
       });
     });
   }

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -146,7 +146,9 @@ describe('Acceptance | Controller | organization-controller', function() {
             attributes: {
               score: '15',
               'completion-percentage': '70',
-              'created-at': '2017-08-31 15:57:06'
+              'created-at': '2017-08-31 15:57:06',
+              'student-code': null,
+              'campaign-code': null
             },
             relationships: {
               user: {
@@ -176,7 +178,7 @@ describe('Acceptance | Controller | organization-controller', function() {
       return server.injectThen(options).then((response) => {
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.eql(expectedSnapshots);
+        expect(response.result).to.deep.equal(expectedSnapshots);
       });
     });
 

--- a/api/tests/unit/application/snapshots/snapshot-controller_test.js
+++ b/api/tests/unit/application/snapshots/snapshot-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
 const profileService = require('../../../../lib/domain/services/profile-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const snapshotService = require('../../../../lib/domain/services/snapshot-service');
@@ -13,7 +13,6 @@ const logger = require('../../../../lib/infrastructure/logger');
 const { InvalidTokenError, NotFoundError } = require('../../../../lib/domain/errors');
 
 const USER_ID = 1;
-const PROFILE_ID = 2;
 const ORGANIZATION_ID = 3;
 const SNAPSHOT_ID = 4;
 
@@ -22,80 +21,6 @@ const user = {
   firstName: 'Luke',
   lastName: 'Skywalker',
   email: 'luke@sky.fr'
-};
-
-const serializedUserProfile = {
-  data: {
-    type: 'users',
-    id: PROFILE_ID,
-    attributes: {
-      'first-name': 'Luke',
-      'last-name': 'Skywalker',
-      'total-pix-score': 128,
-      'email': 'luke@sky.fr'
-    },
-    relationships: {
-      competences: {
-        data: [
-          { type: 'competences', id: 'recCompA' },
-          { type: 'competences', id: 'recCompB' }
-        ]
-      }
-    },
-  },
-  included: [
-    {
-      type: 'areas',
-      id: 'recAreaA',
-      attributes: {
-        name: 'area-name-1'
-      }
-    },
-    {
-      type: 'areas',
-      id: 'recAreaB',
-      attributes: {
-        name: 'area-name-2'
-      }
-    },
-    {
-      type: 'competences',
-      id: 'recCompA',
-      attributes: {
-        name: 'competence-name-1',
-        index: '1.1',
-        level: -1,
-        'course-id': 'recBxPAuEPlTgt72q11'
-      },
-      relationships: {
-        area: {
-          data: {
-            type: 'areas',
-            id: 'recAreaA'
-          }
-        }
-      }
-    },
-    {
-      type: 'competences',
-      id: 'recCompB',
-      attributes: {
-        name: 'competence-name-2',
-        index: '1.2',
-        level: 8,
-        'pix-score': 128,
-        'course-id': 'recBxPAuEPlTgt72q99'
-      },
-      relationships: {
-        area: {
-          data: {
-            type: 'areas',
-            id: 'recAreaB'
-          }
-        }
-      }
-    }
-  ]
 };
 
 describe('Unit | Controller | snapshot-controller', () => {

--- a/api/tests/unit/application/snapshots/snapshot-controller_test.js
+++ b/api/tests/unit/application/snapshots/snapshot-controller_test.js
@@ -1,27 +1,33 @@
 const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
 const profileService = require('../../../../lib/domain/services/profile-service');
-const UserRepository = require('../../../../lib/infrastructure/repositories/user-repository');
-const SnapshotService = require('../../../../lib/domain/services/snapshot-service');
-const ProfileCompletionService = require('../../../../lib/domain/services/profile-completion-service');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const snapshotService = require('../../../../lib/domain/services/snapshot-service');
+const profileCompletionService = require('../../../../lib/domain/services/profile-completion-service');
 const snapshotController = require('../../../../lib/application/snapshots/snapshot-controller');
 const authorizationToken = require('../../../../lib/infrastructure/validators/jsonwebtoken-verify');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
-const OrganizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const profileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/profile-serializer');
 const snapshotSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/snapshot-serializer');
 const logger = require('../../../../lib/infrastructure/logger');
 const { InvalidTokenError, NotFoundError } = require('../../../../lib/domain/errors');
 
+const USER_ID = 1;
+const PROFILE_ID = 2;
+const ORGANIZATION_ID = 3;
+const SNAPSHOT_ID = 4;
+
 const user = {
-  id: 3,
+  id: USER_ID,
   firstName: 'Luke',
   lastName: 'Skywalker',
   email: 'luke@sky.fr'
 };
+
 const serializedUserProfile = {
   data: {
     type: 'users',
-    id: 'user_id',
+    id: PROFILE_ID,
     attributes: {
       'first-name': 'Luke',
       'last-name': 'Skywalker',
@@ -92,11 +98,10 @@ const serializedUserProfile = {
   ]
 };
 
-describe('Unit | Controller | snapshotController', () => {
+describe('Unit | Controller | snapshot-controller', () => {
 
   describe('#Create', () => {
 
-    let sandbox;
     const request = {
       headers: {
         authorization: 'valid_token'
@@ -106,25 +111,20 @@ describe('Unit | Controller | snapshotController', () => {
           relationships: {
             organization: {
               data: {
-                id: 3
+                id: ORGANIZATION_ID
               }
             }
           }
         }
       }
     };
+
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(validationErrorSerializer, 'serialize');
+      sinon.stub(validationErrorSerializer, 'serialize');
     });
 
     afterEach(() => {
-      sandbox.restore();
-    });
-
-    it('should be a function', () => {
-      // then
-      expect(snapshotController.create).to.be.a('function');
+      validationErrorSerializer.serialize.restore();
     });
 
     it('should have a request with Authorization header', () => {
@@ -152,12 +152,13 @@ describe('Unit | Controller | snapshotController', () => {
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
         sandbox.stub(authorizationToken, 'verify');
-        sandbox.stub(UserRepository, 'findUserById');
+        sandbox.stub(userRepository, 'findUserById');
+        sandbox.stub(snapshotSerializer, 'deserialize');
         sandbox.stub(profileService, 'getByUserId');
-        sandbox.stub(OrganizationRepository, 'isOrganizationIdExist');
-        sandbox.stub(SnapshotService, 'create');
+        sandbox.stub(organizationRepository, 'isOrganizationIdExist');
+        sandbox.stub(snapshotService, 'create');
         sandbox.stub(profileSerializer, 'serialize');
-        sandbox.stub(ProfileCompletionService, 'getPercentage');
+        sandbox.stub(profileCompletionService, 'getPercentage');
         sandbox.stub(snapshotSerializer, 'serialize');
         sandbox.stub(logger, 'error');
       });
@@ -168,9 +169,9 @@ describe('Unit | Controller | snapshotController', () => {
 
       describe('Test collaboration', function() {
 
-        it('should call authorization token verify service', () => {
+        it('should verify that user is well authenticated / authorized', () => {
           // given
-          authorizationToken.verify.resolves({});
+          authorizationToken.verify.resolves();
 
           // when
           const promise = snapshotController.create(request, replyStub);
@@ -178,47 +179,62 @@ describe('Unit | Controller | snapshotController', () => {
           // then
           return promise.then(() => {
             sinon.assert.calledOnce(authorizationToken.verify);
-            sinon.assert.calledWith(authorizationToken.verify, request.headers.authorization);
+            sinon.assert.calledWith(authorizationToken.verify, 'valid_token');
           });
         });
 
-        it('should call UserRepository', () => {
+        it('should fetch the user', () => {
           // given
-          authorizationToken.verify.resolves(user.id);
-          UserRepository.findUserById.resolves({});
+          authorizationToken.verify.resolves(USER_ID);
+          userRepository.findUserById.resolves();
 
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
-            sinon.assert.calledOnce(UserRepository.findUserById);
-            sinon.assert.calledWith(UserRepository.findUserById, user.id);
+            sinon.assert.calledOnce(userRepository.findUserById);
+            sinon.assert.calledWith(userRepository.findUserById, USER_ID);
           });
         });
 
-        it('should call OrganizationRepository', () => {
+        it('should deserialize the request payload', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves();
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves();
 
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
-            sinon.assert.calledOnce(OrganizationRepository.isOrganizationIdExist);
-            sinon.assert.calledWith(OrganizationRepository.isOrganizationIdExist, request.payload.data.relationships.organization.data.id);
+            sinon.assert.calledOnce(snapshotSerializer.deserialize);
+            sinon.assert.calledWith(snapshotSerializer.deserialize, request.payload);
           });
         });
 
-        it('should call profile service', () => {
+        it('should verify that the organization exists', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves();
+          snapshotSerializer.deserialize.resolves({ organization: { id: ORGANIZATION_ID } });
+
+          // when
+          const promise = snapshotController.create(request, replyStub);
+
+          // then
+          return promise.then(() => {
+            sinon.assert.calledOnce(organizationRepository.isOrganizationIdExist);
+            sinon.assert.calledWith(organizationRepository.isOrganizationIdExist, 3);
+          });
+        });
+
+        it('should retrieve profile for user', () => {
+          // given
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves(user);
+          snapshotSerializer.deserialize.resolves({ organization: { id: ORGANIZATION_ID } });
+          organizationRepository.isOrganizationIdExist.resolves({ organization: 'a_valid_organization' });
 
           // when
           const promise = snapshotController.create(request, replyStub);
@@ -226,111 +242,94 @@ describe('Unit | Controller | snapshotController', () => {
           // then
           return promise.then(() => {
             sinon.assert.calledOnce(profileService.getByUserId);
+            sinon.assert.calledWith(profileService.getByUserId, USER_ID);
           });
         });
 
-        it('should call profile serializer', () => {
+        it('should serialize profile in JSON in order to be saved in DB', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns({});
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves(user);
+          snapshotSerializer.deserialize.resolves({ organization: { id: ORGANIZATION_ID } });
+          organizationRepository.isOrganizationIdExist.resolves({ organization: 'a_valid_organization' });
+          profileService.getByUserId.resolves({ profile: 'a_valid_profile' });
+
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
             sinon.assert.calledOnce(profileSerializer.serialize);
+            sinon.assert.calledWith(profileSerializer.serialize, { profile: 'a_valid_profile' });
           });
         });
 
-        it('should call Profile completion service', () => {
+        it('should calculate profile completion in percentage', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns({});
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves(user);
+          snapshotSerializer.deserialize.resolves({ organization: { id: ORGANIZATION_ID } });
+          organizationRepository.isOrganizationIdExist.resolves({ organization: 'a_valid_organization' });
+          profileService.getByUserId.resolves();
+          profileSerializer.serialize.resolves({ profile: 'a_valid_profile' });
+
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
-            sinon.assert.calledOnce(ProfileCompletionService.getPercentage);
+            sinon.assert.calledOnce(profileCompletionService.getPercentage);
+            sinon.assert.calledWith(profileCompletionService.getPercentage, { profile: 'a_valid_profile' });
           });
         });
 
-        it('should call Snapshot repository', () => {
+        it('should create & save a Snapshot entity into the repository', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns(serializedUserProfile);
-          ProfileCompletionService.getPercentage.resolves(25);
-          SnapshotService.create.resolves({});
+          const snapshot = { organization: { id: ORGANIZATION_ID } };
+          const serializedProfile = { profile: 'a_valid_profile' };
+
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves(user);
+          snapshotSerializer.deserialize.resolves(snapshot);
+          organizationRepository.isOrganizationIdExist.resolves({ organization: 'a_valid_organization' });
+          profileService.getByUserId.resolves();
+          profileSerializer.serialize.resolves(serializedProfile);
+          profileCompletionService.getPercentage.resolves();
+
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
-            sinon.assert.calledOnce(SnapshotService.create);
-            sinon.assert.calledWith(SnapshotService.create, {
-              organizationId: request.payload.data.relationships.organization.data.id,
-              completionPercentage: 25,
-              profile: serializedUserProfile
-            });
+            sinon.assert.calledOnce(snapshotService.create);
+            sinon.assert.calledWith(snapshotService.create, snapshot, user, serializedProfile);
           });
         });
 
-        it('should call Snapshot serializer', () => {
+        it('should serialize the response payload', () => {
           // given
-          authorizationToken.verify.resolves({});
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns(serializedUserProfile);
-          ProfileCompletionService.getPercentage.resolves(25);
-          SnapshotService.create.resolves(2);
+          const snapshot = { organization: { id: ORGANIZATION_ID } };
+          const serializedProfile = { profile: 'a_valid_profile' };
+
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves(user);
+          snapshotSerializer.deserialize.resolves(snapshot);
+          organizationRepository.isOrganizationIdExist.resolves({ organization: 'a_valid_organization' });
+          profileService.getByUserId.resolves();
+          profileSerializer.serialize.resolves(serializedProfile);
+          profileCompletionService.getPercentage.resolves();
+          snapshotService.create.resolves(SNAPSHOT_ID);
+
           // when
           const promise = snapshotController.create(request, replyStub);
 
           // then
           return promise.then(() => {
             sinon.assert.calledOnce(snapshotSerializer.serialize);
-            sinon.assert.calledWith(snapshotSerializer.serialize, {
-              id: 2
-            });
+            sinon.assert.calledWith(snapshotSerializer.serialize, { id: SNAPSHOT_ID });
           });
         });
 
-      });
-
-      describe('When all things is ok', () => {
-
-        it('should persist a new Snapshot', () => {
-          // given
-          authorizationToken.verify.resolves('user_id');
-          UserRepository.findUserById.resolves(user);
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns(serializedUserProfile);
-          ProfileCompletionService.getPercentage.resolves(25);
-          const expectedSnapshotDetails = {
-            organizationId: request.payload.data.relationships.organization.data.id,
-            completionPercentage: 25,
-            profile: serializedUserProfile
-          };
-          // when
-          const promise = snapshotController.create(request, replyStub);
-
-          // then
-          return promise.then(() => {
-            sinon.assert.calledWith(SnapshotService.create, expectedSnapshotDetails);
-            sinon.assert.calledWith(codeSpy, 201);
-          });
-        });
       });
 
       describe('Errors cases', () => {
@@ -356,8 +355,8 @@ describe('Unit | Controller | snapshotController', () => {
 
         it('should return an error, when user is not found', () => {
           // given
-          authorizationToken.verify.resolves('user_id');
-          UserRepository.findUserById.rejects(new NotFoundError());
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.rejects(new NotFoundError());
           const expectedSerializeArg = {
             data: {
               authorization: ['Cet utilisateur est introuvable']
@@ -376,9 +375,10 @@ describe('Unit | Controller | snapshotController', () => {
 
         it('should return an error, when organisation is not found', () => {
           // given
-          authorizationToken.verify.resolves('user_id');
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(false);
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves();
+          snapshotSerializer.deserialize.resolves({ organization: { id: 'unknnown_organization_id' } });
+          organizationRepository.isOrganizationIdExist.resolves(false);
 
           const expectedSerializeArg = {
             data: {
@@ -398,12 +398,12 @@ describe('Unit | Controller | snapshotController', () => {
 
         it('should return an error, when snapshot saving fails', () => {
           // given
-          authorizationToken.verify.resolves('user_id');
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns(serializedUserProfile);
-          SnapshotService.create.rejects(new Error());
+          authorizationToken.verify.resolves();
+          userRepository.findUserById.resolves();
+          organizationRepository.isOrganizationIdExist.resolves();
+          profileService.getByUserId.resolves();
+          profileSerializer.serialize.resolves();
+          snapshotService.create.rejects(new Error());
 
           const expectedSerializeArg = {
             data: {
@@ -421,17 +421,12 @@ describe('Unit | Controller | snapshotController', () => {
 
         it('should log an error, when unknown error has occured', () => {
           // given
-          const error = new Error();
-          authorizationToken.verify.resolves('user_id');
-          UserRepository.findUserById.resolves({});
-          OrganizationRepository.isOrganizationIdExist.resolves(true);
-          profileService.getByUserId.resolves({});
-          profileSerializer.serialize.returns(serializedUserProfile);
-          ProfileCompletionService.getPercentage.resolves(25);
-          SnapshotService.create.rejects(error);
+          const error = new Error('Another error');
+          authorizationToken.verify.rejects(error);
 
           // when
           const promise = snapshotController.create(request, replyStub);
+
           // then
           return promise.then(() => {
             sinon.assert.calledWith(logger.error, error);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/snapshot-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/snapshot-serializer_test.js
@@ -12,6 +12,8 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
         score: '10',
         createdAt: '2017-08-23 12:52:33',
         completionPercentage: '12',
+        studentCode: 'ABCD-1234',
+        campaignCode: 'EFGH-5678',
         user: {
           id: 2,
           firstName: 'Barack',
@@ -25,7 +27,9 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
           attributes: {
             'completion-percentage': '12',
             'created-at': '2017-08-23 12:52:33',
-            score: '10'
+            'score': '10',
+            'student-code': 'ABCD-1234',
+            'campaign-code': 'EFGH-5678',
           },
           relationships: {
             user: {
@@ -134,6 +138,8 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
         id: 1,
         createdAt: '2017-08-23 12:52:33',
         completionPercentage: '12',
+        studentCode: 'student_code',
+        campaignCode: 'campaign_code',
       };
 
       const expectedSerializedSnapshot = {
@@ -143,7 +149,9 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
           attributes: {
             'created-at': '2017-08-23 12:52:33',
             'completion-percentage': '12',
-            'score': null
+            'score': null,
+            'student-code': 'student_code',
+            'campaign-code': 'campaign_code',
           }
         }
       };
@@ -152,7 +160,7 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
       const result = serializer.serialize(snapshot);
 
       // then
-      expect(result).to.eql(expectedSerializedSnapshot);
+      expect(result).to.deep.equal(expectedSerializedSnapshot);
     });
 
     it('should set the completion percentage to null when it is not defined', () => {
@@ -162,6 +170,8 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
         createdAt: '2017-08-23 12:52:33',
         score: '12',
         completionPercentage: null,
+        studentCode: 'student_code',
+        campaignCode: 'campaign_code',
       };
 
       const expectedSerializedSnapshot = {
@@ -171,7 +181,9 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
           attributes: {
             'created-at': '2017-08-23 12:52:33',
             'completion-percentage': null,
-            'score': '12'
+            'score': '12',
+            'student-code': 'student_code',
+            'campaign-code': 'campaign_code',
           }
         }
       };
@@ -180,9 +192,114 @@ describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {
       const result = serializer.serialize(snapshot);
 
       // then
-      expect(result).to.eql(expectedSerializedSnapshot);
+      expect(result).to.deep.equal(expectedSerializedSnapshot);
     });
 
+    it('should set the student code to null when it is not defined', () => {
+      // given
+      const snapshot = {
+        id: 1,
+        createdAt: '2017-10-05 22:452:58',
+        score: '12',
+        studentCode: null,
+        campaignCode: 'campaign_code',
+      };
+
+      const expectedSerializedSnapshot = {
+        data: {
+          id: '1',
+          type: 'snapshots',
+          attributes: {
+            'created-at': '2017-10-05 22:452:58',
+            'completion-percentage': null,
+            'score': '12',
+            'student-code': null,
+            'campaign-code': 'campaign_code',
+          }
+        }
+      };
+
+      // when
+      const result = serializer.serialize(snapshot);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedSnapshot);
+    });
+
+    it('should set the campaign code to null when it is not defined', () => {
+      // given
+      const snapshot = {
+        id: 1,
+        createdAt: '2017-10-05 22:452:58',
+        score: '12',
+        studentCode: 'student_code',
+        campaignCode: null,
+      };
+
+      const expectedSerializedSnapshot = {
+        data: {
+          id: '1',
+          type: 'snapshots',
+          attributes: {
+            'created-at': '2017-10-05 22:452:58',
+            'completion-percentage': null,
+            'score': '12',
+            'student-code': 'student_code',
+            'campaign-code': null,
+          }
+        }
+      };
+
+      // when
+      const result = serializer.serialize(snapshot);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedSnapshot);
+    });
+
+  });
+
+  describe('#deserialize', () => {
+
+    it('should convert a JSON:API object into an object literal', () => {
+      // given
+      const jsonApiObject = {
+        data: {
+          type: 'snapshots',
+          id: '1',
+          attributes: {
+            'completion-percentage': '20',
+            'created-at': '2017-10-06 09:33:00',
+            'score': '10',
+            'student-code': 'ABCD-1234',
+            'campaign-code': 'EFGH-5678',
+          },
+          relationships: {
+            organization: { data: { id: '3', type: 'organizations' } }
+          }
+        }
+      };
+
+      const expectedObjectLiteral = {
+        id: '1',
+        score: '10',
+        createdAt: '2017-10-06 09:33:00',
+        completionPercentage: '20',
+        studentCode: 'ABCD-1234',
+        campaignCode: 'EFGH-5678',
+        organization: {
+          id: '3'
+        }
+      };
+
+      // when
+      const promise = serializer.deserialize(jsonApiObject);
+
+      // then
+      return promise.then((result) => {
+        expect(result).to.deep.equal(expectedObjectLiteral);
+      });
+    });
   });
 
 });

--- a/live/app/adapters/application.js
+++ b/live/app/adapters/application.js
@@ -11,11 +11,9 @@ export default DS.JSONAPIAdapter.extend({
 
   headers: Ember.computed('session.data.authenticated.token', function() {
 
-    let tokenBearer;
-    if(this.get('session.data.authenticated.token')) {
+    let tokenBearer = '';
+    if (this.get('session.data.authenticated.token')) {
       tokenBearer = `Bearer ${this.get('session.data.authenticated.token')}`;
-    } else {
-      tokenBearer = '';
     }
 
     return {

--- a/live/app/components/share-profile.js
+++ b/live/app/components/share-profile.js
@@ -20,7 +20,8 @@ export default Ember.Component.extend({
   _code: null,
   _organization: null,
   _organizationNotFound: false,
-  _studentId: null,
+  _studentCode: null,
+  _campaignCode: null,
 
   // Computed
   stepOrganizationCodeEntry: Ember.computed.equal('_view', STEP_1_ORGANIZATION_CODE_ENTRY),
@@ -39,12 +40,16 @@ export default Ember.Component.extend({
       this.set('_code', null);
       this.set('_organization', null);
       this.set('_organizationNotFound', false);
+      this.set('_studentCode', null);
+      this.set('_campaignCode', null);
     },
 
     cancelSharingAndGoBackToOrganizationCodeEntryView() {
       this.set('_view', STEP_1_ORGANIZATION_CODE_ENTRY);
       this.set('_organization', null);
       this.set('_organizationNotFound', false);
+      this.set('_studentCode', null);
+      this.set('_campaignCode', null);
     },
 
     findOrganizationAndGoToSharingConfirmationView() {
@@ -63,7 +68,7 @@ export default Ember.Component.extend({
 
     shareSnapshotAndGoToSuccessNotificationView() {
       this
-        .get('shareProfileSnapshot')(this.get('_organization'), this.get('_studentCode'))
+        .get('shareProfileSnapshot')(this.get('_organization'), this.get('_studentCode'), this.get('_campaignCode'))
         .then(() => {
           this.set('_view', STEP_3_SUCCESS_NOTIFICATION);
         });

--- a/live/app/components/share-profile.js
+++ b/live/app/components/share-profile.js
@@ -28,6 +28,21 @@ export default Ember.Component.extend({
   stepProfileSharingConfirmation: Ember.computed.equal('_view', STEP_2_SHARING_CONFIRMATION),
   isOrganizationHasTypeSup: Ember.computed.equal('_organization.type', 'SUP'),
 
+  organizationLabels: Ember.computed('_organization.type', function() {
+    if (this.get('_organization.type') === 'PRO') {
+      return {
+        text1: 'Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'organisation :',
+        text2: 'En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes :',
+        text3: 'Elle ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.'
+      };
+    }
+    return {
+      text1: 'Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'établissement :',
+      text2: 'En cliquant sur le bouton «Envoyer», il recevra les informations suivantes :',
+      text3: 'Il ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.'
+    };
+  }),
+
   actions: {
 
     openModal() {

--- a/live/app/components/share-profile.js
+++ b/live/app/components/share-profile.js
@@ -32,13 +32,13 @@ export default Ember.Component.extend({
     if (this.get('_organization.type') === 'PRO') {
       return {
         text1: 'Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'organisation :',
-        text2: 'En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes :',
+        text2: 'En cliquant sur le bouton « Envoyer », elle recevra les informations suivantes :',
         text3: 'Elle ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.'
       };
     }
     return {
       text1: 'Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'établissement :',
-      text2: 'En cliquant sur le bouton «Envoyer», il recevra les informations suivantes :',
+      text2: 'En cliquant sur le bouton « Envoyer », il recevra les informations suivantes :',
       text3: 'Il ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.'
     };
   }),

--- a/live/app/components/share-profile.js
+++ b/live/app/components/share-profile.js
@@ -20,10 +20,12 @@ export default Ember.Component.extend({
   _code: null,
   _organization: null,
   _organizationNotFound: false,
+  _studentId: null,
 
   // Computed
   stepOrganizationCodeEntry: Ember.computed.equal('_view', STEP_1_ORGANIZATION_CODE_ENTRY),
   stepProfileSharingConfirmation: Ember.computed.equal('_view', STEP_2_SHARING_CONFIRMATION),
+  isOrganizationHasTypeSup: Ember.computed.equal('_organization.type', 'SUP'),
 
   actions: {
 

--- a/live/app/components/share-profile.js
+++ b/live/app/components/share-profile.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
 
     shareSnapshotAndGoToSuccessNotificationView() {
       this
-        .get('shareProfileSnapshot')(this.get('_organization'))
+        .get('shareProfileSnapshot')(this.get('_organization'), this.get('_studentCode'))
         .then(() => {
           this.set('_view', STEP_3_SUCCESS_NOTIFICATION);
         });

--- a/live/app/models/snapshot.js
+++ b/live/app/models/snapshot.js
@@ -7,5 +7,6 @@ export default Model.extend({
   createdAt : attr('date'),
   organization: belongsTo('organization'),
   user: belongsTo('user'),
-  studentCode: attr('string')
+  studentCode: attr('string'),
+  campaignCode: attr('string')
 });

--- a/live/app/models/snapshot.js
+++ b/live/app/models/snapshot.js
@@ -6,5 +6,6 @@ export default Model.extend({
   score : attr('number'),
   createdAt : attr('date'),
   organization: belongsTo('organization'),
-  user: belongsTo('user')
+  user: belongsTo('user'),
+  studentCode: attr('string')
 });

--- a/live/app/routes/compte.js
+++ b/live/app/routes/compte.js
@@ -35,7 +35,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
       });
     },
 
-    shareProfileSnapshot(organization, studentCode = null, campaignCode = null) {
+    shareProfileSnapshot(organization, studentCode, campaignCode) {
       return this.get('store').createRecord('snapshot', { organization, studentCode, campaignCode }).save();
     }
   }

--- a/live/app/routes/compte.js
+++ b/live/app/routes/compte.js
@@ -35,8 +35,8 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
       });
     },
 
-    shareProfileSnapshot(organization) {
-      return this.get('store').createRecord('snapshot', { organization }).save();
+    shareProfileSnapshot(organization, studentCode = null, campaignCode = null) {
+      return this.get('store').createRecord('snapshot', { organization, studentCode, campaignCode }).save();
     }
   }
 });

--- a/live/app/styles/app.scss
+++ b/live/app/styles/app.scss
@@ -9,12 +9,12 @@
 @import 'globals/dimension';
 @import 'globals/loading';
 @import 'globals/redesign-inputs';
+@import 'globals/pix-modale';
 /* 3rd-party */
 @import 'vendor/ember-routable-modal/core';
 @import 'vendor/ember-routable-modal/dialog';
 /* components */
 @import 'components/rounded-panel';
-@import 'components/pix-modale';
 @import 'components/app-footer';
 @import 'components/corner-ribbon';
 @import 'components/challenge-actions';

--- a/live/app/styles/components/_share-profile.scss
+++ b/live/app/styles/components/_share-profile.scss
@@ -1,4 +1,9 @@
 /* Wrapper */
+.share-profile__section {
+  @include device-is('tablet') {
+    padding: 30px 0;
+  }
+}
 
 .share-profile__share-button {
   flex-grow: 0;
@@ -16,15 +21,17 @@
   padding-left: 5px;
 }
 
-/* "Organization code entry" view */
+.share-profile__row {
+  width: 100%;
+  margin-bottom: 10px;
+  text-align: center;
 
-.share-profile__statement {
-  @include device-is('desktop') {
-    width: 545px;
-    height: 59px;
-    text-align: center;
+  @include device-is('tablet') {
+    margin-bottom: 20px;
   }
 }
+
+/* "Organization code entry" view */
 
 .share-profile__modal-form {
   width: 100%;
@@ -34,7 +41,7 @@
   align-items: center;
   justify-content: space-between;
 
-  @include device-is('desktop') {
+  @include device-is('tablet') {
     width: 265px;
     max-width: 380px;
     padding: 30px 16px 16px;
@@ -45,7 +52,7 @@
   width: 100%;
   text-align: center;
 
-  @include device-is('desktop') {
+  @include device-is('tablet') {
     width: 265px;
   }
 }
@@ -54,7 +61,7 @@
   color: $pure-orange;
   margin-bottom: 5px;
 
-  @include device-is('desktop') {
+  @include device-is('tablet') {
     font-size: 16px;
   }
 }
@@ -66,7 +73,7 @@
   justify-content: space-between;
   box-sizing: border-box;
 
-  @include device-is('desktop') {
+  @include device-is('tablet') {
     width: 265px;
   }
 }
@@ -83,7 +90,7 @@
   }
 }
 
-.share-profile__organization-name {
+p.share-profile__organization-name {
   font-weight: $font-bold;
   font-size: 20px;
   text-align: center;
@@ -93,7 +100,7 @@
   }
 }
 
-.share-profile__disclaimer {
+.share-profile__row--disclaimer {
   @include device-is('tablet') {
     font-size: 16px;
   }
@@ -102,5 +109,8 @@
 /* "Success notification" view */
 
 .share-profile__statement {
-  margin-bottom: 5px;
+  @include device-is('tablet') {
+    padding: 20px 0;
+    text-align: center;
+  }
 }

--- a/live/app/styles/globals/_pix-modale.scss
+++ b/live/app/styles/globals/_pix-modale.scss
@@ -31,7 +31,7 @@
   justify-content: center;
 
   @include device-is('tablet') {
-    font-size: 22px;
+    font-size: 18px;
   }
 }
 
@@ -70,6 +70,19 @@
   }
 }
 
+.pix-modal p {
+  margin-bottom: 5px;
+}
+
+.pix-modal ul {
+  margin-bottom: 15px;
+  text-align: left;
+
+  @include device-is('tablet') {
+    text-align: center;
+  }
+}
+
 .pix-modal__text {
   margin-bottom: 15px;
 
@@ -100,11 +113,22 @@
   padding: 15px;
   border-radius: 5px;
   background-color: $white;
-  border: 1px solid $pix-blue;
+  border: 1px solid $gainsboro;
   color: $slate-grey;
   letter-spacing: 2px;
   box-sizing: border-box;
   margin-bottom: 5px;
+  outline: none;
+  text-align: center;
+
+  &:focus {
+    border-color: $pix-blue;
+  }
+
+  @include device-is('tablet') {
+    width: auto;
+    text-align: left;
+  }
 }
 
 /* Buttons
@@ -119,11 +143,6 @@
   box-sizing: border-box;
   font-size: 13px;
   width: 126px;
-  margin-top: 25px;
-
-  @include device-is('tablet') {
-    margin-top: 35px;
-  }
 }
 
 .pix-modal__button--primary {

--- a/live/app/templates/components/share-profile.hbs
+++ b/live/app/templates/components/share-profile.hbs
@@ -44,6 +44,13 @@
           <p class="pix-modal__text">Vous vous apprêtez à transmettre une copie de votre profil Pix à l'organisation :</p>
           <p class="pix-modal__text share-profile__organization-name">{{_organization.name}}</p>
 
+          {{#if isOrganizationHasTypeSup}}
+            <div class="share-profile__student-code">
+              <p class="pix-modal__text">Veuillez saisir votre numéro d'étudiant :</p>
+              {{input class="share-profile__student-code-input" value=_studentCode}}
+            </div>
+          {{/if}}
+
           <div class="share-profile__disclaimer">
             <p class="pix-modal__text">En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes:</p>
             <ul class="pix-modal__list">

--- a/live/app/templates/components/share-profile.hbs
+++ b/live/app/templates/components/share-profile.hbs
@@ -49,6 +49,11 @@
               <p class="pix-modal__text">Veuillez saisir votre numéro d'étudiant :</p>
               {{input class="share-profile__student-code-input" value=_studentCode}}
             </div>
+
+            <div class="share-profile__campaign-code">
+              <p class="pix-modal__text">Précisez le code campagne s'il vous a été fourni :</p>
+              {{input class="share-profile__campaign-code-input" value=_campaignCode}}
+            </div>
           {{/if}}
 
           <div class="share-profile__disclaimer">

--- a/live/app/templates/components/share-profile.hbs
+++ b/live/app/templates/components/share-profile.hbs
@@ -17,53 +17,58 @@
       {{#if stepOrganizationCodeEntry}}
 
         <section class="pix-modal__body share-profile__section share-profile__section--organization-code-entry">
-          <p class="pix-modal__text">Veuillez saisir le code correspondant à votre organisation (collège, lycée, université, école, entreprise).</p>
+          <div class="share-profile__row">
+            <p>Veuillez saisir le code correspondant à votre organisation (collège, lycée, université, école, entreprise).</p>
 
-          {{input class="pix-modal__input share-profile__organization-code-input"
-                  id="code"
-                  placeholder=_placeholder
-                  focus-in="focusInOrganizationCodeInput"
-                  focus-out="focusOutOrganizationCodeInput"
-                  value=_code
-                  enter="findOrganizationAndGoToSharingConfirmationView"}}
+            {{input class="pix-modal__input share-profile__organization-code-input"
+                    id="code"
+                    placeholder=_placeholder
+                    focus-in="focusInOrganizationCodeInput"
+                    focus-out="focusOutOrganizationCodeInput"
+                    value=_code
+                    enter="findOrganizationAndGoToSharingConfirmationView"}}
 
-          {{#if _organizationNotFound}}
-            <p class="pix-modal__text share-profile__form-error">Ce code ne correspond à aucune organisation.</p>
-          {{/if}}
+            {{#if _organizationNotFound}}
+              <p class="share-profile__form-error">Ce code ne correspond à aucune organisation.</p>
+            {{/if}}
+          </div>
 
           <div class="share-profile__share-modal-buttons">
             <button class="pix-modal__button pix-modal__button--primary share-profile__continue-button" {{action "findOrganizationAndGoToSharingConfirmationView"}}>Continuer</button>
             <button class="pix-modal__button pix-modal__button--secondary share-profile__cancel-button" {{action "closeModal"}}>Annuler</button>
           </div>
 
+
         </section>
 
       {{else if stepProfileSharingConfirmation}}
 
         <section class="pix-modal__body share-profile__section share-profile__section--sharing-confirmation">
-          <p class="pix-modal__text">{{organizationLabels.text1}}</p>
-          <p class="pix-modal__text share-profile__organization-name">{{_organization.name}}</p>
+          <div class="share-profile__row share-profile__row--organization-name">
+            <p>{{organizationLabels.text1}}</p>
+            <p class="share-profile__organization-name">{{_organization.name}}</p>
+          </div>
 
           {{#if isOrganizationHasTypeSup}}
-            <div class="share-profile__student-code">
-              <p class="pix-modal__text">Veuillez saisir votre numéro d'étudiant :</p>
-              {{input class="share-profile__student-code-input" value=_studentCode}}
+            <div class="share-profile__row share-profile__row--student-code">
+              <p>Veuillez saisir votre numéro d'étudiant :</p>
+              {{input class="pix-modal__input share-profile__student-code-input" value=_studentCode}}
             </div>
 
-            <div class="share-profile__campaign-code">
-              <p class="pix-modal__text">Précisez le code campagne s'il vous a été fourni :</p>
-              {{input class="share-profile__campaign-code-input" value=_campaignCode}}
+            <div class="share-profile__row share-profile__row--campaign-code">
+              <p>Précisez le code campagne s'il vous a été fourni :</p>
+              {{input class="pix-modal__input share-profile__campaign-code-input" value=_campaignCode}}
             </div>
 
           {{/if}}
 
-          <div class="share-profile__disclaimer">
-            <p class="pix-modal__text">{{organizationLabels.text2}}</p>
+          <div class="share-profile__row share-profile__row--disclaimer">
+            <p>{{organizationLabels.text2}}</p>
             <ul class="pix-modal__list">
               <li class="pix-modal__list-item">› votre nom et prénom</li>
               <li class="pix-modal__list-item">› l'état actuel de votre profil</li>
             </ul>
-            <p class="pix-modal__text">{{organizationLabels.text3}}</p>
+            <p>{{organizationLabels.text3}}</p>
           </div>
 
           <div class="share-profile__share-modal-buttons">
@@ -76,7 +81,9 @@
       {{else}}
 
         <section class="pix-modal__body share-profile__section share-profile__section--success-notification">
-          <p class="pix-modal__text share-profile__statement">Votre profil a été envoyé avec succès.</p>
+          <div class="share-profile__row">
+            <p class="share-profile__statement">Votre profil a été envoyé avec succès.</p>
+          </div>
           <button class="pix-modal__button pix-modal__button--primary share-profile__close-button" {{action "closeModal"}}>Fermer</button>
         </section>
 

--- a/live/app/templates/components/share-profile.hbs
+++ b/live/app/templates/components/share-profile.hbs
@@ -41,7 +41,7 @@
       {{else if stepProfileSharingConfirmation}}
 
         <section class="pix-modal__body share-profile__section share-profile__section--sharing-confirmation">
-          <p class="pix-modal__text">Vous vous apprêtez à transmettre une copie de votre profil Pix à l'organisation :</p>
+          <p class="pix-modal__text">{{organizationLabels.text1}}</p>
           <p class="pix-modal__text share-profile__organization-name">{{_organization.name}}</p>
 
           {{#if isOrganizationHasTypeSup}}
@@ -54,15 +54,16 @@
               <p class="pix-modal__text">Précisez le code campagne s'il vous a été fourni :</p>
               {{input class="share-profile__campaign-code-input" value=_campaignCode}}
             </div>
+
           {{/if}}
 
           <div class="share-profile__disclaimer">
-            <p class="pix-modal__text">En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes:</p>
+            <p class="pix-modal__text">{{organizationLabels.text2}}</p>
             <ul class="pix-modal__list">
               <li class="pix-modal__list-item">› votre nom et prénom</li>
               <li class="pix-modal__list-item">› l'état actuel de votre profil</li>
             </ul>
-            <p class="pix-modal__text">Elle ne recevra pas les évolutions futures de votre profil.</p>
+            <p class="pix-modal__text">{{organizationLabels.text3}}</p>
           </div>
 
           <div class="share-profile__share-modal-buttons">

--- a/live/mirage/scenarios/default.js
+++ b/live/mirage/scenarios/default.js
@@ -28,18 +28,34 @@ export default function(server) {
     recaptchaToken: 'recaptcha-token-xxxxxx'
   });
 
-  const organization = server.create('organization', {
+  const company = server.create('organization', {
     id: 1,
-    name: 'ACME',
-    email: 'contact@acme.com',
+    name: 'Mon Entreprise',
+    email: 'contact@company.com',
     type: 'PRO',
-    code: 'ABCD00',
+    code: 'PRO001',
   });
 
-  prescriber.organization = organization;
-  organization.user = prescriber;
+  server.create('organization', {
+    id: 2,
+    name: 'Mon École',
+    email: 'contact@school.org',
+    type: 'SCO',
+    code: 'SCO002',
+  });
 
-  const snapshots = server.createList('snapshot', 3, { organization: organization });
-  organization.snapshots = snapshots;
+  server.create('organization', {
+    id: 3,
+    name: 'Mon Université',
+    email: 'contact@university.org',
+    type: 'SUP',
+    code: 'SUP003',
+  });
+
+  prescriber.organization = company;
+  company.user = prescriber;
+
+  const snapshots = server.createList('snapshot', 3, { organization: company });
+  company.snapshots = snapshots;
 
 }

--- a/live/tests/acceptance/compte-share-profile-test.js
+++ b/live/tests/acceptance/compte-share-profile-test.js
@@ -38,12 +38,12 @@ describe('Acceptance | Sharing a Profile Snapshot with a given Organization', fu
   }
 
   async function fillInAndSubmitOrganizationCode() {
-    await fillIn('.share-profile__organization-code-input', 'ABCD00');
+    await fillIn('.share-profile__organization-code-input', 'PRO001');
     await click('.share-profile__continue-button');
   }
 
   function expectOrganizationNameToBeDisplayed() {
-    expect(find('.share-profile__organization-name').text().trim()).to.equal('ACME');
+    expect(find('.share-profile__organization-name').text().trim()).to.equal('Mon Entreprise');
   }
 
   function expectToBeOnSuccessNotificationView() {

--- a/live/tests/acceptance/o1-board-organization-test.js
+++ b/live/tests/acceptance/o1-board-organization-test.js
@@ -53,9 +53,9 @@ describe('Acceptance | o1 - board organization', function() {
 
     // then
     expect(find('.board-page__header-organisation__name').length).to.equal(1);
-    expect(find('.board-page__header-organisation__name').text().trim()).to.equal('ACME');
+    expect(find('.board-page__header-organisation__name').text().trim()).to.equal('Mon Entreprise');
     expect(find('.board-page__header-code__text').length).to.equal(1);
-    expect(find('.board-page__header-code__text').text().trim()).to.equal('ABCD00');
+    expect(find('.board-page__header-code__text').text().trim()).to.equal('PRO001');
   });
 
   it('should display an empty list of snapshot', async function() {

--- a/live/tests/integration/components/share-profile-test.js
+++ b/live/tests/integration/components/share-profile-test.js
@@ -168,6 +168,50 @@ describe('Integration | Component | share profile', function() {
 
     });
 
+    describe('when organization\'s type is SCO', function() {
+
+      beforeEach(function() {
+        // given
+        this.set('organization', Ember.Object.create({ name: 'Pix', type: 'SCO' }));
+
+        // when
+        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      });
+
+      it('should not ask for student code (required)', function() {
+        // then
+        expect(document.querySelector('.share-profile__student-code-input')).to.not.exist;
+      });
+
+      it('should not ask for campaign code (optionnal)', function() {
+        // then
+        expect(document.querySelector('.share-profile__campaign-code-input')).to.not.exist;
+      });
+
+    });
+
+    describe('when organization\'s type is PRO', function() {
+
+      beforeEach(function() {
+        // given
+        this.set('organization', Ember.Object.create({ name: 'Pix', type: 'PRO' }));
+
+        // when
+        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      });
+
+      it('should not ask for student code (required)', function() {
+        // then
+        expect(document.querySelector('.share-profile__student-code-input')).to.not.exist;
+      });
+
+      it('should not ask for campaign code (optionnal)', function() {
+        // then
+        expect(document.querySelector('.share-profile__campaign-code-input')).to.not.exist;
+      });
+
+    });
+
     it('should contain a "Confirm" button to valid the profile sharing', function() {
       // when
       this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);

--- a/live/tests/integration/components/share-profile-test.js
+++ b/live/tests/integration/components/share-profile-test.js
@@ -19,25 +19,25 @@ describe('Integration | Component | share profile', function() {
   });
 
   function expectToBeOnOrganizationCodeEntryView() {
-    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.length(1);
-    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.length(0);
-    expect(Ember.$('.share-profile__section--success-notification')).to.have.length(0);
+    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.lengthOf(1);
+    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.lengthOf(0);
+    expect(Ember.$('.share-profile__section--success-notification')).to.have.lengthOf(0);
   }
 
   function expectToBeSharingConfirmationView() {
-    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.length(0);
-    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.length(1);
-    expect(Ember.$('.share-profile__section--success-notification')).to.have.length(0);
+    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.lengthOf(0);
+    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.lengthOf(1);
+    expect(Ember.$('.share-profile__section--success-notification')).to.have.lengthOf(0);
   }
 
   function expectToBeOnSuccessNotificationView() {
-    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.length(0);
-    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.length(0);
-    expect(Ember.$('.share-profile__section--success-notification')).to.have.length(1);
+    expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.lengthOf(0);
+    expect(Ember.$('.share-profile__section--sharing-confirmation')).to.have.lengthOf(0);
+    expect(Ember.$('.share-profile__section--success-notification')).to.have.lengthOf(1);
   }
 
   function expectModalToBeClosed() {
-    expect(Ember.$('.pix-modal')).to.have.length(0);
+    expect(Ember.$('.pix-modal')).to.have.lengthOf(0);
   }
 
   describe('Step 0 - "Share" button on modal wrapper', function() {
@@ -45,14 +45,14 @@ describe('Integration | Component | share profile', function() {
     it('should open profile sharing modal on "organization code entry" view', function() {
       // given
       this.render(hbs`{{share-profile}}`);
-      expect(Ember.$('.pix-modal')).to.have.length(0);
+      expect(Ember.$('.pix-modal')).to.have.lengthOf(0);
 
       // when
       Ember.run(() => document.querySelector(('.share-profile__share-button')).click());
 
       // then
-      expect(Ember.$('.pix-modal')).to.have.length(1);
-      expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.length(1);
+      expect(Ember.$('.pix-modal')).to.have.lengthOf(1);
+      expect(Ember.$('.share-profile__section--organization-code-entry')).to.have.lengthOf(1);
     });
   });
 
@@ -71,7 +71,7 @@ describe('Integration | Component | share profile', function() {
       this.render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect(Ember.$('.share-profile__organization-code-input')).to.have.length(1);
+      expect(Ember.$('.share-profile__organization-code-input')).to.have.lengthOf(1);
     });
 
     it('should contain a "Continue" button to find the organization', function() {
@@ -79,7 +79,7 @@ describe('Integration | Component | share profile', function() {
       this.render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect(Ember.$('.share-profile__continue-button')).to.have.length(1);
+      expect(Ember.$('.share-profile__continue-button')).to.have.lengthOf(1);
     });
 
     it('should contain a "Cancel" button to cancel the profile sharing', function() {
@@ -87,7 +87,7 @@ describe('Integration | Component | share profile', function() {
       this.render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect(Ember.$('.share-profile__cancel-button')).to.have.length(1);
+      expect(Ember.$('.share-profile__cancel-button')).to.have.lengthOf(1);
     });
 
     it('should redirect to "sharing confirmation" view when clicking on "Continue" button', function() {
@@ -116,7 +116,7 @@ describe('Integration | Component | share profile', function() {
       Ember.run(() => document.querySelector('.share-profile__continue-button').click());
 
       // then
-      expect(Ember.$('.share-profile__form-error')).to.have.length(1);
+      expect(Ember.$('.share-profile__form-error')).to.have.lengthOf(1);
       expectToBeOnOrganizationCodeEntryView();
     });
 
@@ -146,12 +146,27 @@ describe('Integration | Component | share profile', function() {
       expect(Ember.$('.share-profile__organization-name').text().trim()).to.equal('Pix');
     });
 
+    describe('when organization\'s type is SUP', function() {
+
+      it('should ask for student code', function() {
+        // given
+        this.set('organization', Ember.Object.create({ name: 'Pix', type: 'SUP' }));
+
+        // when
+        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+
+        // then
+        expect(document.querySelector('.share-profile__student-code-input')).to.exist;
+      });
+
+    });
+
     it('should contain a "Confirm" button to valid the profile sharing', function() {
       // when
       this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
 
       // then
-      expect(Ember.$('.share-profile__confirm-button')).to.have.length(1);
+      expect(Ember.$('.share-profile__confirm-button')).to.have.lengthOf(1);
     });
 
     it('should contain a "Cancel" button to cancel the profile sharing for the given organization', function() {
@@ -159,7 +174,7 @@ describe('Integration | Component | share profile', function() {
       this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
 
       // then
-      expect(Ember.$('.share-profile__cancel-button')).to.have.length(1);
+      expect(Ember.$('.share-profile__cancel-button')).to.have.lengthOf(1);
     });
 
     it('should return back to "organization code entry" view when clicking on "Cancel" button', function() {
@@ -197,7 +212,7 @@ describe('Integration | Component | share profile', function() {
       this.render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
 
       // then
-      expect(Ember.$('.share-profile__close-button')).to.have.length(1);
+      expect(Ember.$('.share-profile__close-button')).to.have.lengthOf(1);
     });
 
     it('should close the modal when clicking on "Cancel" button', function() {
@@ -208,7 +223,7 @@ describe('Integration | Component | share profile', function() {
       Ember.run(() => document.querySelector('.share-profile__close-button').click());
 
       // then
-      expect(Ember.$('.pix-modal')).to.have.length(0);
+      expect(Ember.$('.pix-modal')).to.have.lengthOf(0);
     });
   });
 

--- a/live/tests/integration/components/share-profile-test.js
+++ b/live/tests/integration/components/share-profile-test.js
@@ -148,15 +148,22 @@ describe('Integration | Component | share profile', function() {
 
     describe('when organization\'s type is SUP', function() {
 
-      it('should ask for student code', function() {
+      beforeEach(function() {
         // given
         this.set('organization', Ember.Object.create({ name: 'Pix', type: 'SUP' }));
 
         // when
         this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      });
 
+      it('should ask for student code (required)', function() {
         // then
         expect(document.querySelector('.share-profile__student-code-input')).to.exist;
+      });
+
+      it('should ask for campaign code (optionnal)', function() {
+        // then
+        expect(document.querySelector('.share-profile__campaign-code-input')).to.exist;
       });
 
     });

--- a/live/tests/integration/components/share-profile-test.js
+++ b/live/tests/integration/components/share-profile-test.js
@@ -273,4 +273,63 @@ describe('Integration | Component | share profile', function() {
 
   });
 
+  describe('Actions', function() {
+
+    beforeEach(function() {
+      // given
+      this.set('showingModal', true);
+      this.set('view', 'sharing-confirmation');
+      this.set('code', 'ABCD1234');
+      this.set('organization', { foo: 'bar' });
+      this.set('organizationNotFound', true);
+      this.set('studentCode', 'student_code');
+      this.set('campaignCode', 'campaign_code');
+
+      this.render(hbs`{{share-profile 
+      _showingModal=showingModal 
+      _view=view 
+      _code=code
+      _organization=organization
+      _organizationNotFound=organizationNotFound
+      _studentCode=studentCode 
+      _campaignCode=campaignCode}}`);
+    });
+
+    describe('#closeModal', function() {
+
+      it('should remove all input information when modal is closed', function() {
+        // when
+        Ember.run(() => document.querySelector('.pix-modal__close-link').click());
+
+        // then
+        expect(this.get('showingModal')).to.be.false;
+        expect(this.get('view')).to.equal('organization-code-entry');
+        expect(this.get('code')).to.be.null;
+        expect(this.get('organization')).to.be.null;
+        expect(this.get('organizationNotFound')).to.be.false;
+        expect(this.get('studentCode')).to.be.null;
+        expect(this.get('campaignCode')).to.be.null;
+      });
+
+    });
+
+    describe('#cancelSharingAndGoBackToOrganizationCodeEntryView', function() {
+
+      it('should remove all input information but organization code when sharing confirmation is canceled', function() {
+        // when
+        Ember.run(() => document.querySelector('.share-profile__cancel-button').click());
+
+        // then
+        expect(this.get('showingModal')).to.be.true;
+        expect(this.get('view')).to.equal('organization-code-entry');
+        expect(this.get('code')).to.equal('ABCD1234');
+        expect(this.get('organization')).to.be.null;
+        expect(this.get('organizationNotFound')).to.be.false;
+        expect(this.get('studentCode')).to.be.null;
+        expect(this.get('campaignCode')).to.be.null;
+      });
+    });
+
+  });
+
 });

--- a/live/tests/unit/components/share-profile-test.js
+++ b/live/tests/unit/components/share-profile-test.js
@@ -104,4 +104,5 @@ describe('Unit | Component | share-profile', function() {
     });
 
   });
+
 });

--- a/live/tests/unit/components/share-profile-test.js
+++ b/live/tests/unit/components/share-profile-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import Ember from 'ember';
 
 describe('Unit | Component | share-profile', function() {
 
@@ -74,6 +75,32 @@ describe('Unit | Component | share-profile', function() {
 
       // then
       expect(component.get('_organization')).to.equal(null);
+    });
+
+  });
+
+  describe('#isOrganizationHasTypeSup', function() {
+
+    it('should return "true" when organization type is "SUP"', function() {
+      // given
+      component.set('_organization', Ember.Object.create({ type: 'SUP' }));
+
+      // when
+      const isOrganizationHasTypeSup = component.get('isOrganizationHasTypeSup');
+
+      // then
+      expect(isOrganizationHasTypeSup).to.be.true;
+    });
+
+    it('should return "false" when organization type is not "SUP"', function() {
+      // given
+      component.set('_organization', Ember.Object.create({ type: 'SCO' }));
+
+      // when
+      const isOrganizationHasTypeSup = component.get('isOrganizationHasTypeSup');
+
+      // then
+      expect(isOrganizationHasTypeSup).to.be.false;
     });
 
   });

--- a/live/tests/unit/components/share-profile-test.js
+++ b/live/tests/unit/components/share-profile-test.js
@@ -105,4 +105,33 @@ describe('Unit | Component | share-profile', function() {
 
   });
 
+  describe('.organizationLabels', function() {
+
+    it('should return adapted ("orgnisation"-based) labels when organization type is PRO', function() {
+      // given
+      component.set('_organization', { type: 'PRO' });
+
+      // when
+      const organizationLabel = component.get('organizationLabels');
+
+      // then
+      expect(organizationLabel.text1).to.equal('Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'organisation :');
+      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes :');
+      expect(organizationLabel.text3).to.equal('Elle ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.');
+    });
+
+    it('should return adapted ("établissement"-based) labels when organization type is SUP or SCO', function() {
+      // given
+      component.set('_organization', { type: 'SUP' });
+
+      // when
+      const organizationLabel = component.get('organizationLabels');
+
+      // then
+      expect(organizationLabel.text1).to.equal('Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'établissement :');
+      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton «Envoyer», il recevra les informations suivantes :');
+      expect(organizationLabel.text3).to.equal('Il ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.');
+    });
+
+  });
 });

--- a/live/tests/unit/components/share-profile-test.js
+++ b/live/tests/unit/components/share-profile-test.js
@@ -116,7 +116,7 @@ describe('Unit | Component | share-profile', function() {
 
       // then
       expect(organizationLabel.text1).to.equal('Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'organisation :');
-      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton «Envoyer», elle recevra les informations suivantes :');
+      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton « Envoyer », elle recevra les informations suivantes :');
       expect(organizationLabel.text3).to.equal('Elle ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.');
     });
 
@@ -129,7 +129,7 @@ describe('Unit | Component | share-profile', function() {
 
       // then
       expect(organizationLabel.text1).to.equal('Vous vous apprêtez à transmettre une copie de votre profil Pix à l\'établissement :');
-      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton «Envoyer», il recevra les informations suivantes :');
+      expect(organizationLabel.text2).to.equal('En cliquant sur le bouton « Envoyer », il recevra les informations suivantes :');
       expect(organizationLabel.text3).to.equal('Il ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau.');
     });
 


### PR DESCRIPTION
**RA :** http://712-filling-student-number-when-sharing-profile.pix.beta.gouv.fr 

**Critères d'acceptation**
- ETQ User ayant entré un code établissement appartenant au "sup", JV qu'on me propose d'entrer mon numéro étudiant dans un champ. cf mockup.
- ETQ User ayant entré un code établissement appartenant au "sup", JV qu'on me propose d'entrer un code campagne facultatif. cf. mockup
- ETQ User ayant entré un code établissement appartenant au "sup", JV qu'on adapte le texte qui m'est proposé : "établissement" et non "organisation", liste  adaptée des données qui remontent. cf. texte du mockup
- ETQ User n'appartenant pas au "sup", je veux garder la 2e modale telle que précédemment conçue. 
- Pour tous les users, JV une mini modif de la dernière phrase : "Il ne recevra les évolutions futures de votre profil que si vous le partagez à nouveau."

**Ce que ne contient pas cette PR**

Cette US ne contient pas la gestion des codes étudiant (obligatoire si demandé) et campagne (optionnel).

**Travaux réalisés**

- ajout des champs `student_code` et `campaign_code` dans la table `snapshots`
- petit refactoring de la fonction `snapshot-controller#create` pour la rendre plus lisible
- au passage, ajout de la méthode `snapshot-serializer#deserialize` basée sur le nouveau serializer JSON:API
- remise en format de certains fichiers
- application du nouveau standard concernant les majuscules pour les classes / minuscules pour les modules
- remplacement de `.eql` par `.deep.equal` pour un meilleur nommage
- adaptation du texte affiché en fonction qu’il s’agisse d’un établissement de l’enseignement ou d’une entreprise
- amélioration du style de la modale de partage d’un profil
- remplacement de `chai#length` par `chai#lengthOf` car la méthode `length` est deprecated dans Chai
- ajout de tests unitaires manquant pour le composant `share-profile.js`
