### PR TITLE
[#567] [BUGFIX] Changer la méthode de récupération de la base url d'origine (US-895)

### DIFF
--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -10,7 +10,7 @@ const errorSerializer = require('../../infrastructure/serializers/jsonapi/valida
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 
 function _sendPasswordResetDemandUrlEmail(request, email, temporaryKey, passwordResetDemand) {
-  const passwordResetDemandUrl = request.headers.origin;
+  const passwordResetDemandUrl = `http://${request.headers.host}`;
   return mailService
     .sendResetPasswordDemandEmail(email, passwordResetDemandUrl, temporaryKey)
     .then(() => passwordResetDemand);

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -26,8 +26,7 @@ describe('Unit | Controller | PasswordController', () => {
             }
           }
         },
-        connection: { info: { protocol: 'http' } },
-        headers: { origin: 'http://localhost' }
+        headers: { host: 'localhost' }
       };
 
       let replyStub;


### PR DESCRIPTION
Plutôt qu'utiliser la méthode request.headers.origin, on opte pour request.headers.host qui marche mieux sous firefox.