### PR TITLE
[#591] [TECH] Utilisation de vues privées au niveau des Epreuves (dans Airtable) afin de sécuriser (stabiliser) la plateforme (US-892).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -11,6 +11,7 @@ const challengeRepository = require('../../infrastructure/repositories/challenge
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 const solutionSerializer = require('../../infrastructure/serializers/jsonapi/solution-serializer');
 const courseRepository = require('../../infrastructure/repositories/course-repository');
+const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const skillRepository = require('../../infrastructure/repositories/skill-repository');
 
 const answerRepository = require('../../infrastructure/repositories/answer-repository');
@@ -80,7 +81,6 @@ module.exports = {
         if (assessmentService.isPreviewAssessment(assessment)) {
           return Promise.reject(new NotElligibleToScoringError(`Assessment with ID ${request.params.id} is a preview Challenge`));
         }
-
         return assessmentService.getAssessmentNextChallengeId(assessment, request.params.challengeId);
       })
       .then((nextChallengeId) => {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -151,9 +151,12 @@ module.exports = {
         });
       })
       .then(({ answers, course, challenges }) => {
-        // fetch skillNames (requires course)
-        const competenceId = course.competences[0];
-        const skillNames = skillRepository.findByCompetence(competenceId);
+        return competenceRepository.get(course.competences[0]).then(competence => {
+          return { answers, course, challenges, competence };
+        });
+      })
+      .then(({ answers, course, challenges, competence }) => {
+        const skillNames = skillRepository.findByCompetence(competence);
         return Promise.all([skillNames]).then(values => {
           const skillNames = values[0];
           return { answers, course, challenges, skillNames };

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -13,7 +13,6 @@ const solutionSerializer = require('../../infrastructure/serializers/jsonapi/sol
 const courseRepository = require('../../infrastructure/repositories/course-repository');
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const skillRepository = require('../../infrastructure/repositories/skill-repository');
-
 const answerRepository = require('../../infrastructure/repositories/answer-repository');
 const solutionRepository = require('../../infrastructure/repositories/solution-repository');
 

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -153,7 +153,7 @@ module.exports = {
       .then(({ answers, course, challenges }) => {
         // fetch skillNames (requires course)
         const competenceId = course.competences[0];
-        const skillNames = skillRepository.cache.getFromCompetenceId(competenceId);
+        const skillNames = skillRepository.findByCompetence(competenceId);
         return Promise.all([skillNames]).then(values => {
           const skillNames = values[0];
           return { answers, course, challenges, skillNames };

--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -127,17 +127,17 @@ class Assessment {
 
   get _firstChallenge() {
     const filteredFirstChallenges = this.filteredChallenges.filter(
-      challenge => challenge.hardestSkill.difficulty === 2 && challenge.timer === undefined
+      challenge => (challenge.hardestSkill.difficulty === 2) && (challenge.timer === undefined)
     );
     filteredFirstChallenges.sort(() => 0.5 - Math.random());
     return filteredFirstChallenges[0];
   }
 
   get nextChallenge() {
-    if (this.answers.length == 0) {
+    if (this.answers.length === 0) {
       return this._firstChallenge;
     }
-    if (this.answers.length == 20) {
+    if (this.answers.length >= 20) {
       return null;
     }
     const filteredChallenges = this.filteredChallenges;
@@ -150,7 +150,7 @@ class Assessment {
         bestChallenge = challenge;
       }
     });
-    if (maxReward == 0) { // We will not get extra information
+    if (maxReward === 0) { // We will not get extra information
       return null;
     } else {
       return bestChallenge; // May be undefined, in which case the adaptive test should be ended

--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -127,7 +127,7 @@ class Assessment {
 
   get _firstChallenge() {
     const filteredFirstChallenges = this.filteredChallenges.filter(
-      challenge => challenge.hardestSkill.difficulty == 2 && challenge.timer === undefined
+      challenge => challenge.hardestSkill.difficulty === 2 && challenge.timer === undefined
     );
     filteredFirstChallenges.sort(() => 0.5 - Math.random());
     return filteredFirstChallenges[0];

--- a/api/lib/domain/services/assessment-service-utils.js
+++ b/api/lib/domain/services/assessment-service-utils.js
@@ -1,10 +1,9 @@
 const assessmentAdapter = require('../../infrastructure/adapters/assessment-adapter');
 
-function getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills) {
-  const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skills);
-  return assessment.nextChallenge ? assessment.nextChallenge.id : null;
-}
-
 module.exports = {
-  getNextChallengeInAdaptiveCourse
+
+  getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills) {
+    const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skills);
+    return assessment.nextChallenge ? assessment.nextChallenge.id : null;
+  }
 };

--- a/api/lib/domain/services/assessment-service-utils.js
+++ b/api/lib/domain/services/assessment-service-utils.js
@@ -1,9 +1,11 @@
 const assessmentAdapter = require('../../infrastructure/adapters/assessment-adapter');
+const _ = require('lodash');
 
 module.exports = {
 
   getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills) {
     const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skills);
-    return assessment.nextChallenge ? assessment.nextChallenge.id : null;
+    return _.get(assessment, 'nextChallenge.id', null);
   }
+
 };

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -61,20 +61,16 @@ function getScoredAssessment(assessmentId) {
 
   let assessmentPix, answersPix, challengesPix, coursePix, competenceId, skills;
 
-  return assessmentRepository
-    .get(assessmentId)
+  return assessmentRepository.get(assessmentId)
     .then(retrievedAssessment => {
-
       if (retrievedAssessment === null) {
         return Promise.reject(new NotFoundError(`Unable to find assessment with ID ${assessmentId}`));
       } else if (isPreviewAssessment(retrievedAssessment)) {
         return Promise.reject(new NotElligibleToScoringError(`Assessment with ID ${assessmentId} is a preview Challenge`));
       }
-
       assessmentPix = retrievedAssessment;
-
-      return answerRepository.findByAssessment(assessmentPix.get('id'));
     })
+    .then(() => answerRepository.findByAssessment(assessmentPix.get('id')))
     .then(retrievedAnswers => {
       answersPix = retrievedAnswers;
       assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -11,22 +11,18 @@ const _ = require('../../infrastructure/utils/lodash-utils');
 
 const { NotFoundError, NotElligibleToScoringError } = require('../../domain/errors');
 
-function _selectNextInAdaptiveMode(assessmentPix, coursePix) {
+function _selectNextInAdaptiveMode(assessment, course) {
 
-  let answersPix, challengesPix;
+  let answers, challenges;
 
-  const competenceId = coursePix.competences[0];
+  const competenceId = course.competences[0];
 
-  return answerRepository.findByAssessment(assessmentPix.get('id'))
-    .then(answers => {
-      answersPix = answers;
-      return challengeRepository.findByCompetence(competenceId);
-    }).then(challenges => {
-      challengesPix = challenges;
-      return skillRepository.findByCompetence(competenceId);
-    }).then(skills => {
-      return assessmentUtils.getNextChallengeInAdaptiveCourse(coursePix, answersPix, challengesPix, skills);
-    });
+  return answerRepository.findByAssessment(assessment.get('id'))
+    .then(fetchedAnswers => (answers = fetchedAnswers))
+    .then(() => challengeRepository.findByCompetence(competenceId))
+    .then(fetchedChallenges => (challenges = fetchedChallenges))
+    .then(() => skillRepository.findByCompetence(competenceId))
+    .then(skills => assessmentUtils.getNextChallengeInAdaptiveCourse(course, answers, challenges, skills));
 }
 
 function _selectNextInNormalMode(currentChallengeId, challenges) {

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -53,75 +53,13 @@ function _selectNextChallengeId(course, currentChallengeId, assessment) {
   return Promise.resolve(_selectNextInNormalMode(currentChallengeId, challenges));
 }
 
-module.exports = {
+function getAssessmentNextChallengeId(assessment, currentChallengeId) {
 
-  getAssessmentNextChallengeId(assessment, currentChallengeId) {
+  return new Promise((resolve, reject) => {
 
-    return new Promise((resolve, reject) => {
-
-      if (!assessment) {
-        resolve(null);
-      }
-
-      const courseId = assessment.get('courseId');
-
-      if (!courseId) {
-        resolve(null);
-      }
-
-      if (_.startsWith(courseId, 'null')) {
-        resolve(null);
-      }
-
-      courseRepository.get(courseId)
-        .then(course => resolve(_selectNextChallengeId(course, currentChallengeId, assessment)))
-        .catch(reject);
-    });
-  },
-
-  getScoredAssessment(assessmentId) {
-
-    let assessmentPix, answersPix, challengesPix, coursePix, competencePix, skills;
-
-    return assessmentRepository.get(assessmentId)
-      .then(retrievedAssessment => {
-        if (retrievedAssessment === null) {
-          return Promise.reject(new NotFoundError(`Unable to find assessment with ID ${assessmentId}`));
-        } else if (isPreviewAssessment(retrievedAssessment)) {
-          return Promise.reject(new NotElligibleToScoringError(`Assessment with ID ${assessmentId} is a preview Challenge`));
-        }
-        assessmentPix = retrievedAssessment;
-      })
-      .then(() => answerRepository.findByAssessment(assessmentPix.get('id')))
-      .then(retrievedAnswers => {
-        answersPix = retrievedAnswers;
-        assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));
-      })
-      .then(() => courseRepository.get(assessmentPix.get('courseId')))
-      .then(course => (coursePix = course))
-      .then(() => competenceRepository.get(coursePix.competences[0]))
-      .then((fetchedCompetence) => (competencePix = fetchedCompetence))
-      .then(() => challengeRepository.findByCompetence(competencePix))
-      .then(challenges => challengesPix = challenges)
-      .then(() => skillRepository.findByCompetence(competencePix))
-      .then(skillNames => {
-        if (coursePix.isAdaptive) {
-          const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skillNames);
-          skills = {
-            assessmentId,
-            validatedSkills: assessment.validatedSkills,
-            failedSkills: assessment.failedSkills
-          };
-          assessmentPix.set('estimatedLevel', assessment.obtainedLevel);
-          assessmentPix.set('pixScore', assessment.displayedPixScore);
-        } else {
-          assessmentPix.set('estimatedLevel', 0);
-          assessmentPix.set('pixScore', 0);
-        }
-
-        return { assessmentPix, skills };
-      });
-  },
+    if (!assessment) {
+      resolve(null);
+    }
 
     const courseId = assessment.get('courseId');
 
@@ -138,6 +76,64 @@ module.exports = {
       .catch(reject);
   });
 }
+
+function getScoredAssessment(assessmentId) {
+
+  let assessmentPix, answersPix, challengesPix, coursePix, competencePix, skills;
+
+  return assessmentRepository.get(assessmentId)
+    .then(retrievedAssessment => {
+      if (retrievedAssessment === null) {
+        return Promise.reject(new NotFoundError(`Unable to find assessment with ID ${assessmentId}`));
+      } else if (isPreviewAssessment(retrievedAssessment)) {
+        return Promise.reject(new NotElligibleToScoringError(`Assessment with ID ${assessmentId} is a preview Challenge`));
+      }
+      assessmentPix = retrievedAssessment;
+    })
+    .then(() => answerRepository.findByAssessment(assessmentPix.get('id')))
+    .then(retrievedAnswers => {
+      answersPix = retrievedAnswers;
+      assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));
+    })
+    .then(() => courseRepository.get(assessmentPix.get('courseId')))
+    .then(course => (coursePix = course))
+    .then(() => competenceRepository.get(coursePix.competences[0]))
+    .then((fetchedCompetence) => (competencePix = fetchedCompetence))
+    .then(() => challengeRepository.findByCompetence(competencePix))
+    .then(challenges => challengesPix = challenges)
+    .then(() => skillRepository.findByCompetence(competencePix))
+    .then(skillNames => {
+      if (coursePix.isAdaptive) {
+        const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skillNames);
+        skills = {
+          assessmentId,
+          validatedSkills: assessment.validatedSkills,
+          failedSkills: assessment.failedSkills
+        };
+        assessmentPix.set('estimatedLevel', assessment.obtainedLevel);
+        assessmentPix.set('pixScore', assessment.displayedPixScore);
+      } else {
+        assessmentPix.set('estimatedLevel', 0);
+        assessmentPix.set('pixScore', 0);
+      }
+
+      return { assessmentPix, skills };
+    });
+
+  const courseId = assessment.get('courseId');
+
+  if (!courseId) {
+    resolve(null);
+  }
+
+  if (_.startsWith(courseId, 'null')) {
+    resolve(null);
+  }
+
+  courseRepository.get(courseId)
+    .then(course => resolve(_selectNextChallengeId(course, currentChallengeId, assessment)))
+    .catch(reject);
+};
 
 function isPreviewAssessment(assessment) {
   return _.startsWith(assessment.get('courseId'), 'null');

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -77,20 +77,16 @@ function getScoredAssessment(assessmentId) {
     })
     .then(retrievedAnswers => {
       answersPix = retrievedAnswers;
-
       assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));
-
-      return courseRepository.get(assessmentPix.get('courseId'));
     })
+    .then(() => courseRepository.get(assessmentPix.get('courseId')))
     .then(course => {
       coursePix = course;
       competenceId = coursePix.competences[0];
-      return challengeRepository.findByCompetence(competenceId);
     })
-    .then(challenges => {
-      challengesPix = challenges;
-      return skillRepository.cache.getFromCompetenceId(competenceId);
-    })
+    .then(() => challengeRepository.findByCompetence(competenceId))
+    .then(challenges => challengesPix = challenges)
+    .then(() => skillRepository.cache.getFromCompetenceId(competenceId))
     .then(skillNames => {
       if (coursePix.isAdaptive) {
         const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skillNames);

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -119,21 +119,7 @@ function getScoredAssessment(assessmentId) {
 
       return { assessmentPix, skills };
     });
-
-  const courseId = assessment.get('courseId');
-
-  if (!courseId) {
-    resolve(null);
-  }
-
-  if (_.startsWith(courseId, 'null')) {
-    resolve(null);
-  }
-
-  courseRepository.get(courseId)
-    .then(course => resolve(_selectNextChallengeId(course, currentChallengeId, assessment)))
-    .catch(reject);
-};
+}
 
 function isPreviewAssessment(assessment) {
   return _.startsWith(assessment.get('courseId'), 'null');

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -20,7 +20,7 @@ function _selectNextInAdaptiveMode(assessmentPix, coursePix) {
   return answerRepository.findByAssessment(assessmentPix.get('id'))
     .then(answers => {
       answersPix = answers;
-      return challengeRepository.getFromCompetenceId(competenceId);
+      return challengeRepository.findByCompetence(competenceId);
     }).then(challenges => {
       challengesPix = challenges;
       return skillRepository.cache.getFromCompetenceId(competenceId);
@@ -85,7 +85,7 @@ function getScoredAssessment(assessmentId) {
     .then(course => {
       coursePix = course;
       competenceId = coursePix.competences[0];
-      return challengeRepository.getFromCompetenceId(competenceId);
+      return challengeRepository.findByCompetence(competenceId);
     })
     .then(challenges => {
       challengesPix = challenges;

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -23,9 +23,9 @@ function _selectNextInAdaptiveMode(assessmentPix, coursePix) {
       return challengeRepository.findByCompetence(competenceId);
     }).then(challenges => {
       challengesPix = challenges;
-      return skillRepository.cache.getFromCompetenceId(competenceId);
+      return skillRepository.findByCompetence(competenceId);
     }).then(skills => {
-      return assessmentUtils.getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills);
+      return assessmentUtils.getNextChallengeInAdaptiveCourse(coursePix, answersPix, challengesPix, skills);
     });
 }
 
@@ -86,7 +86,7 @@ function getScoredAssessment(assessmentId) {
     })
     .then(() => challengeRepository.findByCompetence(competenceId))
     .then(challenges => challengesPix = challenges)
-    .then(() => skillRepository.cache.getFromCompetenceId(competenceId))
+    .then(() => skillRepository.findByCompetence(competenceId))
     .then(skillNames => {
       if (coursePix.isAdaptive) {
         const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skillNames);

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -55,7 +55,7 @@ function _selectNextChallengeId(course, currentChallengeId, assessment) {
 
 function getScoredAssessment(assessmentId) {
 
-  let assessmentPix, answersPix, challengesPix, coursePix, competencePix, competenceId, skills;
+  let assessmentPix, answersPix, challengesPix, coursePix, competencePix, skills;
 
   return assessmentRepository.get(assessmentId)
     .then(retrievedAssessment => {
@@ -72,10 +72,7 @@ function getScoredAssessment(assessmentId) {
       assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));
     })
     .then(() => courseRepository.get(assessmentPix.get('courseId')))
-    .then(course => {
-      coursePix = course;
-      competenceId = coursePix.competences[0];
-    })
+    .then(course => (coursePix = course))
     .then(() => competenceRepository.get(coursePix.competences[0]))
     .then((fetchedCompetence) => (competencePix = fetchedCompetence))
     .then(() => challengeRepository.findByCompetence(competencePix))

--- a/api/lib/domain/services/skills-service.js
+++ b/api/lib/domain/services/skills-service.js
@@ -10,7 +10,7 @@ module.exports = {
 
     const formattedSkills = [].concat(formattedValitedSkills, formattedFailedSkills);
 
-    return skillsRespository.db.save(formattedSkills);
+    return skillsRespository.save(formattedSkills);
   }
 };
 

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -14,13 +14,9 @@ module.exports = {
    * @returns {AirtableModel} The fetched and deserialized model object
    */
   getRecord(tableName, id, serializer) {
-    return new Promise((resolve, reject) => {
-      _base(tableName).find(id, (err, record) => {
-        if (err) return reject(err);
-        const model = serializer.deserialize(record);
-        return resolve(model);
-      });
-    });
+    return _base(tableName)
+      .find(id)
+      .then(serializer.deserialize);
   },
 
   /**

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -38,9 +38,9 @@ module.exports = {
     });
   },
 
-  getFromCompetenceId(competenceId) {
+  findByCompetence(competenceId) {
     return new Promise((resolve, reject) => {
-      const cacheKey = `challenge-repository_get_from_competence_${competenceId}`;
+      const cacheKey = `challenge-repository_find_by_competence_${competenceId}`;
       cache.get(cacheKey, (err, cachedValue) => {
         if (err) return reject(err);
         if (cachedValue) return resolve(cachedValue);

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -38,17 +38,20 @@ module.exports = {
     });
   },
 
-  findByCompetence(competenceId) {
-    return new Promise((resolve, reject) => {
-      const cacheKey = `challenge-repository_find_by_competence_${competenceId}`;
-      cache.get(cacheKey, (err, cachedValue) => {
-        if (err) return reject(err);
-        if (cachedValue) return resolve(cachedValue);
-        return _fetchChallenges(cacheKey, resolve, reject,
-          challenge => ['validé', 'validé sans test', 'pré-validé'].includes(challenge.status)
-            && challenge.competence == competenceId);
+  findByCompetence(competence) {
+    const cacheKey = `challenge-repository_find_by_competence_${competence.id}`;
+    const cachedChallenges = cache.get(cacheKey);
+
+    if (cachedChallenges) {
+      return Promise.resolve(cachedChallenges);
+    }
+
+    return airtable
+      .getRecords(AIRTABLE_TABLE_NAME, { view: competence.reference }, serializer)
+      .then(fetchedChallenges => {
+        cache.set(cacheKey, fetchedChallenges);
+        return Promise.resolve(fetchedChallenges);
       });
-    });
   },
 
   get(id) {

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -3,11 +3,11 @@ const airtable = require('../airtable');
 const serializer = require('../serializers/airtable/competence-serializer');
 
 const AIRTABLE_TABLE_NAME = 'Competences';
-const cacheKey = 'competence-repository_list';
 
 module.exports = {
 
   list() {
+    const cacheKey = 'competence-repository_list';
     const cachedCompetences = cache.get(cacheKey);
 
     if (cachedCompetences) {
@@ -21,5 +21,21 @@ module.exports = {
         return competences;
       });
   },
+
+  get(recordId) {
+    const cacheKey = `competence-repository_get_${recordId}`;
+    const cachedCompetence = cache.get(cacheKey);
+
+    if (cachedCompetence) {
+      return Promise.resolve(cachedCompetence);
+    }
+
+    return airtable
+      .getRecord(AIRTABLE_TABLE_NAME, recordId, serializer)
+      .then((competence) => {
+        cache.set(cacheKey, competence);
+        return competence;
+      });
+  }
 
 };

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -8,26 +8,18 @@ const cacheKey = 'competence-repository_list';
 module.exports = {
 
   list() {
-    return new Promise((resolve, reject) => {
+    const cachedCompetences = cache.get(cacheKey);
 
-      cache.get(cacheKey, (err, cachedCompetences) => {
-        if(err) {
-          return reject(err);
-        }
+    if (cachedCompetences) {
+      return Promise.resolve(cachedCompetences);
+    }
 
-        if(cachedCompetences) {
-          return resolve(cachedCompetences);
-        }
-
-        airtable.getRecords(AIRTABLE_TABLE_NAME, {}, serializer)
-          .then((competences) => {
-            cache.set(cacheKey, competences);
-            resolve(competences);
-          })
-          .catch(reject);
+    return airtable
+      .getRecords(AIRTABLE_TABLE_NAME, {}, serializer)
+      .then((competences) => {
+        cache.set(cacheKey, competences);
+        return competences;
       });
-
-    });
   },
 
 };

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const cache = require('../cache');
 const challengeRepository = require('./challenge-repository');
 const Skill = require('../../domain/models/data/skill');

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -5,15 +5,15 @@ const Bookshelf = require('../../infrastructure/bookshelf');
 
 module.exports = {
 
-  findByCompetence(competenceId) {
-    const cacheKey = `skill-repository_find_by_competence_${competenceId}`;
+  findByCompetence(competence) {
+    const cacheKey = `skill-repository_find_by_competence_${competence.id}`;
     const cachedSkills = cache.get(cacheKey);
 
     if (cachedSkills) {
       return Promise.resolve(cachedSkills);
     }
 
-    return challengeRepository.findByCompetence(competenceId)
+    return challengeRepository.findByCompetence(competence)
       .then(challenges => {
         const skills = new Set();
         _(challenges)

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -6,7 +6,7 @@ const Bookshelf = require('../../infrastructure/bookshelf');
 const _ = require('lodash');
 
 function _fetchSkillsFromCompetence(competenceId, cacheKey, resolve, reject) {
-  challengeRepository.getFromCompetenceId(competenceId)
+  challengeRepository.findByCompetence(competenceId)
     .then(challenges => {
       const skills = new Set();
 

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -24,14 +24,11 @@ module.exports = {
       });
   },
 
-  db: {
-    save(arraySkills) {
-      const SkillCollection = Bookshelf.Collection.extend({
-        model: Skill
-      });
-
-      return SkillCollection.forge(arraySkills)
-        .invokeThen('save');
-    }
+  save(arraySkills) {
+    const SkillCollection = Bookshelf.Collection.extend({
+      model: Skill
+    });
+    return SkillCollection.forge(arraySkills)
+      .invokeThen('save');
   }
 };

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -3,39 +3,25 @@ const challengeRepository = require('./challenge-repository');
 const Skill = require('../../domain/models/data/skill');
 const Bookshelf = require('../../infrastructure/bookshelf');
 
-const _ = require('lodash');
-
-function _fetchSkillsFromCompetence(competenceId, cacheKey, resolve, reject) {
-  challengeRepository.findByCompetence(competenceId)
-    .then(challenges => {
-      const skills = new Set();
-
-      _(challenges)
-        .without((challenge) => _.isNil(challenge.skills))
-        .forEach((challenge) => _.forEach(challenge.skills, (skill) => skills.add(skill)));
-
-      cache.set(cacheKey, skills);
-      return resolve(skills);
-    })
-    .catch(reject);
-}
-
 module.exports = {
-  cache: {
-    getFromCompetenceId(competenceId) {
-      return new Promise((resolve, reject) => {
-        const cacheKey = `skill-repository_get_from_competence_${competenceId}`;
-        cache.get(cacheKey, (err, cachedValue) => {
-          if (err) {
-            return reject(err);
-          }
-          if (cachedValue) {
-            return resolve(cachedValue);
-          }
-          return _fetchSkillsFromCompetence(competenceId, cacheKey, resolve, reject);
-        });
-      });
+
+  findByCompetence(competenceId) {
+    const cacheKey = `skill-repository_find_by_competence_${competenceId}`;
+    const cachedSkills = cache.get(cacheKey);
+
+    if (cachedSkills) {
+      return Promise.resolve(cachedSkills);
     }
+
+    return challengeRepository.findByCompetence(competenceId)
+      .then(challenges => {
+        const skills = new Set();
+        _(challenges)
+          .without((challenge) => _.isNil(challenge.skills))
+          .forEach((challenge) => _.forEach(challenge.skills, (skill) => skills.add(skill)));
+        cache.set(cacheKey, skills);
+        return skills;
+      });
   },
 
   db: {

--- a/api/lib/infrastructure/serializers/airtable/competence-serializer.js
+++ b/api/lib/infrastructure/serializers/airtable/competence-serializer.js
@@ -9,11 +9,12 @@ class CompetenceSerializer extends AirtableSerializer {
     competence.id = airtableRecord.id;
 
     const fields = airtableRecord.fields;
-    if(fields) {
+    if (fields) {
       competence.name = fields['Titre'];
       competence.index = fields['Sous-domaine'];
       competence.areaId = fields['Domaine'];
       competence.courseId = fields['Tests Record ID'] ? fields['Tests Record ID'][0] : '';
+      competence.reference = fields['Référence'];
     }
 
     return competence;

--- a/api/lib/infrastructure/serializers/airtable/competence-serializer.js
+++ b/api/lib/infrastructure/serializers/airtable/competence-serializer.js
@@ -15,6 +15,7 @@ class CompetenceSerializer extends AirtableSerializer {
       competence.areaId = fields['Domaine'];
       competence.courseId = fields['Tests Record ID'] ? fields['Tests Record ID'][0] : '';
       competence.reference = fields['Référence'];
+      competence.skills = fields['Acquis'];
     }
 
     return competence;

--- a/api/package.json
+++ b/api/package.json
@@ -55,7 +55,8 @@
     "mocha": "^3.5.3",
     "nock": "^9.0.22",
     "nodemon": "^1.12.1",
-    "sinon": "^3.3.0"
+    "sinon": "^3.3.0",
+    "sinon-chai": "^2.14.0"
   },
   "scripts": {
     "help": "./scripts/help.sh",

--- a/api/tests/acceptance/application/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answer-controller-find_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       assessmentId: '12345'
     };
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
@@ -31,7 +31,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('answers').delete().then(() => {
         done();
       });

--- a/api/tests/acceptance/application/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answer-controller-find_test.js
@@ -3,7 +3,7 @@ const server = require('../../../server');
 
 describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function(done) {
+  after((done) => {
     server.stop(done);
   });
 
@@ -22,29 +22,26 @@ describe('Acceptance | Controller | answer-controller', function() {
       assessmentId: '12345'
     };
 
-    beforeEach((done) => {
-      knex('answers').delete().then(() => {
-        knex('answers').insert([inserted_answer]).then((id) => {
+    beforeEach(() => {
+      return knex('answers').delete().then(() => {
+        return knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
-          done();
         });
       });
     });
 
-    afterEach((done) => {
-      knex('answers').delete().then(() => {
-        done();
-      });
+    afterEach(() => {
+      return knex('answers').delete();
     });
 
-    it('should return 200 HTTP status code', function(done) {
+    it('should return 200 HTTP status code', (done) => {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function(done) {
+    it('should return application/json', (done) => {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -52,7 +49,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should return required answer', function(done) {
+    it('should return required answer', (done) => {
       server.inject({ method: 'GET', url: queryUrl }, (response) => {
         const answer = response.result.data;
 
@@ -66,7 +63,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should return 200 with "null" data if not found answer', function(done) {
+    it('should return 200 with "null" data if not found answer', (done) => {
       server.inject({
         method: 'GET',
         url: '/api/answers?challenge=nothing&assessment=nothing'

--- a/api/tests/acceptance/application/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answer-controller-get_test.js
@@ -3,7 +3,7 @@ const server = require('../../../server');
 
 describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function(done) {
+  after((done) => {
     server.stop(done);
   });
 
@@ -19,30 +19,27 @@ describe('Acceptance | Controller | answer-controller', function() {
       assessmentId: '12345'
     };
 
-    beforeEach((done) => {
-      knex('answers').delete().then(() => {
-        knex('answers').insert([inserted_answer]).then((id) => {
+    beforeEach(() => {
+      return knex('answers').delete().then(() => {
+        return knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
           options = { method: 'GET', url: `/api/answers/${inserted_answer_id}` };
-          done();
         });
       });
     });
 
-    afterEach((done) => {
-      knex('answers').delete().then(() => {
-        done();
-      });
+    afterEach(() => {
+      return knex('answers').delete();
     });
 
-    it('should return 200 HTTP status code', function(done) {
+    it('should return 200 HTTP status code', (done) => {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function(done) {
+    it('should return application/json', (done) => {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -50,7 +47,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should return required answer', function(done) {
+    it('should return required answer', (done) => {
       server.inject(options, (response) => {
         const answer = response.result.data;
 

--- a/api/tests/acceptance/application/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answer-controller-get_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       assessmentId: '12345'
     };
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       knex('answers').delete().then(() => {
         knex('answers').insert([inserted_answer]).then((id) => {
           inserted_answer_id = id;
@@ -29,7 +29,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('answers').delete().then(() => {
         done();
       });

--- a/api/tests/acceptance/application/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answer-controller-save_test.js
@@ -3,7 +3,7 @@ const server = require('../../../server');
 const Answer = require('../../../lib/domain/models/data/answer');
 
 describe('Acceptance | Controller | answer-controller', function() {
-  after(function(done) {
+  after((done) => {
     server.stop(done);
   });
 
@@ -24,11 +24,11 @@ describe('Acceptance | Controller | answer-controller', function() {
         });
     });
 
-    after(function() {
+    after(() => {
       nock.cleanAll();
     });
 
-    afterEach(function() {
+    afterEach(() => {
       return knex('answers').delete();
     });
 
@@ -66,14 +66,14 @@ describe('Acceptance | Controller | answer-controller', function() {
         };
       });
 
-      it('should return 201 HTTP status code', function(done) {
+      it('should return 201 HTTP status code', (done) => {
         server.inject(options, (response) => {
           expect(response.statusCode).to.equal(201);
           done();
         });
       });
 
-      it('should return application/json', function(done) {
+      it('should return application/json', (done) => {
         server.inject(options, (response) => {
           const contentType = response.headers['content-type'];
           expect(contentType).to.contain('application/json');
@@ -81,7 +81,7 @@ describe('Acceptance | Controller | answer-controller', function() {
         });
       });
 
-      it('should add a new answer into the database', function(done) {
+      it('should add a new answer into the database', (done) => {
         server.inject(options, () => {
           Answer.count().then(function(afterAnswersNumber) {
             expect(afterAnswersNumber).to.equal(1);
@@ -90,7 +90,7 @@ describe('Acceptance | Controller | answer-controller', function() {
         });
       });
 
-      it('should return persisted answer', function(done) {
+      it('should return persisted answer', (done) => {
         // when
         server.inject(options, (response) => {
           const answer = response.result.data;
@@ -119,7 +119,7 @@ describe('Acceptance | Controller | answer-controller', function() {
         });
       });
 
-      it('should persist long text for column "answers.value"', function(done) {
+      it('should persist long text for column "answers.value"', (done) => {
         // given
         options.payload.data.attributes.value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?';
 
@@ -134,7 +134,7 @@ describe('Acceptance | Controller | answer-controller', function() {
         });
       });
 
-      it('should return persisted answer with elapsedTime', function(done) {
+      it('should return persisted answer with elapsedTime', (done) => {
         // when
         server.inject(options, () => {
           // then
@@ -192,7 +192,7 @@ describe('Acceptance | Controller | answer-controller', function() {
           });
       });
 
-      it('should return a 409 HTTP status code', function(done) {
+      it('should return a 409 HTTP status code', (done) => {
         server.inject(options, (response) => {
           expect(response.statusCode).to.equal(409);
           done();

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -4,7 +4,7 @@ const Answer = require('../../../lib/domain/models/data/answer');
 
 describe('Acceptance | Controller | answer-controller', function() {
 
-  after(function(done) {
+  after((done) => {
     server.stop(done);
   });
 
@@ -30,8 +30,8 @@ describe('Acceptance | Controller | answer-controller', function() {
       'result-details': null
     };
 
-    beforeEach((done) => {
-      knex('answers').delete()
+    beforeEach(() => {
+      return knex('answers').delete()
         .then(() => knex('answers').insert([insertedAnswer]))
         .then((id) => {
           insertedAnswerId = id;
@@ -60,16 +60,14 @@ describe('Acceptance | Controller | answer-controller', function() {
               }
             }
           };
-          done();
         });
     });
-    afterEach((done) => {
-      knex('answers').delete().then(() => {
-        done();
-      });
+
+    afterEach(() => {
+      return knex('answers').delete();
     });
 
-    before(function(done) {
+    before(() => {
       nock('https://api.airtable.com')
         .get(`/v0/test-base/Epreuves/${insertedAnswer.challengeId}?`)
         .times(5)
@@ -81,17 +79,16 @@ describe('Acceptance | Controller | answer-controller', function() {
             //other fields not represented
           }
         });
-      done();
     });
 
-    it('should return 200 HTTP status code', function(done) {
+    it('should return 200 HTTP status code', (done) => {
       server.inject(options, (response) => {
         expect(response.statusCode).to.equal(200);
         done();
       });
     });
 
-    it('should return application/json', function(done) {
+    it('should return application/json', (done) => {
       server.inject(options, (response) => {
         const contentType = response.headers['content-type'];
         expect(contentType).to.contain('application/json');
@@ -99,7 +96,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should not create a new answer into the database', function(done) {
+    it('should not create a new answer into the database', (done) => {
       server.inject(options, () => {
         Answer.count().then((afterAnswersNumber) => {
           expect(afterAnswersNumber).to.equal(1);
@@ -108,7 +105,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should update the answer in the database', function(done) {
+    it('should update the answer in the database', (done) => {
       // when
       server.inject(options, () => {
         new Answer()
@@ -129,7 +126,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       });
     });
 
-    it('should return the updated answer', function(done) {
+    it('should return the updated answer', (done) => {
       // when
       server.inject(options, (response) => {
         const answer = response.result.data;

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Controller | answer-controller', function() {
       'result-details': null
     };
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       knex('answers').delete()
         .then(() => knex('answers').insert([insertedAnswer]))
         .then((id) => {
@@ -63,7 +63,7 @@ describe('Acceptance | Controller | answer-controller', function() {
           done();
         });
     });
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('answers').delete().then(() => {
         done();
       });

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -1,6 +1,8 @@
 const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 
+// guilty
 describe('Acceptance | API | Assessments', () => {
 
   before(function(done) {
@@ -91,6 +93,7 @@ describe('Acceptance | API | Assessments', () => {
       .reply(200, {
         'id': 'w_first_challenge',
         'fields': {
+          'competences': ['competence_id'],
           'Statut': 'validé',
           'acquis': ['@web2']
         }
@@ -101,6 +104,7 @@ describe('Acceptance | API | Assessments', () => {
       .reply(200, {
         'id': 'w_second_challenge',
         'fields': {
+          'competences': ['competence_id'],
           'Statut': 'validé',
           'acquis': ['@web3']
         }
@@ -111,6 +115,7 @@ describe('Acceptance | API | Assessments', () => {
       .reply(200, {
         'id': 'w_third_challenge',
         'fields': {
+          'competences': ['competence_id'],
           'Statut': 'validé',
           'acquis': ['@web1']
         }
@@ -136,6 +141,7 @@ describe('Acceptance | API | Assessments', () => {
 
   after(function(done) {
     nock.cleanAll();
+    cache.flushAll();
     server.stop(done);
   });
 

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -2,10 +2,9 @@ const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock }
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 
-// guilty
-describe('Acceptance | API | Assessments', () => {
+describe('Acceptance | API | assessment-controller-get-adaptive-correct', () => {
 
-  before(function(done) {
+  before((done) => {
 
     nock.cleanAll();
 
@@ -20,11 +19,23 @@ describe('Acceptance | API | Assessments', () => {
           'Competence': ['competence_id']
         }
       });
-
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': 'challenge-view',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
+      });
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves')
-      .query(true)
-      .times(3)
+      .query({ view: 'challenge-view' })
       .reply(200, {
         'records': [
           {
@@ -53,40 +64,6 @@ describe('Acceptance | API | Assessments', () => {
           }
         ]
       });
-
-    // TMP
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves?view=toto')
-      .query(true)
-      .reply(200, {
-        'records': [
-          {
-            'id': 'w_first_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web2']
-            }
-          },
-          {
-            'id': 'w_second_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web3']
-            },
-          },
-          {
-            'id': 'w_third_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web1']
-            },
-          }
-        ]
-      });
-
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves/w_first_challenge')
       .query(true)
@@ -121,25 +98,10 @@ describe('Acceptance | API | Assessments', () => {
         }
       });
 
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Competences/competence_id')
-      .query(true)
-      .reply(200, {
-        'id': 'competence_id',
-        'fields': {
-          'Référence': 'toto',
-          'Titre': 'Mener une recherche et une veille d\'information',
-          'Sous-domaine': '1.1',
-          'Domaine': '1. Information et données',
-          'Statut': 'validé',
-          'Acquis': ['@web1']
-        }
-      });
-
     done();
   });
 
-  after(function(done) {
+  after((done) => {
     nock.cleanAll();
     cache.flushAll();
     server.stop(done);

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -6,6 +6,7 @@ describe('Acceptance | API | Assessments', () => {
   before(function(done) {
 
     nock.cleanAll();
+
     nock('https://api.airtable.com')
       .get('/v0/test-base/Tests/w_adaptive_course_id')
       .query(true)
@@ -22,6 +23,39 @@ describe('Acceptance | API | Assessments', () => {
       .get('/v0/test-base/Epreuves')
       .query(true)
       .times(3)
+      .reply(200, {
+        'records': [
+          {
+            'id': 'w_first_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web2']
+            }
+          },
+          {
+            'id': 'w_second_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web3']
+            },
+          },
+          {
+            'id': 'w_third_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web1']
+            },
+          }
+        ]
+      });
+
+    // TMP
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves?view=toto')
+      .query(true)
       .reply(200, {
         'records': [
           {
@@ -79,6 +113,21 @@ describe('Acceptance | API | Assessments', () => {
         'fields': {
           'Statut': 'validé',
           'acquis': ['@web1']
+        }
+      });
+
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': 'toto',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
         }
       });
 
@@ -223,4 +272,6 @@ describe('Acceptance | API | Assessments', () => {
       });
     });
   });
-});
+
+})
+;

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -72,6 +72,55 @@ describe('Acceptance | API | Assessments', function() {
         }
       }]);
 
+    // TMP
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves?view=toto')
+      .query(true)
+      .reply(200, {
+        'records': [
+          {
+            'id': 'w_first_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web2']
+            }
+          },
+          {
+            'id': 'w_second_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web3']
+            },
+          },
+          {
+            'id': 'w_third_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web1']
+            },
+          }
+        ]
+      });
+
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': '1.1 Mener une recherche et une veille d\'information',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
+      });
+
+
     done();
   });
 

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -25,7 +25,42 @@ describe('Acceptance | API | assessment-controller-get-adaptive', function() {
           ],
         },
       });
-
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': 'challenge-view',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
+      });
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves')
+      .query({ view: 'challenge-view' })
+      .reply(200, [{
+        'id': 'z_second_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web2']
+        }
+      }, {
+        'id': 'z_first_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web1']
+        }
+      }, {
+        'id': 'z_third_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web3']
+        }
+      }]);
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves/z_first_challenge')
       .query(true)
@@ -57,66 +92,6 @@ describe('Acceptance | API | assessment-controller-get-adaptive', function() {
           'acquis': ['web3']
         },
       });
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves')
-      .query(true)
-      .reply(200, [{
-        'id': 'z_second_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web2']
-        }
-      }, {
-        'id': 'z_first_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web1']
-        }
-      }, {
-        'id': 'z_third_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web3']
-        }
-      }]);
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Competences/competence_id')
-      .query(true)
-      .reply(200, {
-        'id': 'competence_id',
-        'fields': {
-          'Référence': '1.1 Mener une recherche et une veille d\'information',
-          'Titre': 'Mener une recherche et une veille d\'information',
-          'Sous-domaine': '1.1',
-          'Domaine': '1. Information et données',
-          'Statut': 'validé',
-          'Acquis': ['@web1']
-        }
-      });
-
-    // TMP
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves?view=challenge-view')
-      .query(true)
-      .reply(200, [{
-        'id': 'z_second_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web2']
-        }
-      }, {
-        'id': 'z_first_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web1']
-        }
-      }, {
-        'id': 'z_third_challenge',
-        'fields': {
-          'competences': ['competence_id'],
-          'acquis': ['web3']
-        }
-      }]);
 
     done();
   });

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -2,9 +2,9 @@ const { describe, it, before, after, expect, knex, nock } = require('../../test-
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 
-describe('Acceptance | API | Assessments GET (non adaptive)', function() {
+describe('Acceptance | API | assessment-controller-get-nonadaptive', function() {
 
-  before(function(done) {
+  before((done) => {
 
     nock.cleanAll();
     nock('https://api.airtable.com')
@@ -23,10 +23,23 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function() {
           ],
         },
       });
-
     nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves?view=challenge-view')
+      .get('/v0/test-base/Competences/competence_id')
       .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': 'challenge-view',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
+      });
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves')
+      .query({ view: 'challenge-view' })
       .reply(200, [{
         'id': 'z_second_challenge',
         'fields': {
@@ -46,34 +59,6 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function() {
           'acquis': ['web3']
         }
       }]);
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves')
-      .query(true)
-      .times(3)
-      .reply(200, [
-        {
-          'id': 'first_challenge',
-          'fields': {
-            'competences': ['competence_id'],
-            'acquis': ['@web5']
-          }
-        },
-        {
-          'id': 'second_challenge',
-          'fields': {
-            'competences': ['competence_id'],
-            'acquis': ['@url1']
-          },
-        },
-        {
-          'id': 'third_challenge',
-          'fields': {
-            'competences': ['competence_id'],
-            'acquis': ['@web4']
-          },
-        }
-      ]);
-
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves/first_challenge')
       .query(true)
@@ -103,27 +88,12 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function() {
         },
       });
 
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Competences/competence_id')
-      .query(true)
-      .reply(200, {
-        'id': 'competence_id',
-        'fields': {
-          'Référence': 'challenge-view',
-          'Titre': 'Mener une recherche et une veille d\'information',
-          'Sous-domaine': '1.1',
-          'Domaine': '1. Information et données',
-          'Statut': 'validé',
-          'Acquis': ['@web1']
-        }
-      });
-
     done();
   });
 
-  after(function(done) {
-    cache.flushAll();
+  after((done) => {
     nock.cleanAll();
+    cache.flushAll();
     server.stop(done);
   });
 

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -25,6 +25,28 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function() {
       });
 
     nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves?view=challenge-view')
+      .query(true)
+      .reply(200, [{
+        'id': 'z_second_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web2']
+        }
+      }, {
+        'id': 'z_first_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web1']
+        }
+      }, {
+        'id': 'z_third_challenge',
+        'fields': {
+          'competences': ['competence_id'],
+          'acquis': ['web3']
+        }
+      }]);
+    nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves')
       .query(true)
       .times(3)
@@ -79,6 +101,21 @@ describe('Acceptance | API | Assessments GET (non adaptive)', function() {
           'competences': ['competence_id'],
           // a bunch of fields
         },
+      });
+
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': 'challenge-view',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
       });
 
     done();

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -2,7 +2,7 @@ const { describe, it, after, before, beforeEach, afterEach, expect, knex, nock }
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 
-describe.only('Acceptance | API | assessment-controller-get-solutions', () => {
+describe('Acceptance | API | assessment-controller-get-solutions', () => {
 
   before(() => {
     return knex.migrate.latest()
@@ -17,6 +17,7 @@ describe.only('Acceptance | API | assessment-controller-get-solutions', () => {
               'fields': {
                 // a bunch of fields
                 'Adaptatif ?': false,
+                'Competence': ['competence_id'],
                 '\u00c9preuves': [
                   'q_second_challenge',
                   'q_first_challenge',
@@ -49,7 +50,7 @@ describe.only('Acceptance | API | assessment-controller-get-solutions', () => {
           .reply(200, {
             'id': 'competence_id',
             'fields': {
-              'Référence': '1.1 Mener une recherche et une veille d\'information',
+              'Référence': 'toto',
               'Titre': 'Mener une recherche et une veille d\'information',
               'Sous-domaine': '1.1',
               'Domaine': '1. Information et données',
@@ -60,7 +61,7 @@ describe.only('Acceptance | API | assessment-controller-get-solutions', () => {
 
         // TMP
         nock('https://api.airtable.com')
-          .get('/v0/test-base/Epreuves?view=toto')
+          .get('/v0/test-base/Epreuves?view=competence_id')
           .query(true)
           .reply(200, {
             'records': [

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -43,14 +43,13 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
               },
             }
           );
-
         nock('https://api.airtable.com')
           .get('/v0/test-base/Competences/competence_id')
           .query(true)
           .reply(200, {
             'id': 'competence_id',
             'fields': {
-              'Référence': 'toto',
+              'Référence': 'challenge-view',
               'Titre': 'Mener une recherche et une veille d\'information',
               'Sous-domaine': '1.1',
               'Domaine': '1. Information et données',
@@ -58,43 +57,9 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
               'Acquis': ['@web1']
             }
           });
-
-        // TMP
-        nock('https://api.airtable.com')
-          .get('/v0/test-base/Epreuves?view=competence_id')
-          .query(true)
-          .reply(200, {
-            'records': [
-              {
-                'id': 'q_first_challenge',
-                'fields': {
-                  'Statut': 'validé',
-                  'competences': ['competence_id'],
-                  'acquis': ['@web2']
-                }
-              },
-              {
-                'id': 'q_second_challenge',
-                'fields': {
-                  'Statut': 'validé',
-                  'competences': ['competence_id'],
-                  'acquis': ['@web3']
-                },
-              },
-              {
-                'id': 'q_third_challenge',
-                'fields': {
-                  'Statut': 'validé',
-                  'competences': ['competence_id'],
-                  'acquis': ['@web1']
-                },
-              }
-            ]
-          });
-
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves')
-          .query(true)
+          .query({ view: 'challenge-view' })
           .times(3)
           .reply(200, {
             'records': [
@@ -168,6 +133,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
   });
 
   after((done) => {
+    nock.cleanAll();
     cache.flushAll();
     server.stop(done);
   });

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -13,35 +13,35 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
           .query(true)
           .times(4)
           .reply(200, {
-              'id': 'non_adaptive_course_id',
-              'fields': {
-                // a bunch of fields
-                'Adaptatif ?': false,
-                'Competence': ['competence_id'],
-                '\u00c9preuves': [
-                  'q_second_challenge',
-                  'q_first_challenge',
-                ],
-              },
-            }
+            'id': 'non_adaptive_course_id',
+            'fields': {
+              // a bunch of fields
+              'Adaptatif ?': false,
+              'Competence': ['competence_id'],
+              '\u00c9preuves': [
+                'q_second_challenge',
+                'q_first_challenge',
+              ],
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Tests/adaptive_course_id')
           .query(true)
           .times(4)
           .reply(200, {
-              'id': 'adaptive_course_id',
-              'fields': {
-                // a bunch of fields
-                'Adaptatif ?': true,
-                'Competence': ['competence_id'],
-                '\u00c9preuves': [
-                  'q_third_challenge',
-                  'q_second_challenge',
-                  'q_first_challenge',
-                ],
-              },
-            }
+            'id': 'adaptive_course_id',
+            'fields': {
+              // a bunch of fields
+              'Adaptatif ?': true,
+              'Competence': ['competence_id'],
+              '\u00c9preuves': [
+                'q_third_challenge',
+                'q_second_challenge',
+                'q_first_challenge',
+              ],
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Competences/competence_id')
@@ -94,40 +94,40 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
           .query(true)
           .times(2)
           .reply(200, {
-              'id': 'q_first_challenge',
-              'fields': {
-                'Statut': 'validé',
-                'competences': ['competence_id'],
-                'acquis': ['@web3'],
-                'Bonnes réponses': 'fromage'
-              },
-            }
+            'id': 'q_first_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web3'],
+              'Bonnes réponses': 'fromage'
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/q_second_challenge')
           .query(true)
           .times(2)
           .reply(200, {
-              'id': 'q_second_challenge',
-              'fields': {
-                'acquis': ['@web2'],
-                'Statut': 'validé',
-                'Bonnes réponses': 'truite'
-              },
-            }
+            'id': 'q_second_challenge',
+            'fields': {
+              'acquis': ['@web2'],
+              'Statut': 'validé',
+              'Bonnes réponses': 'truite'
+            },
+          }
           );
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/q_third_challenge')
           .query(true)
           .times(1)
           .reply(200, {
-              'id': 'q_third_challenge',
-              'fields': {
-                'acquis': ['@web1'],
-                'Statut': 'validé',
-                'Bonnes réponses': 'dromadaire'
-              },
-            }
+            'id': 'q_third_challenge',
+            'fields': {
+              'acquis': ['@web1'],
+              'Statut': 'validé',
+              'Bonnes réponses': 'dromadaire'
+            },
+          }
           );
       });
   });

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -6,9 +6,10 @@ const settings = require('../../../lib/settings');
 
 describe('Acceptance | API | Assessments GET', function() {
 
-  before(function(done) {
+  before((done) => {
 
     nock.cleanAll();
+
     nock('https://api.airtable.com')
       .get('/v0/test-base/Tests/anyFromAirTable')
       .query(true)
@@ -25,6 +26,54 @@ describe('Acceptance | API | Assessments GET', function() {
             'y_first_challenge'
           ],
         },
+      });
+
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Competences/competence_id')
+      .query(true)
+      .reply(200, {
+        'id': 'competence_id',
+        'fields': {
+          'Référence': '1.1 Mener une recherche et une veille d\'information',
+          'Titre': 'Mener une recherche et une veille d\'information',
+          'Sous-domaine': '1.1',
+          'Domaine': '1. Information et données',
+          'Statut': 'validé',
+          'Acquis': ['@web1']
+        }
+      });
+
+    // TMP
+    nock('https://api.airtable.com')
+      .get('/v0/test-base/Epreuves?view=challenge-view')
+      .query(true)
+      .reply(200, {
+        'records': [
+          {
+            'id': 'w_first_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web2']
+            }
+          },
+          {
+            'id': 'w_second_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web3']
+            },
+          },
+          {
+            'id': 'w_third_challenge',
+            'fields': {
+              'Statut': 'validé',
+              'competences': ['competence_id'],
+              'acquis': ['@web1']
+            },
+          }
+        ]
       });
 
     nock('https://api.airtable.com')
@@ -95,7 +144,7 @@ describe('Acceptance | API | Assessments GET', function() {
 
   });
 
-  after(function(done) {
+  after((done) => {
     cache.flushAll();
     server.stop(done);
   });

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -130,7 +130,7 @@ describe('Acceptance | API | assessment-controller-get', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('assessments').delete().then(() => {
         done();
       });
@@ -213,7 +213,7 @@ describe('Acceptance | API | assessment-controller-get', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('assessments').delete().then(() => {
         done();
       });
@@ -236,7 +236,7 @@ describe('Acceptance | API | assessment-controller-get', function() {
       userId: null
     };
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       inserted_answer_ids = [];
 
       knex('assessments').insert([inserted_assessment_with_user_null]).then((rows) => {

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -50,7 +50,7 @@ describe('Acceptance | API | Assessments GET', function() {
       .reply(200, {
         'records': [
           {
-            'id': 'w_first_challenge',
+            'id': 'y_first_challenge',
             'fields': {
               'Statut': 'validé',
               'competences': ['competence_id'],
@@ -58,7 +58,7 @@ describe('Acceptance | API | Assessments GET', function() {
             }
           },
           {
-            'id': 'w_second_challenge',
+            'id': 'y_second_challenge',
             'fields': {
               'Statut': 'validé',
               'competences': ['competence_id'],
@@ -66,7 +66,7 @@ describe('Acceptance | API | Assessments GET', function() {
             },
           },
           {
-            'id': 'w_third_challenge',
+            'id': 'y_third_challenge',
             'fields': {
               'Statut': 'validé',
               'competences': ['competence_id'],
@@ -145,6 +145,7 @@ describe('Acceptance | API | Assessments GET', function() {
   });
 
   after((done) => {
+    nock.cleanAll();
     cache.flushAll();
     server.stop(done);
   });

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -4,7 +4,7 @@ const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 const settings = require('../../../lib/settings');
 
-describe('Acceptance | API | Assessments GET', function() {
+describe('Acceptance | API | assessment-controller-get', function() {
 
   before((done) => {
 
@@ -27,14 +27,13 @@ describe('Acceptance | API | Assessments GET', function() {
           ],
         },
       });
-
     nock('https://api.airtable.com')
       .get('/v0/test-base/Competences/competence_id')
       .query(true)
       .reply(200, {
         'id': 'competence_id',
         'fields': {
-          'Référence': '1.1 Mener une recherche et une veille d\'information',
+          'Référence': 'challenge-view',
           'Titre': 'Mener une recherche et une veille d\'information',
           'Sous-domaine': '1.1',
           'Domaine': '1. Information et données',
@@ -42,43 +41,9 @@ describe('Acceptance | API | Assessments GET', function() {
           'Acquis': ['@web1']
         }
       });
-
-    // TMP
-    nock('https://api.airtable.com')
-      .get('/v0/test-base/Epreuves?view=challenge-view')
-      .query(true)
-      .reply(200, {
-        'records': [
-          {
-            'id': 'y_first_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web2']
-            }
-          },
-          {
-            'id': 'y_second_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web3']
-            },
-          },
-          {
-            'id': 'y_third_challenge',
-            'fields': {
-              'Statut': 'validé',
-              'competences': ['competence_id'],
-              'acquis': ['@web1']
-            },
-          }
-        ]
-      });
-
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves')
-      .query(true)
+      .query({ view: 'challenge-view' })
       .times(3)
       .reply(200, {
         'records': [
@@ -108,7 +73,6 @@ describe('Acceptance | API | Assessments GET', function() {
           }
         ]
       });
-
     nock('https://api.airtable.com')
       .get('/v0/test-base/Epreuves/y_first_challenge')
       .query(true)
@@ -141,7 +105,6 @@ describe('Acceptance | API | Assessments GET', function() {
       });
 
     done();
-
   });
 
   after((done) => {

--- a/api/tests/acceptance/application/challenge-controller-validate_test.js
+++ b/api/tests/acceptance/application/challenge-controller-validate_test.js
@@ -69,7 +69,7 @@ describe('Acceptance | API | ChallengeController', function() {
       challengeId: 'challenge_1234'
     };
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       knex('answers').delete().then(() => {
         knex('answers').insert([
           ko_answer,
@@ -83,7 +83,7 @@ describe('Acceptance | API | ChallengeController', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('answers').delete().then(() => {done();});
     });
 

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -10,11 +10,11 @@ describe('Acceptance | Controller | feedback-controller', function() {
 
   describe('POST /api/feedbacks', function() {
 
-    beforeEach(function(done) {
+    beforeEach((done) => {
       knex('feedbacks').delete().then(() => done());
     });
 
-    afterEach(function(done) {
+    afterEach((done) => {
       knex('feedbacks').delete().then(() => done());
     });
 

--- a/api/tests/acceptance/application/follower-controller_test.js
+++ b/api/tests/acceptance/application/follower-controller_test.js
@@ -4,11 +4,11 @@ const mailService = require('../../../lib/domain/services/mail-service');
 
 describe('Acceptance | Controller | follower-controller', () => {
 
-  beforeEach(function(done) {
+  beforeEach((done) => {
     knex('followers').delete().then(() => done());
   });
 
-  afterEach(function(done) {
+  afterEach((done) => {
     knex('followers').delete().then(() => done());
   });
 

--- a/api/tests/acceptance/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/acceptance/infrastructure/repositories/skill-repository_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Infrastructure | Repositories | skill-repository', () => 
       ];
 
       // when
-      const promise = skillRepository.db.save(formattedSkills);
+      const promise = skillRepository.save(formattedSkills);
 
       // then
       return promise.then((createdSkills) => {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -8,6 +8,7 @@ chai.use(require('chai-as-promised'));
 
 // Sinon
 const sinon = require('sinon');
+chai.use(require('sinon-chai'));
 
 // Knex
 const knexConfig = require('../db/knexfile');

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -56,7 +56,7 @@ describe('Unit | Controller | answer-controller', function() {
     timeout: null
   });
 
-  afterEach(function(done) {
+  afterEach((done) => {
     knex('answers').delete().then(() => done());
   });
 

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -9,7 +9,7 @@ const assessmentRepository = require('../../../../lib/infrastructure/repositorie
 const Assessment = require('../../../../lib/domain/models/data/assessment');
 const Skill = require('../../../../lib/cat/skill');
 
-describe('Unit | Controller | assessment-controller', () => {
+describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
   describe('#getNextChallenge', () => {
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -126,25 +126,23 @@ describe('Unit | Domain | Services | assessment-service', function() {
       _buildChallenge('challenge_web_2', ['@web2'])
     ];
 
+    const sandbox = sinon.sandbox.create();
+
     beforeEach(() => {
-      sinon.stub(assessmentRepository, 'get').resolves(assessment);
-      sinon.stub(courseRepository, 'get').resolves({
+
+      sandbox.stub(assessmentRepository, 'get').resolves(assessment);
+      sandbox.stub(courseRepository, 'get').resolves({
         challenges: ['challenge_web_2', 'challenge_web_1'],
         competences: ['competence_id']
       });
-      sinon.stub(challengeRepository, 'findByCompetence').resolves(challenges);
-      sinon.stub(skillRepository, 'findByCompetence').resolves(new Set());
-      sinon.stub(assessmentAdapter, 'getAdaptedAssessment');
-      sinon.stub(answerRepository, 'findByAssessment').resolves([correctAnswerWeb2, partialAnswerWeb1]);
+      sandbox.stub(challengeRepository, 'findByCompetence').resolves(challenges);
+      sandbox.stub(skillRepository, 'findByCompetence').resolves(new Set());
+      sandbox.stub(assessmentAdapter, 'getAdaptedAssessment');
+      sandbox.stub(answerRepository, 'findByAssessment').resolves([correctAnswerWeb2, partialAnswerWeb1]);
     });
 
     afterEach(() => {
-      assessmentRepository.get.restore();
-      courseRepository.get.restore();
-      challengeRepository.findByCompetence.restore();
-      skillRepository.findByCompetence.restore();
-      assessmentAdapter.getAdaptedAssessment.restore();
-      answerRepository.findByAssessment.restore();
+      sandbox.restore();
     });
 
     it('should retrieve assessment from repository', () => {

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -42,14 +42,6 @@ function _buildAnswer(challengeId, result, assessmentId = 1) {
 
 describe('Unit | Domain | Services | assessment-service', function() {
 
-  it('should exist', function() {
-    expect(service).to.exist;
-  });
-
-  it('#getAssessmentNextChallengeId should exist', function() {
-    expect(service.getAssessmentNextChallengeId).to.exist;
-  });
-
   describe('#getAssessmentNextChallengeId', function() {
 
     it('Should return the first challenge if no currentChallengeId is given', function(done) {
@@ -112,10 +104,6 @@ describe('Unit | Domain | Services | assessment-service', function() {
   });
 
   describe('#getScoredAssessment', () => {
-
-    it('checks sanity', () => {
-      expect(service.getScoredAssessment).to.exist;
-    });
 
     let getAssessmentStub;
     let getCourseStub;

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -8,6 +8,7 @@ const courseRepository = require('../../../../lib/infrastructure/repositories/co
 const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const answerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
+const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
 
 const Assessment = require('../../../../lib/domain/models/data/assessment');
 const Challenge = require('../../../../lib/domain/models/Challenge');
@@ -41,6 +42,14 @@ function _buildAnswer(challengeId, result, assessmentId = 1) {
 }
 
 describe('Unit | Domain | Services | assessment-service', function() {
+
+  beforeEach(() => {
+    sinon.stub(competenceRepository, 'get');
+  });
+
+  afterEach(() => {
+    competenceRepository.get.restore();
+  });
 
   describe('#getAssessmentNextChallengeId', function() {
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -141,7 +141,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
         challenges: ['challenge_web_2', 'challenge_web_1'],
         competences: ['competence_id']
       });
-      getChallengesStub = sinon.stub(challengeRepository, 'getFromCompetenceId').returns(challenges);
+      getChallengesStub = sinon.stub(challengeRepository, 'findByCompetence').returns(challenges);
       getSkillStub = sinon.stub(skillRepository.cache, 'getFromCompetenceId').returns(new Set());
       sinon.stub(assessmentAdapter, 'getAdaptedAssessment');
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -105,12 +105,6 @@ describe('Unit | Domain | Services | assessment-service', function() {
 
   describe('#getScoredAssessment', () => {
 
-    let getAssessmentStub;
-    let getCourseStub;
-    let getChallengesStub;
-    let findByAssessmentStub;
-    let getSkillStub;
-
     const COURSE_ID = 123;
     const ASSESSMENT_ID = 836;
     const assessment = _buildAssessmentForCourse(COURSE_ID, ASSESSMENT_ID);
@@ -124,47 +118,81 @@ describe('Unit | Domain | Services | assessment-service', function() {
     ];
 
     beforeEach(() => {
-      getAssessmentStub = sinon.stub(assessmentRepository, 'get').returns(Promise.resolve(assessment));
-      getCourseStub = sinon.stub(courseRepository, 'get').returns({
+      sinon.stub(assessmentRepository, 'get').resolves(assessment);
+      sinon.stub(courseRepository, 'get').resolves({
         challenges: ['challenge_web_2', 'challenge_web_1'],
         competences: ['competence_id']
       });
-      getChallengesStub = sinon.stub(challengeRepository, 'findByCompetence').returns(challenges);
-      getSkillStub = sinon.stub(skillRepository.cache, 'getFromCompetenceId').returns(new Set());
+      sinon.stub(challengeRepository, 'findByCompetence').resolves(challenges);
+      sinon.stub(skillRepository, 'findByCompetence').resolves(new Set());
       sinon.stub(assessmentAdapter, 'getAdaptedAssessment');
-
-      findByAssessmentStub = sinon.stub(answerRepository, 'findByAssessment')
-        .returns(Promise.resolve([correctAnswerWeb2, partialAnswerWeb1]));
+      sinon.stub(answerRepository, 'findByAssessment').resolves([correctAnswerWeb2, partialAnswerWeb1]);
     });
 
     afterEach(() => {
-      getAssessmentStub.restore();
-      getCourseStub.restore();
-      getChallengesStub.restore();
-      getSkillStub.restore();
-      findByAssessmentStub.restore();
+      assessmentRepository.get.restore();
+      courseRepository.get.restore();
+      challengeRepository.findByCompetence.restore();
+      skillRepository.findByCompetence.restore();
       assessmentAdapter.getAdaptedAssessment.restore();
+      answerRepository.findByAssessment.restore();
     });
 
     it('should retrieve assessment from repository', () => {
-      // When
+      // when
       const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-      // Then
+      // then
       return promise.then(() => {
-        sinon.assert.calledWithExactly(getAssessmentStub, ASSESSMENT_ID);
+        expect(assessmentRepository.get).to.have.been.calledWith(ASSESSMENT_ID);
+      });
+    });
+
+    it('should return a rejected promise when the assessment does not exist', () => {
+      // given
+      assessmentRepository.get.resolves(null);
+
+      // when
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.fail('Should not succeed');
+      }, (error) => {
+        expect(error.message).to.equal(`Unable to find assessment with ID ${ASSESSMENT_ID}`);
+      });
+    });
+
+    it('should rejects when assessment is in preview mode', function() {
+      // given
+      const assessment = {
+        get() {
+          return 'nullCourseId';
+        }
+      };
+      assessmentRepository.get.resolves(assessment);
+
+      // when
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.fail('Should not succeed');
+      }, (error) => {
+        expect(error).to.be.instanceOf(NotElligibleToScoringError);
+        expect(error.message).to.equal(`Assessment with ID ${ASSESSMENT_ID} is a preview Challenge`);
       });
     });
 
     it('should return a rejected promise when something fails in the repository', () => {
-      // Given
+      // given
       const errorOnRepository = new Error();
-      getAssessmentStub.returns(Promise.reject(errorOnRepository));
+      assessmentRepository.get.rejects(errorOnRepository);
 
-      // When
+      // when
       const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-      // Then
+      // then
       return promise.then(() => {
         sinon.assert.fail('Should not succeed');
       }, (error) => {
@@ -173,107 +201,65 @@ describe('Unit | Domain | Services | assessment-service', function() {
 
     });
 
-    it('should return a rejected promise when the assessment does not exist', () => {
-      // Given
-      getAssessmentStub.returns(Promise.resolve(null));
-
-      // When
-      const promise = service.getScoredAssessment(ASSESSMENT_ID);
-
-      // Then
-      return promise.then(() => {
-        sinon.assert.fail('Should not succeed');
-      }, (error) => {
-        expect(error.message).to.equal(`Unable to find assessment with ID ${ASSESSMENT_ID}`);
-      });
-    });
-
-    it('should detect Assessment created for preview Challenge and do not evaluate score', () => {
-      // Given
-      const assessmentFromPreview = new Assessment({
-        id: '1',
-        courseId: 'nullfec89bd5-a706-419b-a6d2-f8805e708ace'
-      });
-      getAssessmentStub.returns(Promise.resolve(assessmentFromPreview));
-
-      // When
-      const promise = service.getScoredAssessment(ASSESSMENT_ID);
-
-      // Then
-      return promise
-        .then(() => {
-          sinon.assert.fail('Should not succeed');
-        })
-        .catch((err) => {
-          sinon.assert.notCalled(findByAssessmentStub);
-          expect(err).to.be.an.instanceof(NotElligibleToScoringError);
-          expect(err.message).to.equal(`Assessment with ID ${ASSESSMENT_ID} is a preview Challenge`);
-        });
-    });
-
-    describe('when we retrieved the assessment', () => {
+    context('when we retrieved the assessment', () => {
 
       beforeEach(() => {
-        getAssessmentStub.returns(Promise.resolve(assessment));
+        assessmentRepository.get.resolves(assessment);
       });
 
       it('should return a rejected promise when the repository is on error', () => {
-        // Given
-        getCourseStub.returns(Promise.reject(new Error('Error from courseRepository')));
+        // given
+        courseRepository.get.rejects(new Error('Error from courseRepository'));
 
-        // When
+        // when
         const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-        // Then
-        return promise.then(() => {
-          sinon.assert.fail('Should not succeed');
-        })
+        // then
+        return promise
+          .then(() => sinon.assert.fail('Should not succeed'))
           .catch((error) => {
-            sinon.assert.calledWithExactly(getCourseStub, COURSE_ID);
+            expect(courseRepository.get).to.have.been.calledWithExactly(COURSE_ID);
             expect(error.message).to.equal('Error from courseRepository');
           });
       });
 
       it('should load answers for the assessment', () => {
-        // When
+        // when
         const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-        // Then
-        return promise
-          .then(() => {
-            sinon.assert.calledOnce(findByAssessmentStub);
-            sinon.assert.calledWithExactly(findByAssessmentStub, ASSESSMENT_ID);
-          });
+        // then
+        return promise.then(() => {
+          expect(answerRepository.findByAssessment).to.have.been.calledWithExactly(ASSESSMENT_ID);
+        });
       });
 
-      describe('when we retrieved every challenge', () => {
+      context('when we retrieved every challenge', () => {
 
         let firstFakeChallenge;
         let secondFakeChallenge;
 
         beforeEach(() => {
           const course = { challenges: ['challenge_web_1', 'challenge_web_2'], competences: ['competence_id'] };
-          getCourseStub.returns(Promise.resolve(course));
+          courseRepository.get.resolves(course);
 
           firstFakeChallenge = _buildChallenge(['@web1']);
           secondFakeChallenge = _buildChallenge(['@web2']);
 
-          getChallengesStub.resolves([firstFakeChallenge, secondFakeChallenge]);
+          challengeRepository.findByCompetence.resolves([firstFakeChallenge, secondFakeChallenge]);
         });
 
         it('should resolve the promise with a scored assessment', () => {
-          // When
+          // when
           const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-          // Then
+          // then
           return promise
             .then(({ assessmentPix, skills }) => {
               expect(assessmentPix.get('id')).to.equal(ASSESSMENT_ID);
               expect(assessmentPix.get('courseId')).to.deep.equal(COURSE_ID);
               expect(assessmentPix.get('estimatedLevel')).to.equal(0);
               expect(assessmentPix.get('pixScore')).to.equal(0);
-              expect(assessmentPix.get('successRate')).to.equal(50);
-              expect(skills).to.be.undefined;
+              expect(assessmentPix.get('successRate')).to.equal(50);expect(skills).to.be.undefined;
             });
         });
 
@@ -284,7 +270,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
             competences: ['competence_id'],
             isAdaptive: true
           };
-          getCourseStub.returns(Promise.resolve(course));
+          courseRepository.get.resolves(course);
           const expectedValitedSkills = _generateValidatedSkills();
           const expectedFailedSkills = _generateFailedSkills();
 
@@ -295,20 +281,19 @@ describe('Unit | Domain | Services | assessment-service', function() {
             displayedPixScore: 13
           });
 
-          // When
+          // when
           const promise = service.getScoredAssessment(ASSESSMENT_ID);
 
-          // Then
-          return promise
-            .then(({ assessmentPix, skills }) => {
-              expect(assessmentPix.get('id')).to.equal(ASSESSMENT_ID);
-              expect(assessmentPix.get('courseId')).to.deep.equal(COURSE_ID);
-              expect(assessmentPix.get('estimatedLevel')).to.equal(50);
-              expect(assessmentPix.get('pixScore')).to.equal(13);
-              expect(skills.assessmentId).to.equal(ASSESSMENT_ID);
-              expect([...skills.validatedSkills]).to.deep.equal([...expectedValitedSkills]);
-              expect([...skills.failedSkills]).to.deep.equal([...expectedFailedSkills]);
-            });
+          // then
+          return promise.then(({ assessmentPix, skills }) => {
+            expect(assessmentPix.get('id')).to.equal(ASSESSMENT_ID);
+            expect(assessmentPix.get('courseId')).to.deep.equal(COURSE_ID);
+            expect(assessmentPix.get('estimatedLevel')).to.equal(50);
+            expect(assessmentPix.get('pixScore')).to.equal(13);
+            expect(skills.assessmentId).to.equal(ASSESSMENT_ID);
+            expect([...skills.validatedSkills]).to.deep.equal([...expectedValitedSkills]);
+            expect([...skills.failedSkills]).to.deep.equal([...expectedFailedSkills]);
+          });
         });
 
       });

--- a/api/tests/unit/domain/services/skills-service_test.js
+++ b/api/tests/unit/domain/services/skills-service_test.js
@@ -1,18 +1,18 @@
 const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
 const Skill = require('../../../../lib/cat/skill');
 const skillsService = require('../../../../lib/domain/services/skills-service');
-const skillsRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
+const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
 
 describe('Unit | Service | Skills Service', () => {
 
   describe('#saveAssessmentSkills', () => {
 
     beforeEach(() => {
-      sinon.stub(skillsRepository.db, 'save').resolves();
+      sinon.stub(skillRepository, 'save').resolves();
     });
 
     afterEach(() => {
-      skillsRepository.save.restore();
+      skillRepository.save.restore();
     });
 
     it('should call Skills Repository#save with formatted skills', () => {
@@ -35,8 +35,8 @@ describe('Unit | Service | Skills Service', () => {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(skillsRepository.save);
-        sinon.assert.calledWith(skillsRepository.save, skillsFormatted);
+        sinon.assert.calledOnce(skillRepository.save);
+        sinon.assert.calledWith(skillRepository.save, skillsFormatted);
       });
     });
 

--- a/api/tests/unit/domain/services/skills-service_test.js
+++ b/api/tests/unit/domain/services/skills-service_test.js
@@ -12,7 +12,7 @@ describe('Unit | Service | Skills Service', () => {
     });
 
     afterEach(() => {
-      skillsRepository.db.save.restore();
+      skillsRepository.save.restore();
     });
 
     it('should call Skills Repository#save with formatted skills', () => {
@@ -35,8 +35,8 @@ describe('Unit | Service | Skills Service', () => {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(skillsRepository.db.save);
-        sinon.assert.calledWith(skillsRepository.db.save, skillsFormatted);
+        sinon.assert.calledOnce(skillsRepository.save);
+        sinon.assert.calledWith(skillsRepository.save, skillsFormatted);
       });
     });
 

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -116,13 +116,13 @@ describe('Unit | Repository | challenge-repository', function() {
   });
 
   /*
-   * #getFromCompetenceId
+   * #findByCompetence
    */
 
-  describe('#getFromCompetenceId', function() {
+  describe('#findByCompetence', function() {
 
     const competenceId = 'competence_id';
-    const cacheKey = `challenge-repository_get_from_competence_${competenceId}`;
+    const cacheKey = `challenge-repository_find_by_competence_${competenceId}`;
     const challenges = [
       _buildChallengeWithCompetence('challenge_id_1', 'Instruction #1', 'Proposals #1', 'competence_id', 'validé'),
       _buildChallengeWithCompetence('challenge_id_2', 'Instruction #2', 'Proposals #2', 'other_competence_id', 'validé'),
@@ -137,7 +137,7 @@ describe('Unit | Repository | challenge-repository', function() {
       });
 
       // when
-      const result = challengeRepository.getFromCompetenceId(competenceId);
+      const result = challengeRepository.findByCompetence(competenceId);
 
       // then
       cache.get.restore();
@@ -152,7 +152,7 @@ describe('Unit | Repository | challenge-repository', function() {
       cache.set(cacheKey, expectedChallenges);
 
       // when
-      const result = challengeRepository.getFromCompetenceId(competenceId);
+      const result = challengeRepository.findByCompetence(competenceId);
 
       // then
       expect(getRecords.notCalled).to.be.true;
@@ -168,7 +168,7 @@ describe('Unit | Repository | challenge-repository', function() {
 
       it('should resolve with the challenges fetched from Airtable and filtered for this competence', function(done) {
         // when
-        const result = challengeRepository.getFromCompetenceId(competenceId);
+        const result = challengeRepository.findByCompetence(competenceId);
 
         // then
         const expectedChallenges = [challenges[0], challenges[2]];
@@ -178,7 +178,7 @@ describe('Unit | Repository | challenge-repository', function() {
 
       it('should cache the challenges fetched from Airtable', function(done) {
         // when
-        challengeRepository.getFromCompetenceId(competenceId).then(() => {
+        challengeRepository.findByCompetence(competenceId).then(() => {
 
           // then
           cache.get(cacheKey, (err, cachedValue) => {
@@ -193,7 +193,7 @@ describe('Unit | Repository | challenge-repository', function() {
         const expectedQuery = {};
 
         // when
-        challengeRepository.getFromCompetenceId(competenceId).then(() => {
+        challengeRepository.findByCompetence(competenceId).then(() => {
 
           // then
           expect(getRecords.calledWith('Epreuves', expectedQuery, challengeSerializer)).to.be.true;

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -119,87 +119,74 @@ describe('Unit | Repository | challenge-repository', function() {
    * #findByCompetence
    */
 
-  describe('#findByCompetence', function() {
+  describe('#findByCompetence', () => {
 
-    const competenceId = 'competence_id';
-    const cacheKey = `challenge-repository_find_by_competence_${competenceId}`;
+    const competence = { id: 'recsvLz0W2ShyfD63', reference: '1.1 Mener une recherche et une veille d\'information' };
+    const cacheKey = `challenge-repository_find_by_competence_${competence.id}`;
     const challenges = [
-      _buildChallengeWithCompetence('challenge_id_1', 'Instruction #1', 'Proposals #1', 'competence_id', 'validé'),
-      _buildChallengeWithCompetence('challenge_id_2', 'Instruction #2', 'Proposals #2', 'other_competence_id', 'validé'),
-      _buildChallengeWithCompetence('challenge_id_3', 'Instruction #3', 'Proposals #3', 'competence_id', 'validé')
+      _buildChallengeWithCompetence('challenge_id_1', 'Instruction #1', 'Proposals #1', competence.id, 'validé'),
+      _buildChallengeWithCompetence('challenge_id_2', 'Instruction #2', 'Proposals #2', competence.id, 'validé sans test'),
+      _buildChallengeWithCompetence('challenge_id_3', 'Instruction #3', 'Proposals #3', competence.id, 'pre-validé')
     ];
 
-    it('should reject with an error when the cache throws an error', function(done) {
-      // given
-      const cacheErrorMessage = 'Cache error';
-      sinon.stub(cache, 'get').callsFake((key, callback) => {
-        callback(new Error(cacheErrorMessage));
-      });
+    beforeEach(() => {
+      sinon.stub(cache, 'get');
+      sinon.stub(cache, 'set');
+    });
 
-      // when
-      const result = challengeRepository.findByCompetence(competenceId);
-
-      // then
+    afterEach(() => {
       cache.get.restore();
-      expect(result).to.eventually.be.rejectedWith(cacheErrorMessage);
-      done();
+      cache.set.restore();
     });
 
-    it('should resolve challenges directly retrieved from the cache without calling Airtable when the challenge has been cached', function(done) {
-      // given
-      getRecords.resolves(true);
-      const expectedChallenges = [challenges[0], challenges[2]];
-      cache.set(cacheKey, expectedChallenges);
+    context('when challenges have been cached', () => {
 
-      // when
-      const result = challengeRepository.findByCompetence(competenceId);
+      it('should resolve challenges directly retrieved from the cache without calling Airtable', () => {
+        // given
+        cache.get.returns(challenges);
 
-      // then
-      expect(getRecords.notCalled).to.be.true;
-      expect(result).to.eventually.deep.equal(expectedChallenges);
-      done();
-    });
-
-    describe('when challenges have not been previously cached', function() {
-
-      beforeEach(function() {
-        getRecords.resolves(challenges);
-      });
-
-      it('should resolve with the challenges fetched from Airtable and filtered for this competence', function(done) {
         // when
-        const result = challengeRepository.findByCompetence(competenceId);
+        const promise = challengeRepository.findByCompetence(competence);
 
         // then
-        const expectedChallenges = [challenges[0], challenges[2]];
-        expect(result).to.eventually.deep.equal(expectedChallenges);
-        done();
-      });
-
-      it('should cache the challenges fetched from Airtable', function(done) {
-        // when
-        challengeRepository.findByCompetence(competenceId).then(() => {
-
-          // then
-          cache.get(cacheKey, (err, cachedValue) => {
-            expect(cachedValue).to.exist;
-            done();
-          });
+        return promise.then(fetchedChallenges => {
+          expect(fetchedChallenges).to.deep.equal(challenges);
+          expect(getRecords).to.not.have.been.called;
+          expect(cache.set).to.not.have.been.called;
         });
       });
 
-      it('should query correctly Airtable', function(done) {
-        // given
-        const expectedQuery = {};
+    });
 
+    context('when challenges have not been previously cached', function() {
+
+      beforeEach(() => {
+        getRecords.resolves(challenges);
+        cache.get.returns();
+        cache.set.returns();
+      });
+
+      it('should resolve with the challenges fetched from Airtable and filtered for this competence', () => {
         // when
-        challengeRepository.findByCompetence(competenceId).then(() => {
+        const promise = challengeRepository.findByCompetence(competence);
 
-          // then
-          expect(getRecords.calledWith('Epreuves', expectedQuery, challengeSerializer)).to.be.true;
-          done();
+        // then
+        return promise.then((fetchedChallenges) => {
+          expect(airtable.getRecords).to.have.been.calledWith('Epreuves', { view: competence.reference }, challengeSerializer);
+          expect(fetchedChallenges).to.deep.equal(challenges);
         });
       });
+
+      it('should cache the challenges fetched from Airtable', () => {
+        // when
+        const promise = challengeRepository.findByCompetence(competence);
+
+        // then
+        return promise.then((fetchedChallenges) => {
+          expect(cache.set).to.have.been.calledWith(cacheKey, fetchedChallenges);
+        });
+      });
+
     });
 
   });

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -6,34 +6,35 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 
 describe('Unit | Repository | competence-repository', function() {
 
-  const competenceRecords = [{
-    id: 'recsvLDFHShyfDXXXXX',
-    name: '1.1 Mener une recherche d’information',
-    areaId: 'recvoGdo0z0z0pXWZ',
-    courseId: 'Test de positionnement 1.1'
-  },
-    {
-      id: 'recsvLDFHShyfDXXXXX',
-      name: '1.1 Mener une recherche d’information',
-      areaId: 'recvoGdo0z0z0pXWZ',
-      courseId: 'Test de positionnement 1.2'
-    }];
-
   beforeEach(() => {
     sinon.stub(cache, 'get');
     sinon.stub(cache, 'set');
+    sinon.stub(airtable, 'getRecord');
     sinon.stub(airtable, 'getRecords');
   });
 
   afterEach(() => {
     cache.get.restore();
     cache.set.restore();
+    airtable.getRecord.restore();
     airtable.getRecords.restore();
   });
 
-  describe('#List', () => {
+  describe('#list', () => {
 
-    context('when record has not been cached', () => {
+    const competenceRecords = [{
+      id: 'recsvLDFHShyfDXXXXX',
+      name: '1.1 Mener une recherche d’information',
+      areaId: 'recvoGdo0z0z0pXWZ',
+      courseId: 'Test de positionnement 1.1'
+    }, {
+      id: 'recsvLDFHShyfDXXXXX',
+      name: '1.1 Mener une recherche d’information',
+      areaId: 'recvoGdo0z0z0pXWZ',
+      courseId: 'Test de positionnement 1.2'
+    }];
+
+    context('when records have not been cached', () => {
 
       beforeEach(() => {
         cache.get.returns();
@@ -82,7 +83,7 @@ describe('Unit | Repository | competence-repository', function() {
 
     });
 
-    context('when record have been cached', () => {
+    context('when records have been cached', () => {
 
       it('should retrieve records directly from the cache', () => {
         // given
@@ -101,5 +102,83 @@ describe('Unit | Repository | competence-repository', function() {
     });
 
   });
-})
-;
+
+  describe('#get', () => {
+
+    const competence = {
+      id: 'recsvLz0W2ShyfD63',
+      name: '1.1 Mener une recherche d’information',
+      areaId: 'recvoGdo0z0z0pXWZ',
+      courseId: 'Test de positionnement 1.1'
+    };
+
+    context('when record has not been cached', () => {
+
+      beforeEach(() => {
+        cache.get.returns();
+        cache.set.returns();
+      });
+
+      it('should fetch Competence from Airtable filtered by its Record ID', () => {
+        // given
+        airtable.getRecord.resolves(competence);
+
+        // when
+        const promise = competenceRepository.get(competence.id);
+
+        // then
+        return promise.then((fetchedCompetence) => {
+          expect(airtable.getRecord).to.have.been.calledWith('Competences', competence.id);
+          expect(fetchedCompetence).to.deep.equal(competence);
+        });
+      });
+
+      it('should set in cache the fetched Competence', () => {
+        // given
+        airtable.getRecord.resolves(competence);
+
+        // when
+        const promise = competenceRepository.get(competence.id);
+
+        // then
+        return promise.then((fetchedCompetence) => {
+          expect(cache.set).to.have.been.calledWith(`competence-repository_get_${competence.id}`, fetchedCompetence);
+        });
+      });
+
+      it('should throw an error when Airtable call fails', (done) => {
+        // given
+        airtable.getRecord.rejects(new Error('some error'));
+
+        // when
+        const promise = competenceRepository.get(competence.id);
+
+        // then
+        promise.catch(err => {
+          expect(err).to.exist;
+          done();
+        });
+      });
+
+    });
+
+    context('when record has been cached', () => {
+
+      it('should retrieve records directly from the cache', () => {
+        // given
+        cache.get.returns(competence);
+
+        // when
+        const promise = competenceRepository.get(competence.id);
+
+        // then
+        return promise.then((fetchedCompetence) => {
+          expect(fetchedCompetence).to.deep.equal(competence);
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -3,20 +3,15 @@ const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 
 const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
-const competenceSerializer = require('../../../../lib/infrastructure/serializers/airtable/competence-serializer');
 
 describe('Unit | Repository | competence-repository', function() {
 
-  let getRecordsStub;
-  let cacheStub;
-  const cacheKey = 'competence-repository_list';
-  const competenceRecords = [
-    {
-      id: 'recsvLDFHShyfDXXXXX',
-      name: '1.1 Mener une recherche d’information',
-      areaId: 'recvoGdo0z0z0pXWZ',
-      courseId: 'Test de positionnement 1.1'
-    },
+  const competenceRecords = [{
+    id: 'recsvLDFHShyfDXXXXX',
+    name: '1.1 Mener une recherche d’information',
+    areaId: 'recvoGdo0z0z0pXWZ',
+    courseId: 'Test de positionnement 1.1'
+  },
     {
       id: 'recsvLDFHShyfDXXXXX',
       name: '1.1 Mener une recherche d’information',
@@ -24,124 +19,87 @@ describe('Unit | Repository | competence-repository', function() {
       courseId: 'Test de positionnement 1.2'
     }];
 
-  beforeEach(function() {
-    cache.flushAll();
-    cacheStub = sinon.stub(cache, 'get');
-    getRecordsStub = sinon.stub(airtable, 'getRecords');
+  beforeEach(() => {
+    sinon.stub(cache, 'get');
+    sinon.stub(cache, 'set');
+    sinon.stub(airtable, 'getRecords');
   });
 
-  afterEach(function() {
-    cacheStub.restore();
-    cache.flushAll();
-    getRecordsStub.restore();
+  afterEach(() => {
+    cache.get.restore();
+    cache.set.restore();
+    airtable.getRecords.restore();
   });
 
   describe('#List', () => {
 
-    it('should be a method', function() {
-      // then
-      expect(competenceRepository.list).to.be.a('function');
-    });
-
-    it('should correctly query Airtable', () => {
-      // Given
-      cacheStub.callsArgWith(1, null, null);
-      getRecordsStub.resolves({});
-      // When
-      const competencesPromise = competenceRepository.list();
-      // Then
-      return competencesPromise.then(() => {
-        expect(getRecordsStub.calledWith('Competences', {}, competenceSerializer)).to.be.true;
-      });
-    });
-
-    describe('When record has not been cached', () => {
+    context('when record has not been cached', () => {
 
       beforeEach(() => {
-        sinon.spy(cache, 'set');
-        getRecordsStub.resolves(competenceRecords);
-      });
-
-      afterEach(() => {
-        cache.set.restore();
+        cache.get.returns();
+        cache.set.returns();
       });
 
       it('should fetch Competences from Airtable', () => {
-        // When
-        cacheStub.callsArgWith(1, null, null);
-        const competencesPromise = competenceRepository.list();
-        // Then
-        return competencesPromise.then((competencesFetched) => {
-          expect(competencesFetched).to.be.equal(competenceRecords);
+        // given
+        airtable.getRecords.resolves(competenceRecords);
+
+        // when
+        const promise = competenceRepository.list();
+
+        // then
+        return promise.then((competencesFetched) => {
+          expect(competencesFetched).to.deep.equal(competenceRecords);
         });
       });
 
-      it('should cached previously fetched Competences', () => {
-        // When
-        cacheStub.callsArgWith(1, null, null);
-        const competencesPromise = competenceRepository.list();
-        // Then
-        return competencesPromise.then((competencesFetched) => {
-          expect(cache.set.getCall(0).args[0]).to.be.equal('competence-repository_list');
-          expect(cache.set.getCall(0).args[1]).to.be.equal(competencesFetched);
+      it('should set in cache the fetched Competences', () => {
+        // given
+        airtable.getRecords.resolves(competenceRecords);
+
+        // when
+        const promise = competenceRepository.list();
+
+        // then
+        return promise.then(() => {
+          expect(cache.set).to.have.been.calledWith('competence-repository_list', competenceRecords);
+        });
+      });
+
+      it('should throw an error when Airtable call fails', (done) => {
+        // given
+        airtable.getRecords.rejects(new Error('some error'));
+
+        // when
+        const promise = competenceRepository.list();
+
+        // then
+        promise.catch(err => {
+          expect(err).to.exist;
+          done();
         });
       });
 
     });
 
-    describe('When record have been cached', () => {
+    context('when record have been cached', () => {
 
-      it('should retrieve records directly from cache', () => {
-        // Given
-        cacheStub.callsArgWith(1, null, competenceRecords);
-        getRecordsStub.resolves(true);
-        // When
+      it('should retrieve records directly from the cache', () => {
+        // given
+        cache.get.returns(competenceRecords);
+
+        // when
         const promise = competenceRepository.list();
 
         return promise.then((competencesFetched) => {
-          // Then
-          expect(competencesFetched).to.be.equal(competenceRecords);
-          sinon.assert.calledOnce(cacheStub);
-          sinon.assert.calledWith(cacheStub, cacheKey);
+          // then
+          expect(competencesFetched).to.equal(competenceRecords);
+          expect(cache.get).to.have.been.calledWith('competence-repository_list');
         });
       });
 
     });
 
-    describe('Error occured cases: ', () => {
-
-      it('should throw an error, when something going wrong from cache', () => {
-        // Given
-        cacheStub.callsArgWith(1, new Error('Error on cache recuperation'));
-
-        // When
-        const cachedPromise = competenceRepository.list();
-
-        return cachedPromise.catch((err) => {
-          // Then
-          expect(cachedPromise).to.be.rejectedWith(Error);
-          expect(err.message).to.be.equal('Error on cache recuperation');
-        });
-
-      });
-
-      it('should throw an error, when something going wrong from airtable', () => {
-        // Given
-        cacheStub.callsArgWith(1, null, null);
-
-        getRecordsStub.rejects(new Error('Error on Airtable recuperation'));
-
-        // When
-        const cachedPromise = competenceRepository.list();
-
-        return cachedPromise.catch((err) => {
-          // Then
-          expect(cachedPromise).to.be.rejectedWith(Error);
-          expect(err.message).to.be.equal('Error on Airtable recuperation');
-        });
-      });
-
-    });
   });
 })
 ;

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -6,18 +6,17 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 
 describe('Unit | Repository | competence-repository', function() {
 
+  const sandbox = sinon.sandbox.create();
+
   beforeEach(() => {
-    sinon.stub(cache, 'get');
-    sinon.stub(cache, 'set');
-    sinon.stub(airtable, 'getRecord');
-    sinon.stub(airtable, 'getRecords');
+    sandbox.stub(cache, 'get');
+    sandbox.stub(cache, 'set');
+    sandbox.stub(airtable, 'getRecord');
+    sandbox.stub(airtable, 'getRecords');
   });
 
   afterEach(() => {
-    cache.get.restore();
-    cache.set.restore();
-    airtable.getRecord.restore();
-    airtable.getRecords.restore();
+    sandbox.restore();
   });
 
   describe('#list', () => {

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -1,8 +1,7 @@
 const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
-const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
-const challengeSerializer = require('../../../../lib/infrastructure/serializers/airtable/challenge-serializer');
+const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const Bookshelf = require('../../../../lib/infrastructure/bookshelf');
 
 function _buildChallenge(id, instruction, proposals, competence, status, skills) {
@@ -11,106 +10,80 @@ function _buildChallenge(id, instruction, proposals, competence, status, skills)
 
 describe('Unit | Repository | skill-repository', function() {
 
-  let getRecord;
-  let getRecords;
-
-  beforeEach(function() {
-    cache.flushAll();
-    getRecord = sinon.stub(airtable, 'getRecord');
-    getRecords = sinon.stub(airtable, 'getRecords');
+  beforeEach(() => {
+    sinon.stub(cache, 'get');
+    sinon.stub(cache, 'set');
+    sinon.stub(challengeRepository, 'findByCompetence');
   });
 
-  afterEach(function() {
-    cache.flushAll();
-    getRecord.restore();
-    getRecords.restore();
+  afterEach(() => {
+    cache.get.restore();
+    cache.set.restore();
+    challengeRepository.findByCompetence.restore();
   });
 
   /*
-   * #getFromCompetenceId
+   * #findByCompetence
    */
 
-  describe('#getFromCompetenceId', function() {
+  describe('#findByCompetence', function() {
 
     const competenceId = 'competence_id';
-    const cacheKey = `skill-repository_get_from_competence_${competenceId}`;
-    const challenges = [
-      _buildChallenge('challenge_id_1', 'Instruction #1', 'Proposals #1', 'competence_id', 'validé', ['web2', 'web3']),
-      _buildChallenge('challenge_id_2', 'Instruction #2', 'Proposals #2', 'other_competence_id', 'validé', ['url1']),
-      _buildChallenge('challenge_id_3', 'Instruction #3', 'Proposals #3', 'competence_id', 'validé', ['web1'])
-    ];
 
-    it('should reject with an error when the cache throws an error', function() {
-      // given
-      const cacheErrorMessage = 'Cache error';
-      sinon.stub(cache, 'get').callsFake((key, callback) => {
-        callback(new Error(cacheErrorMessage));
-      });
+    describe('when the skills has been cached', () => {
 
-      // when
-      const result = skillRepository.cache.getFromCompetenceId(competenceId);
-
-      // then
-      cache.get.restore();
-      return expect(result).to.eventually.be.rejectedWith(cacheErrorMessage);
-    });
-
-    it('should resolve skills directly retrieved from the cache without calling Airtable when the challenge has been cached', function() {
-      // given
-      getRecords.resolves(true);
-      const expectedSkills = new Set(['web1', 'web2', 'web3']);
-      cache.set(cacheKey, expectedSkills);
-
-      // when
-      const result = skillRepository.cache.getFromCompetenceId(competenceId);
-
-      // then
-      expect(getRecords.notCalled).to.be.true;
-      return expect(result).to.eventually.deep.equal(expectedSkills);
-    });
-
-    describe('when skills have not been previously cached', function() {
-
-      beforeEach(function() {
-        getRecords.resolves(challenges);
-      });
-
-      it('should resolve skills with the challenges fetched from Airtable', function() {
-        // when
-        const result = skillRepository.cache.getFromCompetenceId(competenceId);
-
-        // then
-        const expectedSkills = new Set(['web1', 'web2', 'web3']);
-        return expect(result).to.eventually.deep.equal(expectedSkills);
-      });
-
-      it('should cache the challenges fetched from Airtable', function(done) {
-        // when
-        const result = skillRepository.cache.getFromCompetenceId(competenceId);
-
-        // then
-        result.then(() => {
-          cache.get(cacheKey, (err, cachedValue) => {
-            expect(cachedValue).to.exist;
-            done();
-          });
-        });
-      });
-
-      it('should query correctly Airtable', function() {
+      it('should resolve skills directly retrieved from the cache without calling Airtable when the challenge has been cached', () => {
         // given
-        const expectedQuery = {};
+        const cachedSkills = new Set(['web1', 'web2', 'web3']);
+        cache.get.returns(cachedSkills);
 
         // when
-        const result = skillRepository.cache.getFromCompetenceId(competenceId);
+        const promise = skillRepository.findByCompetence(competenceId);
 
         // then
-        return result.then(() => {
-          expect(getRecords.calledWith('Epreuves', expectedQuery, challengeSerializer)).to.be.true;
+        return promise.then((skills) => {
+          expect(cache.get).to.have.been.calledWith(`skill-repository_find_by_competence_${competenceId}`);
+          expect(skills).to.deep.equal(cachedSkills);
+        });
+      });
+
+    });
+
+    context('when skills have not been cached', function() {
+
+      const challenges = [
+        _buildChallenge('challenge_id_1', 'Instruction #1', 'Proposals #1', 'competence_id', 'validé', ['web2', 'web3']),
+        _buildChallenge('challenge_id_2', 'Instruction #2', 'Proposals #2', 'competence_id', 'validé', ['url1']),
+        _buildChallenge('challenge_id_3', 'Instruction #3', 'Proposals #3', 'competence_id', 'validé', ['web1'])
+      ];
+
+      beforeEach(() => {
+        cache.get.returns();
+        cache.set.returns();
+        challengeRepository.findByCompetence.resolves(challenges);
+      });
+
+      it('should resolve skills with the challenges fetched from Airtable', () => {
+        // when
+        const promise = skillRepository.findByCompetence(competenceId);
+
+        // then
+        return promise.then((skills) => {
+          const expectedSkills = new Set(['web1', 'web2', 'web3', 'url1']);
+          expect(skills).to.deep.equal(expectedSkills);
+        });
+      });
+
+      it('should cache the skills fetched from Airtable', () => {
+        // when
+        const promise = skillRepository.findByCompetence(competenceId);
+
+        // then
+        return promise.then((skills) => {
+          expect(cache.set).to.have.been.calledWith(`skill-repository_find_by_competence_${competenceId}`, skills);
         });
       });
     });
-
   });
 
   describe('#save', () => {

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -28,7 +28,10 @@ describe('Unit | Repository | skill-repository', function() {
 
   describe('#findByCompetence', function() {
 
-    const competenceId = 'competence_id';
+    const competence = {
+      id: 'competence_id',
+      reference: 'X.Y Titre de la compétence'
+    };
 
     describe('when the skills has been cached', () => {
 
@@ -38,11 +41,11 @@ describe('Unit | Repository | skill-repository', function() {
         cache.get.returns(cachedSkills);
 
         // when
-        const promise = skillRepository.findByCompetence(competenceId);
+        const promise = skillRepository.findByCompetence(competence);
 
         // then
         return promise.then((skills) => {
-          expect(cache.get).to.have.been.calledWith(`skill-repository_find_by_competence_${competenceId}`);
+          expect(cache.get).to.have.been.calledWith(`skill-repository_find_by_competence_${competence.id}`);
           expect(skills).to.deep.equal(cachedSkills);
         });
       });
@@ -65,7 +68,7 @@ describe('Unit | Repository | skill-repository', function() {
 
       it('should resolve skills with the challenges fetched from Airtable', () => {
         // when
-        const promise = skillRepository.findByCompetence(competenceId);
+        const promise = skillRepository.findByCompetence(competence);
 
         // then
         return promise.then((skills) => {
@@ -76,11 +79,11 @@ describe('Unit | Repository | skill-repository', function() {
 
       it('should cache the skills fetched from Airtable', () => {
         // when
-        const promise = skillRepository.findByCompetence(competenceId);
+        const promise = skillRepository.findByCompetence(competence);
 
         // then
         return promise.then((skills) => {
-          expect(cache.set).to.have.been.calledWith(`skill-repository_find_by_competence_${competenceId}`, skills);
+          expect(cache.set).to.have.been.calledWith(`skill-repository_find_by_competence_${competence.id}`, skills);
         });
       });
     });

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -117,7 +117,7 @@ describe('Unit | Repository | skill-repository', function() {
       ];
 
       // when
-      const promise = skillRepository.db.save(skillsFormatted);
+      const promise = skillRepository.save(skillsFormatted);
 
       // then
       return promise.then(() => {

--- a/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
@@ -48,12 +48,13 @@ describe('Unit | Serializer | competence-serializer', function() {
         const competences = serializer.deserialize(airtableCompetencesRecord);
 
         // Then
-        expect(competences.id).to.be.equal(airtableCompetencesRecord.id);
-        expect(competences.name).to.be.equal(airtableCompetencesRecord.fields['Titre']);
-        expect(competences.index).to.be.equal(airtableCompetencesRecord.fields['Sous-domaine']);
-        expect(competences.areaId).to.be.equal(airtableCompetencesRecord.fields['Domaine']);
-        expect(competences.courseId).to.be.equal(airtableCompetencesRecord.fields['Tests Record ID'][0]);
+        expect(competences.id).to.equal(airtableCompetencesRecord.id);
+        expect(competences.name).to.equal(airtableCompetencesRecord.fields['Titre']);
+        expect(competences.index).to.equal(airtableCompetencesRecord.fields['Sous-domaine']);
+        expect(competences.areaId).to.equal(airtableCompetencesRecord.fields['Domaine']);
+        expect(competences.courseId).to.equal(airtableCompetencesRecord.fields['Tests Record ID'][0]);
         expect(competences.Epreuves).to.not.exist;
+        expect(competences.reference).to.equal(airtableCompetencesRecord.fields['Référence']);
       });
 
       it('should get a new competence Model even if there is no course associated', () => {
@@ -61,12 +62,13 @@ describe('Unit | Serializer | competence-serializer', function() {
         const competences = serializer.deserialize(airtableCompetencesRecordWithNoCourseIdAssociated);
 
         // Then
-        expect(competences.id).to.be.equal(airtableCompetencesRecord.id);
-        expect(competences.name).to.be.equal(airtableCompetencesRecord.fields['Titre']);
-        expect(competences.index).to.be.equal(airtableCompetencesRecord.fields['Sous-domaine']);
-        expect(competences.areaId).to.deep.equal(airtableCompetencesRecord.fields['Domaine']);
-        expect(competences.courseId).to.be.equal('');
+        expect(competences.id).to.equal(airtableCompetencesRecordWithNoCourseIdAssociated.id);
+        expect(competences.name).to.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Titre']);
+        expect(competences.index).to.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Sous-domaine']);
+        expect(competences.areaId).to.deep.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Domaine']);
+        expect(competences.courseId).to.equal('');
         expect(competences.Epreuves).to.not.exist;
+        expect(competences.reference).to.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Référence']);
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
@@ -2,11 +2,8 @@ const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/competence-serializer');
 
 describe('Unit | Serializer | competence-serializer', function() {
+
   describe('#Deserialize', () => {
-    it('should be a function', function() {
-      // then
-      expect(serializer.deserialize).to.be.a('function');
-    });
 
     describe('Success deserialization', () => {
       const airtableCompetencesRecord = {
@@ -15,15 +12,11 @@ describe('Unit | Serializer | competence-serializer', function() {
           'Référence': '1.1 Mener une recherche d\'information',
           'Titre': 'Mener une recherche d\'information',
           'Sous-domaine': '1.1',
-          'Domaine': [
-            'recvoGdo0z0z0pXWZ'
-          ],
-          'Epreuves': [
-            'recsvLz0W2ShyfD00',
-            'recsvLz0W2ShyfD01'
-          ],
+          'Domaine': ['recvoGdo0z0z0pXWZ'],
+          'Epreuves': ['recsvLz0W2ShyfD00', 'recsvLz0W2ShyfD01'],
           'Tests': ['Test de positionnement 1.1'],
-          'Tests Record ID': ['recAY0W7x9urA11OLZJJ']
+          'Tests Record ID': ['recAY0W7x9urA11OLZJJ'],
+          'Acquis': ['@url2', '@url5', '@utiliserserv6', '@rechinfo1', '@eval1', '@publi3', '@modèleEco1']
         }
       };
 
@@ -33,13 +26,9 @@ describe('Unit | Serializer | competence-serializer', function() {
           'Référence': '1.1 Mener une recherche d\'information',
           'Titre': 'Mener une recherche d\'information',
           'Sous-domaine': '1.1',
-          'Domaine': [
-            'recvoGdo0z0z0pXWZ'
-          ],
-          'Epreuves': [
-            'recsvLz0W2ShyfD00',
-            'recsvLz0W2ShyfD01'
-          ]
+          'Domaine': ['recvoGdo0z0z0pXWZ'],
+          'Epreuves': ['recsvLz0W2ShyfD00', 'recsvLz0W2ShyfD01'],
+          'Acquis': ['@url2', '@url5', '@utiliserserv6', '@rechinfo1', '@eval1', '@publi3', '@modèleEco1']
         }
       };
 
@@ -55,6 +44,7 @@ describe('Unit | Serializer | competence-serializer', function() {
         expect(competences.courseId).to.equal(airtableCompetencesRecord.fields['Tests Record ID'][0]);
         expect(competences.Epreuves).to.not.exist;
         expect(competences.reference).to.equal(airtableCompetencesRecord.fields['Référence']);
+        expect(competences.skills).to.deep.equal(airtableCompetencesRecord.fields['Acquis']);
       });
 
       it('should get a new competence Model even if there is no course associated', () => {
@@ -69,6 +59,7 @@ describe('Unit | Serializer | competence-serializer', function() {
         expect(competences.courseId).to.equal('');
         expect(competences.Epreuves).to.not.exist;
         expect(competences.reference).to.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Référence']);
+        expect(competences.skills).to.deep.equal(airtableCompetencesRecordWithNoCourseIdAssociated.fields['Acquis']);
       });
     });
 


### PR DESCRIPTION
[Story Trello](https://trello.com/c/CFlim7bo/892-optimiser-la-s%C3%A9lection-des-challenges-pour-une-comp%C3%A9tence-vue-prot%C3%A9g%C3%A9e-airtable)

**Ce qui a été fait (que côté API)**

- Définition de 16 vues privées dans la table "Epreuves" de Airtable (-prod et -aval), détenues par le compte "Pix Officiel", correspondant aux 16 compétences sur lesquelles portent les épreuves ; ces vues contiennent les filtres : 
    - le champs "compétences" contient "référence_de_la_compétence" (cf. table "Competences")
    - le champs "acquis" n'est pas pas null
    - le champs "Statut" est dans la liste : "validé", "validé sans test", 'pré-validé'
- Renommage et changement de signature de la méthode `#getFromCompetenceId(competenceId)` en `#findByCompetence(competence)` dans les classes _ChallengeRepository_ et _Skill Repository_ ; désormais on passe l'objet Compétence car on a besoin de son ID (pour le cache) mais aussi de la référence (Airtable Record ID) pour filtrer les épreuves ou les acquis récupérés depuis Airtable par vue (cf. ci-dessus)
- Prise en compte de ces modifications dans _AssessmentController_
- Ajout de `sinon-chai` côté API pour faire des assertions plus jolies
- Correction de tests d'acceptance "trop adhérés" (via des `cache.flushAll()`)
- Modification du wrapper Airtable (`airtable.js`) dont la version 0.5.0 permet d'utiliser des promesses plutôt que des callbacks.
- Moult rebases longs et douloureux...
- Changement des variables d'environnement utilisées par l'API 892 pour tester.
- Plein de réparations de la base -aval

⚠️ **Penser à changer la clé Airtable en production dès que ce sera livré !!!**

