### PR TITLE
[#600] [FEATURE]Afficher la bannière de certification sur les épreuves (US-887).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -11,7 +11,11 @@ class AssessmentSerializer extends JSONAPISerializer {
     data.attributes['estimated-level'] = model.estimatedLevel;
     data.attributes['pix-score'] = model.pixScore;
     data.attributes['type'] = model.type;
-    data.attributes['course-id'] = model.courseId;
+    if (model.type === 'CERTIFICATION') {
+      data.attributes['certification-number'] = model.courseId;
+    } else {
+      data.attributes['certification-number'] = null;
+    }
   }
 
   serializeRelationships(model, data) {

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -11,6 +11,7 @@ class AssessmentSerializer extends JSONAPISerializer {
     data.attributes['estimated-level'] = model.estimatedLevel;
     data.attributes['pix-score'] = model.pixScore;
     data.attributes['type'] = model.type;
+    data.attributes['course-id'] = model.courseId;
   }
 
   serializeRelationships(model, data) {

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -178,7 +178,8 @@ describe('Acceptance | API | assessment-controller-get', function() {
             'estimated-level': 0,
             'pix-score': 0,
             'success-rate': null,
-            'type' : null
+            'type' : null,
+            'course-id' : 'anyFromAirTable'
           },
           'relationships': {
             'course': { 'data': { 'type': 'courses', 'id': 'anyFromAirTable' } },
@@ -315,7 +316,8 @@ describe('Acceptance | API | assessment-controller-get', function() {
             'estimated-level': 1,
             'pix-score': 8,
             'success-rate': 50,
-            'type' : null
+            'type' : null,
+            'course-id' : 'anyFromAirTable'
           },
           'relationships': {
             'course': { 'data': { 'type': 'courses', 'id': 'anyFromAirTable' } },

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -179,7 +179,7 @@ describe('Acceptance | API | assessment-controller-get', function() {
             'pix-score': 0,
             'success-rate': null,
             'type' : null,
-            'course-id' : 'anyFromAirTable'
+            'certification-number' : null
           },
           'relationships': {
             'course': { 'data': { 'type': 'courses', 'id': 'anyFromAirTable' } },
@@ -317,7 +317,7 @@ describe('Acceptance | API | assessment-controller-get', function() {
             'pix-score': 8,
             'success-rate': 50,
             'type' : null,
-            'course-id' : 'anyFromAirTable'
+            'certification-number' : null
           },
           'relationships': {
             'course': { 'data': { 'type': 'courses', 'id': 'anyFromAirTable' } },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         'pix-score': undefined,
         'success-rate': 24,
         'type' : 'charade',
-        'course-id' : 'course_id'
+        'certification-number' : null
       },
       relationships: {
         course: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -19,7 +19,8 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         'estimated-level': undefined,
         'pix-score': undefined,
         'success-rate': 24,
-        'type' : 'charade'
+        'type' : 'charade',
+        'course-id' : 'course_id'
       },
       relationships: {
         course: {

--- a/live/app/models/assessment.js
+++ b/live/app/models/assessment.js
@@ -14,7 +14,7 @@ export default Model.extend({
   estimatedLevel: attr('number'),
   pixScore: attr('number'),
   type: attr('string'),
-  courseId: attr('string'),
+  certificationNumber: attr('string'),
   isCertification: Ember.computed.equal('type', 'CERTIFICATION'),
 
 });

--- a/live/app/models/assessment.js
+++ b/live/app/models/assessment.js
@@ -14,7 +14,7 @@ export default Model.extend({
   estimatedLevel: attr('number'),
   pixScore: attr('number'),
   type: attr('string'),
-
+  courseId: attr('string'),
   isCertification: Ember.computed.equal('type', 'CERTIFICATION'),
 
 });

--- a/live/app/models/assessment.js
+++ b/live/app/models/assessment.js
@@ -15,4 +15,6 @@ export default Model.extend({
   pixScore: attr('number'),
   type: attr('string'),
 
+  isCertification: Ember.computed.equal('type', 'CERTIFICATION'),
+
 });

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -46,7 +46,7 @@ Router.map(function() {
   this.route('assessments.resume', { path: '/assessments/:assessment_id' });
   this.route('assessments.results', { path: '/assessments/:assessment_id/results' });
   this.route('assessments.comparison', { path: '/assessments/:assessment_id/results/compare/:answer_id/:index' });
-  this.route('certifications.results', { path: '/certifications/:course_id/results' });
+  this.route('certifications.results', { path: '/certifications/:certification_number/results' });
   this.route('login', { path: '/connexion' });
   this.route('logout', { path: '/deconnexion' });
   this.route('course-groups', { path: '/defis-pix' });

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -46,7 +46,7 @@ Router.map(function() {
   this.route('assessments.resume', { path: '/assessments/:assessment_id' });
   this.route('assessments.results', { path: '/assessments/:assessment_id/results' });
   this.route('assessments.comparison', { path: '/assessments/:assessment_id/results/compare/:answer_id/:index' });
-  this.route('certifications.results', { path: '/certifications/:assessment_id/results' });
+  this.route('certifications.results', { path: '/certifications/:course_id/results' });
   this.route('login', { path: '/connexion' });
   this.route('logout', { path: '/deconnexion' });
   this.route('course-groups', { path: '/defis-pix' });

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -46,7 +46,7 @@ Router.map(function() {
   this.route('assessments.resume', { path: '/assessments/:assessment_id' });
   this.route('assessments.results', { path: '/assessments/:assessment_id/results' });
   this.route('assessments.comparison', { path: '/assessments/:assessment_id/results/compare/:answer_id/:index' });
-  this.route('certifications.results', { path: '/certifications/results' });
+  this.route('certifications.results', { path: '/certifications/:assessment_id/results' });
   this.route('login', { path: '/connexion' });
   this.route('logout', { path: '/deconnexion' });
   this.route('course-groups', { path: '/defis-pix' });

--- a/live/app/routes/assessments/challenge.js
+++ b/live/app/routes/assessments/challenge.js
@@ -1,5 +1,6 @@
 import RSVP from 'rsvp';
 import BaseRoute from 'pix-live/routes/base-route';
+import Ember from 'ember';
 
 export default BaseRoute.extend({
 
@@ -24,28 +25,23 @@ export default BaseRoute.extend({
 
   afterModel(model) {
     const store = this.get('store');
-
     // FIXME Quick-win pour contourner la récupération d'un course (qui n'existe pas pour une certif)
-    // Correction possible: Séparer la phase de récupération du course et la phase de création d'un assessment
-    if (model.assessment.get('type') !== 'CERTIFICATION') {
+    if (!model.assessment.get('isCertification')) {
       return RSVP.hash({
         answers: store.queryRecord('answer', { assessment: model.assessment.id, challenge: model.challenge.id }),
-        course: model.assessment.get('course'),
-        type: model.assessment.get('type')
-      }).then(({ answers, course, type }) => {
-
+        course: model.assessment.get('course')
+      }).then(({ answers, course }) => {
         model.answers = answers;
         model.progress = course.getProgress(model.challenge);
-        model.isCertification = (type === 'CERTIFICATION');
-        if(model.isCertification) {
-          return this.get('store').findRecord('user', this.get('session.data.authenticated.userId'));
-        } else {
-          return null;
-        }
-      }).then(user => {
-        model.user = user;
         return model;
       });
+    } else {
+      model.courseId = model.assessment.get('courseId');
+      return this.get('store').findRecord('user', this.get('session.data.authenticated.userId'))
+        .then(user => {
+          model.user = user;
+          return model;
+        });
     }
   },
 
@@ -70,7 +66,7 @@ export default BaseRoute.extend({
       .then((nextChallenge) => this.transitionTo('assessments.challenge', { assessment, challenge: nextChallenge }))
       .catch(() => {
         assessment.get('type') === 'CERTIFICATION' ?
-          this.transitionTo('certifications.results')
+          this.transitionTo('certifications.results', assessment.get('courseId'))
           : this.transitionTo('assessments.results', assessment.get('id'));
       });
   },

--- a/live/app/routes/assessments/challenge.js
+++ b/live/app/routes/assessments/challenge.js
@@ -3,6 +3,8 @@ import BaseRoute from 'pix-live/routes/base-route';
 
 export default BaseRoute.extend({
 
+  session: Ember.inject.service(),
+
   model(params) {
     const store = this.get('store');
 
@@ -28,10 +30,20 @@ export default BaseRoute.extend({
     if (model.assessment.get('type') !== 'CERTIFICATION') {
       return RSVP.hash({
         answers: store.queryRecord('answer', { assessment: model.assessment.id, challenge: model.challenge.id }),
-        course: model.assessment.get('course')
-      }).then(({ answers, course }) => {
+        course: model.assessment.get('course'),
+        type: model.assessment.get('type')
+      }).then(({ answers, course, type }) => {
+
         model.answers = answers;
         model.progress = course.getProgress(model.challenge);
+        model.isCertification = (type === 'CERTIFICATION');
+        if(model.isCertification) {
+          return this.get('store').findRecord('user', this.get('session.data.authenticated.userId'));
+        } else {
+          return null;
+        }
+      }).then(user => {
+        model.user = user;
         return model;
       });
     }

--- a/live/app/routes/assessments/challenge.js
+++ b/live/app/routes/assessments/challenge.js
@@ -25,6 +25,7 @@ export default BaseRoute.extend({
 
   afterModel(model) {
     const store = this.get('store');
+
     // FIXME Quick-win pour contourner la récupération d'un course (qui n'existe pas pour une certif)
     if (!model.assessment.get('isCertification')) {
       return RSVP.hash({
@@ -36,7 +37,6 @@ export default BaseRoute.extend({
         return model;
       });
     } else {
-      model.courseId = model.assessment.get('courseId');
       return this.get('store').findRecord('user', this.get('session.data.authenticated.userId'))
         .then(user => {
           model.user = user;
@@ -66,7 +66,7 @@ export default BaseRoute.extend({
       .then((nextChallenge) => this.transitionTo('assessments.challenge', { assessment, challenge: nextChallenge }))
       .catch(() => {
         assessment.get('type') === 'CERTIFICATION' ?
-          this.transitionTo('certifications.results', assessment.get('courseId'))
+          this.transitionTo('certifications.results', assessment.get('certificationNumber'))
           : this.transitionTo('assessments.results', assessment.get('id'));
       });
   },

--- a/live/app/routes/certifications/results.js
+++ b/live/app/routes/certifications/results.js
@@ -10,7 +10,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
   model(params) {
     return RSVP.hash({
       user: this.get('store').findRecord('user', this.get('session.data.authenticated.userId'), { reload: true }),
-      courseId: params.certification_number // FIXME certification number is a domain attribute and should not be queried as a technical id
+      certificationNumber: params.certification_number // FIXME certification number is a domain attribute and should not be queried as a technical id
     })
       .catch(_ => {
         this.transitionTo('logout');

--- a/live/app/routes/certifications/results.js
+++ b/live/app/routes/certifications/results.js
@@ -1,3 +1,4 @@
+import RSVP from 'rsvp';
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import BaseRoute from 'pix-live/routes/base-route';
@@ -6,8 +7,11 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
   authenticationRoute: '/connexion',
   session: Ember.inject.service(),
 
-  model() {
-    return this.get('store').findRecord('user', this.get('session.data.authenticated.userId'), { reload: true })
+  model(params) {
+    return RSVP.hash({
+      user: this.get('store').findRecord('user', this.get('session.data.authenticated.userId'), { reload: true }),
+      assessmentId: params.assessment_id
+    })
       .catch(_ => {
         this.transitionTo('logout');
       });

--- a/live/app/routes/certifications/results.js
+++ b/live/app/routes/certifications/results.js
@@ -10,7 +10,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
   model(params) {
     return RSVP.hash({
       user: this.get('store').findRecord('user', this.get('session.data.authenticated.userId'), { reload: true }),
-      courseId: params.course_id
+      courseId: params.certification_number // FIXME certification number is a domain attribute and should not be queried as a technical id
     })
       .catch(_ => {
         this.transitionTo('logout');

--- a/live/app/routes/certifications/results.js
+++ b/live/app/routes/certifications/results.js
@@ -10,7 +10,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
   model(params) {
     return RSVP.hash({
       user: this.get('store').findRecord('user', this.get('session.data.authenticated.userId'), { reload: true }),
-      assessmentId: params.assessment_id
+      courseId: params.course_id
     })
       .catch(_ => {
         this.transitionTo('logout');

--- a/live/app/styles/components/_certification-banner.scss
+++ b/live/app/styles/components/_certification-banner.scss
@@ -32,7 +32,7 @@
   text-transform: capitalize;
 }
 
-.certification-banner__course-id {
+.certification-banner__certification-number {
   color: $white;
   font-family: $font-lato;
   font-size: 50px;

--- a/live/app/styles/components/_certification-banner.scss
+++ b/live/app/styles/components/_certification-banner.scss
@@ -32,7 +32,7 @@
   text-transform: capitalize;
 }
 
-.certification-banner__user-id {
+.certification-banner__assessment-id {
   color: $white;
   font-family: $font-lato;
   font-size: 50px;

--- a/live/app/styles/components/_certification-banner.scss
+++ b/live/app/styles/components/_certification-banner.scss
@@ -32,7 +32,7 @@
   text-transform: capitalize;
 }
 
-.certification-banner__assessment-id {
+.certification-banner__course-id {
   color: $white;
   font-family: $font-lato;
   font-size: 50px;

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -2,7 +2,7 @@
 
   <div class="assessment-challenge__course-banner">
     {{#if model.assessment.isCertification}}
-      {{certification-banner user=model.user assessmentId=model.assessment.id}}
+      {{certification-banner user=model.user courseId=model.assessment.course.id}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}
     {{/if}}

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -2,7 +2,7 @@
 
   <div class="assessment-challenge__course-banner">
     {{#if model.assessment.isCertification}}
-      {{certification-banner user=model.user courseId=model.assessment.certificationNumber}}
+      {{certification-banner user=model.user certificationNumber=model.assessment.certificationNumber}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}
     {{/if}}

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -1,7 +1,7 @@
 <div class="assessment-challenge">
 
   <div class="assessment-challenge__course-banner">
-    {{#if model.isCertification}}
+    {{#if model.assessment.isCertification}}
       {{certification-banner user=model.user}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -2,14 +2,14 @@
 
   <div class="assessment-challenge__course-banner">
     {{#if model.assessment.isCertification}}
-      {{certification-banner user=model.user courseId=model.assessment.course.id}}
+      {{certification-banner user=model.user courseId=model.courseId}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}
     {{/if}}
   </div>
 
   <div class="assessment-challenge__content">
-    {{#unless (eq model.assessment.type 'CERTIFICATION')}}
+    {{#unless model.assessment.isCertification}}
       {{#unless model.assessment.course.isAdaptive}}
         <div class="assessment-challenge__progress-bar">
           {{progress-bar progress=model.progress}}

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -1,7 +1,11 @@
 <div class="assessment-challenge">
 
   <div class="assessment-challenge__course-banner">
-    {{course-banner course=model.assessment.course withHomeLink=true}}
+    {{#if model.isCertification}}
+      {{certification-banner user=model.user}}
+    {{else}}
+      {{course-banner course=model.assessment.course withHomeLink=true}}
+    {{/if}}
   </div>
 
   <div class="assessment-challenge__content">

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -2,7 +2,7 @@
 
   <div class="assessment-challenge__course-banner">
     {{#if model.assessment.isCertification}}
-      {{certification-banner user=model.user}}
+      {{certification-banner user=model.user assessmentId=model.assessment.id}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}
     {{/if}}

--- a/live/app/templates/assessments/challenge.hbs
+++ b/live/app/templates/assessments/challenge.hbs
@@ -2,7 +2,7 @@
 
   <div class="assessment-challenge__course-banner">
     {{#if model.assessment.isCertification}}
-      {{certification-banner user=model.user courseId=model.courseId}}
+      {{certification-banner user=model.user courseId=model.assessment.certificationNumber}}
     {{else}}
       {{course-banner course=model.assessment.course withHomeLink=true}}
     {{/if}}

--- a/live/app/templates/certifications/results.hbs
+++ b/live/app/templates/certifications/results.hbs
@@ -1,1 +1,1 @@
-{{certification-results-page user=model.user assessmentId=model.assessmentId}}
+{{certification-results-page user=model.user courseId=model.courseId}}

--- a/live/app/templates/certifications/results.hbs
+++ b/live/app/templates/certifications/results.hbs
@@ -1,1 +1,1 @@
-{{certification-results-page user=model}}
+{{certification-results-page user=model.user assessmentId=model.assessmentId}}

--- a/live/app/templates/certifications/results.hbs
+++ b/live/app/templates/certifications/results.hbs
@@ -1,1 +1,1 @@
-{{certification-results-page user=model.user courseId=model.courseId}}
+{{certification-results-page user=model.user certificationNumber=model.certificationNumber}}

--- a/live/app/templates/components/certification-banner.hbs
+++ b/live/app/templates/components/certification-banner.hbs
@@ -3,7 +3,7 @@
     {{fullname}}
   </div>
 
-  <div class="certification-banner__course-id">
-    #{{courseId}}
+  <div class="certification-banner__certification-number">
+    #{{certificationNumber}}
   </div>
 </div>

--- a/live/app/templates/components/certification-banner.hbs
+++ b/live/app/templates/components/certification-banner.hbs
@@ -3,7 +3,7 @@
     {{fullname}}
   </div>
 
-  <div class="certification-banner__user-id">
-    #{{user.id}}
+  <div class="certification-banner__assessment-id">
+    #{{assessmentId}}
   </div>
 </div>

--- a/live/app/templates/components/certification-banner.hbs
+++ b/live/app/templates/components/certification-banner.hbs
@@ -3,7 +3,7 @@
     {{fullname}}
   </div>
 
-  <div class="certification-banner__assessment-id">
-    #{{assessmentId}}
+  <div class="certification-banner__course-id">
+    #{{courseId}}
   </div>
 </div>

--- a/live/app/templates/components/certification-results-page.hbs
+++ b/live/app/templates/components/certification-results-page.hbs
@@ -1,5 +1,5 @@
 <div class="certification-results__certification-banner">
-  {{certification-banner user=user}}
+  {{certification-banner user=user assessmentId=assessmentId}}
 </div>
 
 <div class="certification-results__content result-content">
@@ -9,7 +9,7 @@
       <img src="{{rootURL}}/images/flag.svg" alt="drapeau">
     </div>
     <div class="result-content__panel-title">
-      Vous avez terminé
+      Vous avez terminé.
     </div>
     <div class="result-content__panel-description">
       Vos résultats vous seront communiqués dans les 10 jours suivant la fin de ce test par courrier électronique.

--- a/live/app/templates/components/certification-results-page.hbs
+++ b/live/app/templates/components/certification-results-page.hbs
@@ -1,5 +1,5 @@
 <div class="certification-results__certification-banner">
-  {{certification-banner user=user assessmentId=assessmentId}}
+  {{certification-banner user=user courseId=courseId}}
 </div>
 
 <div class="certification-results__content result-content">
@@ -23,7 +23,7 @@
     </div>
 
     <div class="result-content__warning-logout">
-      {{#link-to "logout" class="warning-logout-button"}}se deconnecter{{/link-to}}
+      {{#link-to "logout" class="warning-logout-button"}}Se déconnecter{{/link-to}}
     </div>
   </div>
 </div>

--- a/live/app/templates/components/certification-results-page.hbs
+++ b/live/app/templates/components/certification-results-page.hbs
@@ -1,5 +1,5 @@
 <div class="certification-results__certification-banner">
-  {{certification-banner user=user courseId=courseId}}
+  {{certification-banner user=user certificationNumber=certificationNumber}}
 </div>
 
 <div class="certification-results__content result-content">

--- a/live/mirage/routes/post-assessments.js
+++ b/live/mirage/routes/post-assessments.js
@@ -20,6 +20,7 @@ export default function(schema, request) {
     'user-id': 'user_id',
     'user-name': 'Jane Doe',
     'user-email': 'jane@acme.com',
+    'certification-number': 'certification-number',
     courseId
   };
 

--- a/live/tests/acceptance/certification-course-test.js
+++ b/live/tests/acceptance/certification-course-test.js
@@ -4,7 +4,7 @@ import { startApp, destroyApp } from '../helpers/application';
 import { authenticateAsSimpleUser } from '../helpers/testing';
 import defaultScenario from '../../mirage/scenarios/default';
 
-describe.only('Acceptance | Certification | Start Course', function() {
+describe('Acceptance | Certification | Start Course', function() {
 
   let application;
 
@@ -42,13 +42,13 @@ describe.only('Acceptance | Certification | Start Course', function() {
 
       it('should navigate to redirect to certification result page at the end of the assessment', async function() {
         // given
-        await click('.challenge-actions__action-skip-text');
+        await click('.challenge-actions__action-skip');
 
         // when
-        await click('.challenge-actions__action-skip-text');
+        await click('.challenge-actions__action-skip');
 
         // then
-        expect(currentURL()).to.match(/certifications\/\d+\/results/);
+        expect(currentURL()).to.equal('/certifications/certification-number/results');
       });
     });
   });

--- a/live/tests/acceptance/certification-course-test.js
+++ b/live/tests/acceptance/certification-course-test.js
@@ -4,7 +4,7 @@ import { startApp, destroyApp } from '../helpers/application';
 import { authenticateAsSimpleUser } from '../helpers/testing';
 import defaultScenario from '../../mirage/scenarios/default';
 
-describe('Acceptance | Certification | Start Course', function() {
+describe.only('Acceptance | Certification | Start Course', function() {
 
   let application;
 
@@ -48,7 +48,7 @@ describe('Acceptance | Certification | Start Course', function() {
         await click('.challenge-actions__action-skip-text');
 
         // then
-        expect(currentURL()).to.equals('/certifications/results');
+        expect(currentURL()).to.match(/certifications\/\d+\/results/);
       });
     });
   });

--- a/live/tests/integration/components/certification-banner-test.js
+++ b/live/tests/integration/components/certification-banner-test.js
@@ -11,7 +11,7 @@ describe('Integration | Component | Certification Banner', function() {
 
   context('On component rendering', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
-    const courseId = 'course_id';
+    const certificationNumber = 'certification-number';
 
     it('should render component container', function() {
       // when
@@ -31,14 +31,14 @@ describe('Integration | Component | Certification Banner', function() {
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
     });
 
-    it('should render component with a div:certification-banner__course-id', function() {
+    it('should render component with a div:certification-banner__certification-number', function() {
       // when
-      this.set('courseId', courseId);
-      this.render(hbs`{{certification-banner user=user courseId=courseId}}`);
+      this.set('certificationNumber', certificationNumber);
+      this.render(hbs`{{certification-banner user=user certificationNumber=certificationNumber}}`);
 
       // then
-      expect(this.$('.certification-banner__container .certification-banner__course-id')).to.have.lengthOf(1);
-      expect(this.$('.certification-banner__container .certification-banner__course-id').text().trim()).to.equal(`#${courseId}`);
+      expect(this.$('.certification-banner__container .certification-banner__certification-number')).to.have.lengthOf(1);
+      expect(this.$('.certification-banner__container .certification-banner__certification-number').text().trim()).to.equal(`#${certificationNumber}`);
     });
 
   });

--- a/live/tests/integration/components/certification-banner-test.js
+++ b/live/tests/integration/components/certification-banner-test.js
@@ -11,6 +11,7 @@ describe('Integration | Component | Certification Banner', function() {
 
   context('On component rendering', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
+    const assessmentId = 'assessment_id';
 
     it('should render component container', function() {
       // when
@@ -30,14 +31,14 @@ describe('Integration | Component | Certification Banner', function() {
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
     });
 
-    it('should render component with a div:certification-banner__user-id', function() {
+    it('should render component with a div:certification-banner__assessment-id', function() {
       // when
-      this.set('user', user);
-      this.render(hbs`{{certification-banner user=user}}`);
+      this.set('assessmentId', assessmentId);
+      this.render(hbs`{{certification-banner user=user assessmentId=assessmentId}}`);
 
       // then
-      expect(this.$('.certification-banner__container .certification-banner__user-id')).to.have.lengthOf(1);
-      expect(this.$('.certification-banner__container .certification-banner__user-id').text().trim()).to.equal(`#${user.id}`);
+      expect(this.$('.certification-banner__container .certification-banner__assessment-id')).to.have.lengthOf(1);
+      expect(this.$('.certification-banner__container .certification-banner__assessment-id').text().trim()).to.equal(`#${assessmentId}`);
     });
 
   });

--- a/live/tests/integration/components/certification-banner-test.js
+++ b/live/tests/integration/components/certification-banner-test.js
@@ -11,7 +11,7 @@ describe('Integration | Component | Certification Banner', function() {
 
   context('On component rendering', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
-    const assessmentId = 'assessment_id';
+    const courseId = 'course_id';
 
     it('should render component container', function() {
       // when
@@ -31,14 +31,14 @@ describe('Integration | Component | Certification Banner', function() {
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
     });
 
-    it('should render component with a div:certification-banner__assessment-id', function() {
+    it('should render component with a div:certification-banner__course-id', function() {
       // when
-      this.set('assessmentId', assessmentId);
-      this.render(hbs`{{certification-banner user=user assessmentId=assessmentId}}`);
+      this.set('courseId', courseId);
+      this.render(hbs`{{certification-banner user=user courseId=courseId}}`);
 
       // then
-      expect(this.$('.certification-banner__container .certification-banner__assessment-id')).to.have.lengthOf(1);
-      expect(this.$('.certification-banner__container .certification-banner__assessment-id').text().trim()).to.equal(`#${assessmentId}`);
+      expect(this.$('.certification-banner__container .certification-banner__course-id')).to.have.lengthOf(1);
+      expect(this.$('.certification-banner__container .certification-banner__course-id').text().trim()).to.equal(`#${courseId}`);
     });
 
   });

--- a/live/tests/integration/components/certification-results-page-test.js
+++ b/live/tests/integration/components/certification-results-page-test.js
@@ -12,22 +12,22 @@ describe('Integration | Component | certification results template', function() 
 
   context('When component is rendered', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
-    const assessmentId = 'assessment_id';
+    const courseId = 'course_id';
 
     beforeEach(function() {
       this.set('user', user);
-      this.set('assessmentId', assessmentId);
+      this.set('courseId', courseId);
     });
 
     it('should also render a certification banner', function() {
       // when
-      this.render(hbs`{{certification-results-page user=user assessmentId=assessmentId}}`);
+      this.render(hbs`{{certification-results-page user=user courseId=courseId}}`);
 
       // then
       expect(this.$('.certification-banner')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
-      expect(this.$('.certification-banner__container .certification-banner__assessment-id').text().trim()).to.equal(`#${assessmentId}`);
+      expect(this.$('.certification-banner__container .certification-banner__course-id').text().trim()).to.equal(`#${courseId}`);
     });
 
     it('should have a button to logout', function() {
@@ -37,7 +37,7 @@ describe('Integration | Component | certification results template', function() 
       });
 
       // when
-      this.render(hbs`{{certification-results-page user=user assessmentId=assessmentId}}`);
+      this.render(hbs`{{certification-results-page user=user courseId=courseId}}`);
 
       // then
       expect(this.$('.warning-logout-button')).to.have.lengthOf(1);

--- a/live/tests/integration/components/certification-results-page-test.js
+++ b/live/tests/integration/components/certification-results-page-test.js
@@ -12,19 +12,22 @@ describe('Integration | Component | certification results template', function() 
 
   context('When component is rendered', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
+    const assessmentId = 'assessment_id';
+
     beforeEach(function() {
       this.set('user', user);
+      this.set('assessmentId', assessmentId);
     });
 
     it('should also render a certification banner', function() {
       // when
-      this.render(hbs`{{certification-results-page user=user}}`);
+      this.render(hbs`{{certification-results-page user=user assessmentId=assessmentId}}`);
 
       // then
       expect(this.$('.certification-banner')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
-      expect(this.$('.certification-banner__container .certification-banner__user-id').text().trim()).to.equal(`#${user.id}`);
+      expect(this.$('.certification-banner__container .certification-banner__assessment-id').text().trim()).to.equal(`#${assessmentId}`);
     });
 
     it('should have a button to logout', function() {
@@ -34,7 +37,7 @@ describe('Integration | Component | certification results template', function() 
       });
 
       // when
-      this.render(hbs`{{certification-results-page user=user}}`);
+      this.render(hbs`{{certification-results-page user=user assessmentId=assessmentId}}`);
 
       // then
       expect(this.$('.warning-logout-button')).to.have.lengthOf(1);

--- a/live/tests/integration/components/certification-results-page-test.js
+++ b/live/tests/integration/components/certification-results-page-test.js
@@ -12,22 +12,22 @@ describe('Integration | Component | certification results template', function() 
 
   context('When component is rendered', function() {
     const user = { id: 5, firstName: 'shi', lastName: 'fu' };
-    const courseId = 'course_id';
+    const certificationNumber = 'certification-number';
 
     beforeEach(function() {
       this.set('user', user);
-      this.set('courseId', courseId);
+      this.set('certificationNumber', certificationNumber);
     });
 
     it('should also render a certification banner', function() {
       // when
-      this.render(hbs`{{certification-results-page user=user courseId=courseId}}`);
+      this.render(hbs`{{certification-results-page user=user certificationNumber=certificationNumber}}`);
 
       // then
       expect(this.$('.certification-banner')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname')).to.have.lengthOf(1);
       expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(`${user.firstName} ${user.lastName}`);
-      expect(this.$('.certification-banner__container .certification-banner__course-id').text().trim()).to.equal(`#${courseId}`);
+      expect(this.$('.certification-banner__container .certification-banner__certification-number').text().trim()).to.equal(`#${certificationNumber}`);
     });
 
     it('should have a button to logout', function() {
@@ -37,7 +37,7 @@ describe('Integration | Component | certification results template', function() 
       });
 
       // when
-      this.render(hbs`{{certification-results-page user=user courseId=courseId}}`);
+      this.render(hbs`{{certification-results-page user=user certificationNumber=certificationNumber}}`);
 
       // then
       expect(this.$('.warning-logout-button')).to.have.lengthOf(1);

--- a/live/tests/unit/routes/assessments/challenge-test.js
+++ b/live/tests/unit/routes/assessments/challenge-test.js
@@ -29,12 +29,13 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
       id: 'challenge_id'
     }
   };
+  const userId = 'user_id';
   beforeEach(function() {
     // define stubs
     createRecordStub = sinon.stub();
     queryRecordStub = sinon.stub();
     findRecordStub = sinon.stub();
-    findRecordStub.withArgs('user', 12).resolves({ userId: 'user_id' });
+    findRecordStub.withArgs('user', userId).resolves({ userId });
     StoreStub = EmberService.extend({
       createRecord: createRecordStub,
       queryRecord: queryRecordStub,
@@ -45,7 +46,7 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
     this.register('service:store', StoreStub);
     this.inject.service('store', { as: 'store' });
     this.register('service:session', EmberService.extend({
-      data: { authenticated: { userId: 12, token: 'VALID-TOKEN' } }
+      data: { authenticated: { userId: userId, token: 'VALID-TOKEN' } }
     }));
     // instance route object
     route = this.subject();
@@ -95,7 +96,7 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
       // then
       return promise.then(() => {
         sinon.assert.calledOnce(findRecordStub);
-        sinon.assert.calledWith(findRecordStub, 'user', 12);
+        sinon.assert.calledWith(findRecordStub, 'user', userId);
       });
     });
 
@@ -121,7 +122,7 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
         assessment: { id: 'assessment_id' },
         challenge: { id: 'challenge_id' },
         progress: 'course',
-        user: { userId: 'user_id' },
+        user: { userId: userId },
         courseId: 'course_id'
       };
 

--- a/live/tests/unit/routes/assessments/challenge-test.js
+++ b/live/tests/unit/routes/assessments/challenge-test.js
@@ -71,14 +71,14 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
   describe('#afterModel', function() {
     it('should call queryRecord to find answer', function() {
       // given
-      model.assessment.get.withArgs('type').returns('TEST');
+      model.assessment.get.withArgs('isCertification').returns(false);
       model.assessment.get.withArgs('course').returns({ getProgress: sinon.stub().returns('course') });
 
       // when
       const promise = route.afterModel(model);
 
       // then
-      promise.then(() => {
+      return promise.then(() => {
         sinon.assert.calledOnce(queryRecordStub);
         sinon.assert.calledWith(queryRecordStub, 'answer', { assessment : model.assessment.id, challenge: model.challenge.id });
       });
@@ -86,14 +86,14 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
 
     it('should call findRecord for user if assessment is certification', function() {
       // given
-      model.assessment.get.withArgs('type').returns('CERTIFICATION');
+      model.assessment.get.withArgs('isCertification').returns(true);
       model.assessment.get.withArgs('course').returns({ getProgress: sinon.stub().returns('course') });
 
       // when
       const promise = route.afterModel(model);
 
       // then
-      promise.then(() => {
+      return promise.then(() => {
         sinon.assert.calledOnce(findRecordStub);
         sinon.assert.calledWith(findRecordStub, 'user', 12);
       });
@@ -101,27 +101,26 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
 
     it('should not call findRecord for user if assessement is not a certification', function() {
       // given
-      model.assessment.get.withArgs('type').returns('TEST');
+      model.assessment.get.withArgs('isCertification').returns(false);
       model.assessment.get.withArgs('course').returns({ getProgress: sinon.stub().returns('course') });
 
       // when
       const promise = route.afterModel(model);
 
       // then
-      promise.then(() => {
+      return promise.then(() => {
         sinon.assert.notCalled(findRecordStub);
       });
     });
 
     it('should return a complete model', function() {
       // given
-      model.assessment.get.withArgs('type').returns('CERTIFICATION');
+      model.assessment.get.withArgs('isCertification').returns(true);
       model.assessment.get.withArgs('course').returns({ getProgress: sinon.stub().returns('course') });
       const expectedModel = {
         assessment: { id: 'assessment_id' },
         challenge: { id: 'challenge_id' },
         progress: 'course',
-        isCertification: true,
         user: { userId: 'user_id' }
       };
 
@@ -129,8 +128,8 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
       const promise = route.afterModel(model);
 
       // then
-      promise.then((createdModel) => {
-        expect(createdModel.toString()).to.deep.equal(expectedModel.toString());
+      return promise.then((createdModel) => {
+        expect(createdModel.toString()).to.equal(expectedModel.toString());
       });
     });
   });

--- a/live/tests/unit/routes/assessments/challenge-test.js
+++ b/live/tests/unit/routes/assessments/challenge-test.js
@@ -34,7 +34,7 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
     createRecordStub = sinon.stub();
     queryRecordStub = sinon.stub();
     findRecordStub = sinon.stub();
-    findRecordStub.withArgs('user', 12).returns({ userId: 'user_id' });
+    findRecordStub.withArgs('user', 12).resolves({ userId: 'user_id' });
     StoreStub = EmberService.extend({
       createRecord: createRecordStub,
       queryRecord: queryRecordStub,
@@ -121,7 +121,8 @@ describe('Unit | Route | Assessments.ChallengeRoute', function() {
         assessment: { id: 'assessment_id' },
         challenge: { id: 'challenge_id' },
         progress: 'course',
-        user: { userId: 'user_id' }
+        user: { userId: 'user_id' },
+        courseId: 'course_id'
       };
 
       // when

--- a/live/tests/unit/routes/certifications/results-test.js
+++ b/live/tests/unit/routes/certifications/results-test.js
@@ -10,7 +10,7 @@ describe('Unit | Route | Certifications | Results', function() {
     needs: ['service:current-routed-modal', 'service:session']
   });
   const params = {
-    assessment_id: 'assessment_id',
+    certification_number: 'certification_number',
   };
 
   it('exists', function() {

--- a/live/tests/unit/routes/certifications/results-test.js
+++ b/live/tests/unit/routes/certifications/results-test.js
@@ -9,6 +9,9 @@ describe('Unit | Route | Certifications | Results', function() {
   setupTest('route:certifications.results', {
     needs: ['service:current-routed-modal', 'service:session']
   });
+  const params = {
+    assessment_id: 'assessment_id',
+  };
 
   it('exists', function() {
     const route = this.subject();
@@ -46,7 +49,7 @@ describe('Unit | Route | Certifications | Results', function() {
         // Given
         findRecordStub.rejects();
         // When
-        const promise = route.model();
+        const promise = route.model(params);
 
         // Then
         return promise.then(function() {
@@ -79,12 +82,12 @@ describe('Unit | Route | Certifications | Results', function() {
         findRecordStub.resolves(expectedUser);
 
         // When
-        const promise = route.model();
+        const promise = route.model(params);
 
         // Then
-        return promise.then(function(user) {
+        return promise.then(function(model) {
           sinon.assert.calledWith(findRecordStub, 'user', 1435, { reload: true });
-          expect(user).to.equal(expectedUser);
+          expect(model.user).to.equal(expectedUser);
         });
       });
     });


### PR DESCRIPTION
**Ticket Trello :** https://trello.com/c/YvHXEeVW/887-etq-candidat-jv-voir-mon-userid-sur-le-bandeau-de-chaque-epreuve-dun-test-de-certif-au-lieu-du-titre-du-test
**RA :** http://887-use-certification-banner-in-challenge.pix-dev.ovh/

**Ce qui a été réalisé :**
- Ajout d'un IF dans le template de la route challenge
- Appel de l'user du store pour afficher le nom seulement si c'est un test de certification
- Ajout de tests unitaires sur des parties de challenges.js qui n'étaient pas testés
- Ajout du "type" d'assessment dans l'assessment serializer pour que l'api renvoie le type
- Ajout de l'assessment id dans la certification-banner
- Changement de la route /certifications/results pour /certifications/:assessment_id/results

**Pour tester :**
- Vu qu'il n'y a pas encore de test de certification qui se lance, il faut lancer un assessment, et modifier ensuite son type dans la base de données, pour que le type soit "CERTIFICATION".
