### PR TITLE
[#602] [BUGFIX] Correction d'une modale grise (US-921).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -189,6 +189,10 @@ module.exports = {
         }
 
       })
-      .catch((err) => reply(Boom.badImplementation(err)));
+      .catch((err) => {
+        logger.error(err);
+
+        reply(Boom.badImplementation(err));
+      });
   }
 };

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -120,7 +120,7 @@ module.exports = {
       });
   },
 
-  getAssessmentSolutions(request, reply) {
+  getAssessmentSolution(request, reply) {
 
     assessmentRepository
       .get(request.params.id)
@@ -185,7 +185,7 @@ module.exports = {
               return reply(solutionSerializer.serialize(solution));
             });
         } else {
-          return reply('null');
+          return reply('null').code(202);
         }
 
       })

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -1,24 +1,49 @@
 const Boom = require('boom');
-const _ = require('../../infrastructure/utils/lodash-utils');
 
 const assessmentSerializer = require('../../infrastructure/serializers/jsonapi/assessment-serializer');
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const assessmentService = require('../../domain/services/assessment-service');
 const skillsService = require('../../domain/services/skills-service');
 const tokenService = require('../../domain/services/token-service');
-const assessmentUtils = require('../../domain/services/assessment-service-utils');
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 const solutionSerializer = require('../../infrastructure/serializers/jsonapi/solution-serializer');
-const courseRepository = require('../../infrastructure/repositories/course-repository');
-const competenceRepository = require('../../infrastructure/repositories/competence-repository');
-const skillRepository = require('../../infrastructure/repositories/skill-repository');
+
 const answerRepository = require('../../infrastructure/repositories/answer-repository');
 const solutionRepository = require('../../infrastructure/repositories/solution-repository');
 
 const logger = require('../../infrastructure/logger');
 
-const { NotFoundError, NotElligibleToScoringError } = require('../../domain/errors');
+const { NotFoundError, NotElligibleToScoringError, NotCompletedAssessmentError } = require('../../domain/errors');
+
+function _doesAssessmentExistsAndIsCompleted(assessment) {
+  if(!assessment)
+    throw new NotFoundError();
+
+  const isAssessmentNotCompleted = !assessmentService.isAssessmentCompleted(assessment);
+
+  if(isAssessmentNotCompleted)
+    throw new NotCompletedAssessmentError();
+}
+
+function _doesAnswerExists(answer) {
+  if (answer)
+    return answer;
+
+  throw new NotFoundError();
+}
+
+function _replyWithError(reply, error) {
+  if (error instanceof NotFoundError)
+    return reply(Boom.notFound());
+
+  if (error instanceof NotCompletedAssessmentError)
+    return reply(Boom.conflict(error.message));
+
+  logger.error(error);
+
+  reply(Boom.badImplementation());
+}
 
 module.exports = {
 
@@ -122,77 +147,13 @@ module.exports = {
 
   getAssessmentSolution(request, reply) {
 
-    assessmentRepository
+    return assessmentRepository
       .get(request.params.id)
-      .then((assessment) => {
-        if (_.isEmpty(assessment)) {
-          return reply('null');
-        }
-        return assessment;
-      })
-      .then((assessment) => {
-
-        // fetch course & answers
-        const answers = answerRepository.findByAssessment(assessment.get('id'));
-        const course = courseRepository.get(assessment.get('courseId'));
-        return Promise.all([answers, course]).then(values => {
-          const answers = values[0];
-          const course = values[1];
-          return { answers, course };
-        });
-      })
-      .then(({ answers, course }) => {
-        // fetch challenges (requires course)
-        const challenges = course.challenges.map(challengeId => challengeRepository.get(challengeId));
-
-        return Promise.all(challenges).then(challenges => {
-          return { answers, course, challenges };
-        });
-      })
-      .then(({ answers, course, challenges }) => {
-        return competenceRepository.get(course.competences[0]).then(competence => {
-          return { answers, course, challenges, competence };
-        });
-      })
-      .then(({ answers, course, challenges, competence }) => {
-        const skillNames = skillRepository.findByCompetence(competence);
-        return Promise.all([skillNames]).then(values => {
-          const skillNames = values[0];
-          return { answers, course, challenges, skillNames };
-        });
-      })
-      .then(({ answers, course, challenges, skillNames }) => {
-        // verify if test is over
-        let testIsOver;
-        if (course.isAdaptive) {
-          const nextChallengeId = assessmentUtils.getNextChallengeInAdaptiveCourse(answers, challenges, skillNames);
-          testIsOver = _.isEmpty(nextChallengeId);
-        } else {
-          const answersLength = answers.length || 0;
-          const challengesLength = challenges.length || 0;
-          testIsOver = _.isEqual(answersLength, challengesLength);
-        }
-        return { answers, testIsOver };
-      })
-      .then(({ answers, testIsOver }) => {
-
-        if (testIsOver) {
-          const requestedAnswer = answers.filter(answer => answer.id === _.parseInt(request.params.answerId))[0];
-
-          solutionRepository
-            .get(requestedAnswer.get('challengeId'))
-            .then((solution) => {
-              return reply(solutionSerializer.serialize(solution));
-            });
-        } else {
-          return reply('null').code(202);
-        }
-
-      })
-      .catch((err) => {
-        logger.error(err);
-
-        reply(Boom.badImplementation(err));
-      });
+      .then(_doesAssessmentExistsAndIsCompleted)
+      .then(() => answerRepository.get(request.params.answerId))
+      .then(_doesAnswerExists)
+      .then(answer => solutionRepository.get(answer.get('challengeId')))
+      .then(solution => reply(solutionSerializer.serialize(solution)))
+      .catch(error => _replyWithError(reply, error));
   }
 };

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -35,7 +35,7 @@ exports.register = function(server, options, next) {
       method: 'GET',
       path: '/api/assessments/{id}/solutions/{answerId}',
       config: {
-        handler: AssessmentController.getAssessmentSolutions, tags: ['api']
+        handler: AssessmentController.getAssessmentSolution, tags: ['api']
       }
     }
   ]);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -40,6 +40,12 @@ class AlreadyRegisteredEmailError extends Error {
   }
 }
 
+class NotCompletedAssessmentError extends Error {
+  constructor() {
+    super('Cette évaluation n\'est pas terminée.');
+  }
+}
+
 class UserNotFoundError extends Error {
   constructor() {
     super();
@@ -122,5 +128,6 @@ module.exports = {
   PasswordResetDemandNotFoundError,
   InvalidTemporaryKeyError,
   NotElligibleToQmailError,
-  UserNotAuthorizedToCertifyError
+  UserNotAuthorizedToCertifyError,
+  NotCompletedAssessmentError
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -16,12 +16,6 @@ class InvalidTokenError extends Error {
   }
 }
 
-class NotElligibleToScoringError extends Error {
-  constructor(message) {
-    super(message);
-  }
-}
-
 class NotElligibleToQmailError extends Error {
   constructor(message) {
     super(message);
@@ -118,7 +112,6 @@ class UserNotAuthorizedToCertifyError extends Error {
 
 module.exports = {
   NotFoundError,
-  NotElligibleToScoringError,
   PasswordNotMatching,
   InvalidTokenError,
   AlreadyRegisteredEmailError,

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -9,7 +9,7 @@ const answerService = require('../services/answer-service');
 const assessmentUtils = require('./assessment-service-utils');
 const _ = require('../../infrastructure/utils/lodash-utils');
 
-const { NotFoundError, NotElligibleToScoringError } = require('../../domain/errors');
+const { NotFoundError } = require('../../domain/errors');
 
 function _selectNextInAdaptiveMode(assessment, course) {
 
@@ -77,47 +77,58 @@ function getAssessmentNextChallengeId(assessment, currentChallengeId) {
   });
 }
 
-function getScoredAssessment(assessmentId) {
+async function getScoredAssessment(assessmentId) {
 
-  let assessmentPix, answersPix, challengesPix, coursePix, competencePix, skills;
+  let skills;
 
-  return assessmentRepository.get(assessmentId)
-    .then(retrievedAssessment => {
-      if (retrievedAssessment === null) {
-        return Promise.reject(new NotFoundError(`Unable to find assessment with ID ${assessmentId}`));
-      } else if (isPreviewAssessment(retrievedAssessment)) {
-        return Promise.reject(new NotElligibleToScoringError(`Assessment with ID ${assessmentId} is a preview Challenge`));
+  const [assessmentPix, answers] = await Promise.all([
+    assessmentRepository.get(assessmentId),
+    answerRepository.findByAssessment(assessmentId)
+  ]);
+
+  if (assessmentPix === null) {
+    return Promise.reject(new NotFoundError(`Unable to find assessment with ID ${assessmentId}`));
+  }
+
+  assessmentPix.set('estimatedLevel', 0);
+  assessmentPix.set('pixScore', 0);
+  assessmentPix.set('successRate', answerService.getAnswersSuccessRate(answers));
+
+  if (isPreviewAssessment(assessmentPix)) {
+    return Promise.resolve({ assessmentPix, skills });
+  }
+
+  return courseRepository.get(assessmentPix.get('courseId'))
+    .then((course) => {
+
+      if (course.isAdaptive) {
+        return competenceRepository
+          .get(course.competences[0])
+          .then(competencePix => Promise.all([
+            skillRepository.findByCompetence(competencePix),
+            challengeRepository.findByCompetence(competencePix)
+          ]));
       }
-      assessmentPix = retrievedAssessment;
+
+      return null;
     })
-    .then(() => answerRepository.findByAssessment(assessmentPix.get('id')))
-    .then(retrievedAnswers => {
-      answersPix = retrievedAnswers;
-      assessmentPix.set('successRate', answerService.getAnswersSuccessRate(retrievedAnswers));
-    })
-    .then(() => courseRepository.get(assessmentPix.get('courseId')))
-    .then(course => (coursePix = course))
-    .then(() => competenceRepository.get(coursePix.competences[0]))
-    .then((fetchedCompetence) => (competencePix = fetchedCompetence))
-    .then(() => challengeRepository.findByCompetence(competencePix))
-    .then(challenges => challengesPix = challenges)
-    .then(() => skillRepository.findByCompetence(competencePix))
-    .then(skillNames => {
-      if (coursePix.isAdaptive) {
-        const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skillNames);
+    .then((skillsAndChallenges) => {
+
+      if(skillsAndChallenges) {
+        const [skillNames, challengesPix] = skillsAndChallenges;
+        const catAssessment = assessmentAdapter.getAdaptedAssessment(answers, challengesPix, skillNames);
+
         skills = {
           assessmentId,
-          validatedSkills: assessment.validatedSkills,
-          failedSkills: assessment.failedSkills
+          validatedSkills: catAssessment.validatedSkills,
+          failedSkills: catAssessment.failedSkills
         };
-        assessmentPix.set('estimatedLevel', assessment.obtainedLevel);
-        assessmentPix.set('pixScore', assessment.displayedPixScore);
-      } else {
-        assessmentPix.set('estimatedLevel', 0);
-        assessmentPix.set('pixScore', 0);
+
+        assessmentPix.set('estimatedLevel', catAssessment.obtainedLevel);
+        assessmentPix.set('pixScore', catAssessment.displayedPixScore);
       }
 
-      return { assessmentPix, skills };
+      return Promise.resolve({ assessmentPix, skills });
     });
 }
 
@@ -146,7 +157,6 @@ function isAssessmentCompleted(assessment) {
 module.exports = {
   getAssessmentNextChallengeId,
   getScoredAssessment,
-  isPreviewAssessment,
   createCertificationAssessmentForUser,
   isAssessmentCompleted
 };

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -131,14 +131,22 @@ function createCertificationAssessmentForUser(certificationCourse, userId) {
     courseId: certificationCourse.id,
     userId: userId
   };
-  return assessmentRepository.save(assessmentCertification);
 
+  return assessmentRepository.save(assessmentCertification);
+}
+
+function isAssessmentCompleted(assessment) {
+  if (_.isNil(assessment.get('estimatedLevel')) || _.isNil(assessment.get('pixScore'))) {
+    return false;
+  }
+
+  return true;
 }
 
 module.exports = {
-
   getAssessmentNextChallengeId,
   getScoredAssessment,
   isPreviewAssessment,
-  createCertificationAssessmentForUser
+  createCertificationAssessmentForUser,
+  isAssessmentCompleted
 };

--- a/api/lib/infrastructure/adapters/assessment-adapter.js
+++ b/api/lib/infrastructure/adapters/assessment-adapter.js
@@ -4,31 +4,25 @@ const Course = require('../../cat/course');
 const Answer = require('../../cat/answer');
 const Assessment = require('../../cat/assessment');
 
+// TODO: Déclencher une erreur quand pas de skill ?
+
 function getAdaptedAssessment(answersPix, challengesPix, skills) {
   const challenges = [];
   const challengesById = {};
   const catSkills = {};
 
-  skills.forEach(skill => catSkills[skill.name] = new Skill(skill.name));
-  const competenceSkills = new Set(Object.values(catSkills));
-
   challengesPix.forEach(challengePix => {
-    const challengeSkills = [];
-
     if (challengePix.skills) {
+      const challengeCatSkills = challengePix.skills.map(skill => new Skill(skill.name));
+      const challenge = new Challenge(challengePix.id, challengePix.status, challengeCatSkills, challengePix.timer);
 
-      challengePix.skills.forEach(skill => {
-        if (!catSkills.hasOwnProperty(skill.name)) {
-          catSkills[skill.name] = new Skill(skill.name);
-        }
-        challengeSkills.push(catSkills[skill.name]);
-      });
-
-      const challenge = new Challenge(challengePix.id, challengePix.status, challengeSkills, challengePix.timer);
       challenges.push(challenge);
       challengesById[challengePix.id] = challenge;
     }
   });
+
+  skills.forEach(skill => catSkills[skill.name] = new Skill(skill.name));
+  const competenceSkills = new Set(Object.values(catSkills));
 
   const course = new Course(challenges, competenceSkills);
 

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -2,7 +2,7 @@ const Answer = require('../../domain/models/data/answer');
 
 module.exports = {
 
-  getById(answerId) {
+  get(answerId) {
     return Answer.where('id', answerId).fetch();
   },
 

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -2,6 +2,10 @@ const Answer = require('../../domain/models/data/answer');
 
 module.exports = {
 
+  getById(answerId) {
+    return Answer.where('id', answerId).fetch();
+  },
+
   findByChallengeAndAssessment(challengeId, assessmentId) {
     return Answer
       .where({ challengeId, assessmentId })

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5888,6 +5888,12 @@
         "type-detect": "4.0.5"
       }
     },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -139,12 +139,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     server.stop(done);
   });
 
-  afterEach(() => {
-    return knex('assessments').delete()
-      .then(() => {
-        return knex('answers').delete();
-      });
-  });
+  afterEach(() => knex('assessments').delete());
 
   describe('(non-adaptive end of test) GET /api/assessments/:assessment_id/solutions/:answer_id', () => {
 
@@ -153,7 +148,9 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     let insertedAnswerId = null;
 
     const insertedAssessment = {
-      courseId: 'non_adaptive_course_id'
+      courseId: 'non_adaptive_course_id',
+      estimatedLevel: 0,
+      pixScore: 5
     };
 
     beforeEach(() => {
@@ -210,12 +207,12 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     let insertedAssessmentId = null;
     let insertedAnswerId = null;
 
-    const insertedAssessment = {
+    const notCompletedAssessment = {
       courseId: 'non_adaptive_course_id'
     };
 
     beforeEach(() => {
-      return knex('assessments').insert([insertedAssessment]).then((rows) => {
+      return knex('assessments').insert([ notCompletedAssessment ]).then((rows) => {
         insertedAssessmentId = rows[0];
 
         const inserted_answer = {
@@ -244,8 +241,12 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
 
       // Then
       return promise.then((response) => {
-        expect(response.statusCode).to.equal(202);
-        expect(response.result).to.equal('null');
+        expect(response.statusCode).to.equal(409);
+        expect(response.result).to.deep.equal({
+          'error': 'Conflict',
+          'message': 'Cette évaluation n\'est pas terminée.',
+          'statusCode': 409
+        });
       });
     });
   });
@@ -255,13 +256,15 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     let insertedAssessmentId = null;
     let insertedAnswerId = null;
 
-    const insertedAssessment = {
-      courseId: 'adaptive_course_id'
+    const completedAssessment = {
+      courseId: 'adaptive_course_id',
+      estimatedLevel: 1,
+      pixScore: 9
     };
 
     beforeEach(() => {
       return knex('assessments')
-        .insert([insertedAssessment])
+        .insert([ completedAssessment ])
         .then((rows) => {
 
           insertedAssessmentId = rows[0];
@@ -306,7 +309,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     let insertedAssessmentId = null;
     let insertedAnswerId = null;
 
-    const insertedAssessment = {
+    const notCompletedAssessment = {
       courseId: 'adaptive_course_id'
     };
 
@@ -317,7 +320,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
     };
 
     beforeEach(() => {
-      return knex('assessments').insert([insertedAssessment])
+      return knex('assessments').insert([ notCompletedAssessment ])
         .then((rows) => {
           insertedAssessmentId = rows[0];
 
@@ -352,7 +355,12 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
 
       // Then
       return promise.then((response) => {
-        expect(response.result).to.equal('null');
+        expect(response.statusCode).to.equal(409);
+        expect(response.result).to.deep.equal({
+          'error': 'Conflict',
+          'message': 'Cette évaluation n\'est pas terminée.',
+          'statusCode': 409
+        });
       });
     });
   });

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -243,6 +243,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
 
       // Then
       return promise.then((response) => {
+        expect(response.statusCode).to.equal(202);
         expect(response.result).to.equal('null');
       });
     });

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -103,6 +103,7 @@ describe('Acceptance | API | assessment-controller-get-solutions', () => {
             },
           }
           );
+
         nock('https://api.airtable.com')
           .get('/v0/test-base/Epreuves/q_second_challenge')
           .query(true)

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -13,6 +13,8 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
   describe('#getNextChallenge', () => {
 
+    let replyStub;
+    let codeStub;
     let sandbox;
     let assessmentWithoutScore;
     let assessmentWithScore;
@@ -25,6 +27,9 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
     };
 
     beforeEach(() => {
+
+      codeStub = sinon.stub();
+      replyStub = sinon.stub().returns({ code: codeStub });
 
       assessmentWithoutScore = new Assessment({
         id: 1,
@@ -47,30 +52,38 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       sandbox = sinon.sandbox.create();
 
       sandbox.stub(assessmentService, 'getScoredAssessment').resolves(scoredAsssessment);
-      sandbox.stub(assessmentWithScore, 'save');
+      sandbox.stub(assessmentWithScore, 'save').resolves();
       sandbox.stub(assessmentRepository, 'get').resolves(assessmentWithoutScore);
-      sandbox.stub(assessmentService, 'getAssessmentNextChallengeId');
-      sandbox.stub(skillService, 'saveAssessmentSkills');
+      sandbox.stub(skillService, 'saveAssessmentSkills').resolves();
+      sandbox.stub(assessmentService, 'getAssessmentNextChallengeId').resolves();
     });
 
     afterEach(() => {
-
       sandbox.restore();
-
     });
 
     describe('when the assessment is a preview', () => {
-      it('should', () => {
-        // Given
-        const replyStub = sinon.stub();
-        assessmentWithoutScore.set('courseId', 'null2356871');
 
+      const PREVIEW_ASSESSMENT_ID = 245;
+
+      beforeEach(() => {
+        assessmentRepository.get.resolves(new Assessment({
+          id: 1,
+          courseId: 'null2356871',
+          userId: 5,
+          estimatedLevel: 0,
+          pixScore: 0,
+        }));
+      });
+
+      it('should return a 204 code directly', () => {
         // When
-        const promise = assessmentController.getNextChallenge({ params: { id: 12 } }, replyStub);
+        const promise = assessmentController.getNextChallenge({ params: { id: PREVIEW_ASSESSMENT_ID } }, replyStub);
 
         // Then
         return promise.then(() => {
-          sinon.assert.calledWith(replyStub, 'null');
+          sinon.assert.calledOnce(replyStub);
+          sinon.assert.calledWith(codeStub, 204);
         });
       });
     });
@@ -83,8 +96,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call getScoredAssessment', () => {
         // When
-        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {
-        });
+        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {});
 
         // Then
         return promise.then(() => {
@@ -94,8 +106,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should save the assessment with score', () => {
         // When
-        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {
-        });
+        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {});
 
         // Then
         return promise.then(() => {
@@ -107,8 +118,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         // When
         assessmentWithScore.save.resolves();
         skillService.saveAssessmentSkills.resolves({});
-        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {
-        });
+        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
 
         // Then
         return promise.then(() => {
@@ -121,10 +131,6 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         // Given
         assessmentWithScore.save.resolves();
         skillService.saveAssessmentSkills.resolves({});
-        const replyStub = sinon.stub().returns({
-          code: () => {
-          }
-        });
 
         // When
         const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
@@ -193,8 +199,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should not evaluate assessment score', () => {
         // When
-        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, () => {
-        });
+        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
 
         // Then
         return promise.then(() => {

--- a/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
@@ -1,0 +1,158 @@
+const { describe, it, beforeEach, afterEach, sinon } = require('../../../test-helper');
+
+const Boom = require('boom');
+const logger = require('../../../../lib/infrastructure/logger');
+
+const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const answerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
+const solutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');
+
+const solutionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/solution-serializer');
+
+const Assessment = require('../../../../lib/domain/models/data/assessment');
+const Answer = require('../../../../lib/domain/models/data/answer');
+const Solution = require('../../../../lib/domain/models/referential/solution');
+
+describe('Unit | Controller | assessment-controller', () => {
+
+  describe('#getAssessmentSolution', () => {
+
+    let sandbox;
+    let replyStub;
+    let codeStub;
+
+    const boomResponseForConflict = { message: 'Boom Response for Conflict' };
+    const boomResponseForNotFound = { message: 'Not found' };
+    const boomResponseForbBadImplementation = { message: 'Bad Implementation' };
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+
+      codeStub = sinon.stub();
+      replyStub = sinon.stub().returns({
+        code: codeStub
+      });
+
+      sandbox.stub(logger, 'error');
+      sandbox.stub(Boom, 'notFound').returns(boomResponseForNotFound);
+      sandbox.stub(Boom, 'conflict').returns(boomResponseForConflict);
+      sandbox.stub(Boom, 'badImplementation').returns(boomResponseForbBadImplementation);
+      sandbox.stub(assessmentRepository, 'get');
+      sandbox.stub(answerRepository, 'get');
+      sandbox.stub(solutionRepository, 'get');
+      sandbox.stub(solutionSerializer, 'serialize');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should return 404 when the assessment is not found', () => {
+      // given
+      assessmentRepository.get.resolves();
+
+      // when
+      const promise = assessmentController.getAssessmentSolution({ params: { id: 13465 } }, replyStub);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.calledWith(assessmentRepository.get, 13465);
+        sinon.assert.calledOnce(Boom.notFound);
+        sinon.assert.calledWith(replyStub, boomResponseForNotFound);
+      });
+    });
+
+    it('should return 202 when the assessment is found but not completed yet', () => {
+      // given
+      assessmentRepository.get.resolves(new Assessment({ id: 13465, estimatedLevel: null, pixScore: null }));
+
+      // when
+      const promise = assessmentController.getAssessmentSolution({ params: { id: 13465 } }, replyStub);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.calledWith(assessmentRepository.get, 13465);
+        sinon.assert.calledWith(Boom.conflict, 'Cette évaluation n\'est pas terminée.');
+        sinon.assert.calledWith(replyStub, boomResponseForConflict);
+      });
+    });
+
+    context('when a repository is on error', () => {
+      it('should log the error for the assessmentRepository', () => {
+        // given
+        const error = new Error('Database locked');
+        assessmentRepository.get.rejects(error);
+
+        // when
+        const promise = assessmentController.getAssessmentSolution({ params: { id: 13465 } }, replyStub);
+
+        // then
+        return promise.then(() => {
+          sinon.assert.calledWith(logger.error, error);
+          sinon.assert.calledOnce(Boom.badImplementation);
+          sinon.assert.calledWith(replyStub, boomResponseForbBadImplementation);
+        });
+      });
+
+      it('should log the error for the answerRepository', () => {
+        // given
+        const error = new Error('Database locked');
+        answerRepository.get.rejects(error);
+        assessmentRepository.get.resolves(new Assessment({ id: 13465, estimatedLevel: 1, pixScore: 12 }));
+
+        // when
+        const promise = assessmentController.getAssessmentSolution({ params: { id: 13465 } }, replyStub);
+
+        // then
+        return promise.then(() => {
+          sinon.assert.calledWith(logger.error, error);
+          sinon.assert.calledOnce(Boom.badImplementation);
+          sinon.assert.calledWith(replyStub, boomResponseForbBadImplementation);
+        });
+      });
+    });
+
+    context('when the assessment exists and is completed', () => {
+      beforeEach(() => {
+        assessmentRepository.get.resolves(new Assessment({ id: 13465, estimatedLevel: 1, pixScore: 12 }));
+      });
+
+      it('should return an 404 error when the answer is not found', () => {
+        // given
+        answerRepository.get.resolves();
+
+        // when
+        const promise = assessmentController.getAssessmentSolution({ params: { id: 13465, answerId: 2467 } }, replyStub);
+
+        // then
+        return promise.then(() => {
+          sinon.assert.calledWith(answerRepository.get, 2467);
+          sinon.assert.calledOnce(Boom.notFound);
+          sinon.assert.calledWith(replyStub, boomResponseForNotFound);
+        });
+      });
+
+      it('should the serialized solution', () => {
+        // given
+        const challengeId = '5738623';
+        const solution = new Solution({});
+        answerRepository.get.resolves(new Answer({ challengeId }));
+        solutionRepository.get.resolves(solution);
+        solutionSerializer.serialize.returns({ message: 'serialized solution' });
+
+        // when
+        const promise = assessmentController.getAssessmentSolution({ params: { id: 13465, answerId: 2467 } }, replyStub);
+
+        // then
+        return promise.then(() => {
+          sinon.assert.calledWith(solutionRepository.get, challengeId);
+          sinon.assert.calledWith(solutionSerializer.serialize, solution);
+          sinon.assert.calledWith(replyStub, { message: 'serialized solution' });
+        });
+      });
+
+    });
+  });
+
+});

--- a/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
@@ -118,22 +118,24 @@ describe('Unit | Controller | assessment-controller', () => {
         assessmentRepository.get.resolves(new Assessment({ id: 13465, estimatedLevel: 1, pixScore: 12 }));
       });
 
-      it('should return an 404 error when the answer is not found', () => {
-        // given
-        answerRepository.get.resolves();
+      context('when the answer is not found', () => {
+        it('should return an 404 error', () => {
+          // given
+          answerRepository.get.resolves();
 
-        // when
-        const promise = assessmentController.getAssessmentSolution({ params: { id: 13465, answerId: 2467 } }, replyStub);
+          // when
+          const promise = assessmentController.getAssessmentSolution({ params: { id: 13465, answerId: 2467 } }, replyStub);
 
-        // then
-        return promise.then(() => {
-          sinon.assert.calledWith(answerRepository.get, 2467);
-          sinon.assert.calledOnce(Boom.notFound);
-          sinon.assert.calledWith(replyStub, boomResponseForNotFound);
+          // then
+          return promise.then(() => {
+            sinon.assert.calledWith(answerRepository.get, 2467);
+            sinon.assert.calledOnce(Boom.notFound);
+            sinon.assert.calledWith(replyStub, boomResponseForNotFound);
+          });
         });
       });
 
-      it('should the serialized solution', () => {
+      it('should reply the serialized solution', () => {
         // given
         const challengeId = '5738623';
         const solution = new Solution({});

--- a/api/tests/unit/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get_test.js
@@ -7,8 +7,7 @@ const assessmentRepository = require('../../../../lib/infrastructure/repositorie
 const assessmentService = require('../../../../lib/domain/services/assessment-service');
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 
-const { NotFoundError, NotElligibleToScoringError } = require('../../../../lib/domain/errors');
-const Assessment = require('../../../../lib/domain/models/data/assessment');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Controller | assessment-controller', () => {
 
@@ -69,27 +68,6 @@ describe('Unit | Controller | assessment-controller', () => {
         sinon.assert.calledWithExactly(boomNotFound, getScoredError);
 
       });
-    });
-
-    it('should return the Assessment without scoring with getScoredAssessment rejecting NotElligibleToScoringError', () => {
-      // Given
-      const assessment = new Assessment({});
-      assessmentRepository.get.returns(Promise.resolve(assessment));
-      assessmentService.getScoredAssessment.rejects(new NotElligibleToScoringError('Expected Error Message'));
-
-      const expectedSerializedAssessment = { message: 'mySerializedAssessment' };
-      assessmentSerializer.serialize.returns(expectedSerializedAssessment);
-
-      // When
-      const promise = assessmentController.get(request, reply);
-
-      // Then
-      return promise.then(() => {
-        sinon.assert.calledWith(assessmentRepository.get, ASSESSMENT_ID);
-        sinon.assert.calledWith(assessmentSerializer.serialize, assessment);
-        sinon.assert.calledWith(reply, expectedSerializedAssessment);
-      });
-
     });
 
     it('should return a Bad Implementation error when we cannot retrieve the score', () => {

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -101,7 +101,7 @@ describe('Unit | Controller | assessment-controller', () => {
       sinon.assert.calledOnce(saveAssessmentStub);
     });
 
-    describe('when the assessment is successfully saved', () => {
+    context('when the assessment is successfully saved', () => {
       it('should serialize the assessment after its creation', () => {
         // When
         const promise = controller.save(request, replyStub);
@@ -124,7 +124,7 @@ describe('Unit | Controller | assessment-controller', () => {
       });
     });
 
-    describe('when the assessment can not be saved', () => {
+    context('when the assessment can not be saved', () => {
 
       let badImplementationStub;
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -308,12 +308,15 @@ describe('Unit | Domain | Services | assessment-service', function() {
   });
 
   describe('#createCertificationAssessmentForUser', () => {
+
     beforeEach(() => {
       sinon.stub(assessmentRepository, 'save').resolves();
     });
+
     afterEach(() => {
       assessmentRepository.save.restore();
     });
+
     it('should save an assessment with CERTIFICATION type', () => {
       // given
       const certificationCourse = { id: 'certificationId' };
@@ -323,14 +326,50 @@ describe('Unit | Domain | Services | assessment-service', function() {
         type: 'CERTIFICATION',
         userId: userId
       };
-      // when
 
+      // when
       const promise = service.createCertificationAssessmentForUser(certificationCourse, userId);
+
       // then
       return promise.then(() => {
         sinon.assert.calledOnce(assessmentRepository.save);
         sinon.assert.calledWith(assessmentRepository.save, expectedAssessment);
       });
+    });
+  });
+
+  describe('#isAssessmentCompleted', () => {
+    it('should return true when the assessment has a pixScore and an estimatedLevel', () => {
+      // given
+      const notCompletedAssessment = new Assessment({ id: '2752', estimatedLevel: 0, pixScore: 0 });
+
+      // when
+      const isCompleted = service.isAssessmentCompleted(notCompletedAssessment);
+
+      // then
+      expect(isCompleted).to.equal(true);
+    });
+
+    it('should return false when the assessment miss a pixScore', () => {
+      // given
+      const notCompletedAssessment = new Assessment({ id: '2752', estimatedLevel: 0 });
+
+      // when
+      const isCompleted = service.isAssessmentCompleted(notCompletedAssessment);
+
+      // then
+      expect(isCompleted).to.equal(false);
+    });
+
+    it('should return false when the assessment miss an estimatedLevel', () => {
+      // given
+      const notCompletedAssessment = new Assessment({ id: '2752', pixScore: 0 });
+
+      // when
+      const isCompleted = service.isAssessmentCompleted(notCompletedAssessment);
+
+      // then
+      expect(isCompleted).to.equal(false);
     });
   });
 

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -39,7 +39,7 @@ function _buildAnswer(challengeId, result, assessmentId = 1) {
   return answer;
 }
 
-describe('Unit | Domain | Services | assessment-service', function() {
+describe('Unit | Domain | Services | assessment-service', () => {
 
   beforeEach(() => {
     sinon.stub(competenceRepository, 'get');
@@ -49,7 +49,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
     competenceRepository.get.restore();
   });
 
-  describe('#getAssessmentNextChallengeId', function() {
+  describe('#getAssessmentNextChallengeId', () => {
 
     it('Should return the first challenge if no currentChallengeId is given', () => {
       // given
@@ -59,7 +59,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null);
 
       // then
-      return promise.then(function(result) {
+      return promise.then((result) => {
         expect(result).to.equal('the_first_challenge');
         courseRepository.get.restore();
       });
@@ -73,7 +73,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge');
 
       // then
-      return promise.then(function(result) {
+      return promise.then((result) => {
         expect(result).to.equal('2nd_challenge');
         courseRepository.get.restore();
       });
@@ -85,7 +85,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       const promise = service.getAssessmentNextChallengeId();
 
       // then
-      return promise.then(function(result) {
+      return promise.then((result) => {
         expect(result).to.equal(null);
       });
     });
@@ -98,7 +98,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge');
 
       // then
-      return promise.then(function(result) {
+      return promise.then((result) => {
         expect(result).to.equal(null);
         courseRepository.get.restore();
       });
@@ -113,7 +113,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge');
 
       // then
-      return promise.then(function(result) {
+      return promise.then((result) => {
         expect(result).to.equal(null);
         courseRepository.get.restore();
       });
@@ -189,6 +189,21 @@ describe('Unit | Domain | Services | assessment-service', function() {
       });
     });
 
+    it('should rejects when acessing to the assessment is failing', () => {
+      // given
+      assessmentRepository.get.rejects(new Error('Access DB is failing'));
+
+      // when
+      const promise = service.getScoredAssessment(ASSESSMENT_ID);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.fail('Should not succeed');
+      }, (error) => {
+        expect(error.message).to.equal('Access DB is failing');
+      });
+    });
+
     it('should return an assessment with an id and a courseId', () => {
       // when
       const promise = service.getScoredAssessment(ASSESSMENT_ID);
@@ -248,7 +263,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
       context('when the assessement is linked to a course', () => {
         beforeEach(() => {
           const assessmentFromPreview = new Assessment({ id: ASSESSMENT_ID, courseId: COURSE_ID });
-          assessmentRepository.get.returns(Promise.resolve(assessmentFromPreview));
+          assessmentRepository.get.resolves(assessmentFromPreview);
         });
 
         it('should load course details', () => {
@@ -300,7 +315,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
           });
         });
 
-        context('when the course is an adaptative one', () => {
+        context('when the course is an adaptive one', () => {
 
           beforeEach(() => {
             courseRepository.get.resolves({
@@ -345,7 +360,7 @@ describe('Unit | Domain | Services | assessment-service', function() {
         id: '1',
         courseId: PREVIEW_COURSE_ID
       });
-      assessmentRepository.get.returns(Promise.resolve(assessmentFromPreview));
+      assessmentRepository.get.resolves(assessmentFromPreview);
 
       // when
       const promise = service.getScoredAssessment(ASSESSMENT_ID);

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -53,63 +53,73 @@ describe('Unit | Domain | Services | assessment-service', function() {
 
   describe('#getAssessmentNextChallengeId', function() {
 
-    it('Should return the first challenge if no currentChallengeId is given', function(done) {
-
+    it('Should return the first challenge if no currentChallengeId is given', () => {
+      // given
       sinon.stub(courseRepository, 'get').resolves({ challenges: ['the_first_challenge'] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null).then(function(result) {
+      // when
+      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null);
+
+      // then
+      return promise.then(function(result) {
         expect(result).to.equal('the_first_challenge');
         courseRepository.get.restore();
-        done();
       });
-
     });
 
-    it('Should return the next challenge if currentChallengeId is given', function(done) {
-
+    it('Should return the next challenge if currentChallengeId is given', () => {
+      // given
       sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge').then(function(result) {
+      // when
+      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge');
+
+      // then
+      return promise.then(function(result) {
         expect(result).to.equal('2nd_challenge');
         courseRepository.get.restore();
-        done();
       });
 
     });
 
-    it('Should resolves to "null" if no assessment is given', function(done) {
+    it('Should resolves to "null" if no assessment is given', () => {
+      // when
+      const promise = service.getAssessmentNextChallengeId();
 
-      service.getAssessmentNextChallengeId().then(function(result) {
+      // then
+      return promise.then(function(result) {
         expect(result).to.equal(null);
-        done();
       });
-
     });
 
-    it('Should resolves to "null" if no courseId is given', function(done) {
-
+    it('Should resolves to "null" if no courseId is given', () => {
+      // given
       sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge').then(function(result) {
+      // when
+      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge');
+
+      // then
+      return promise.then(function(result) {
         expect(result).to.equal(null);
         courseRepository.get.restore();
-        done();
       });
 
     });
 
-    it('Should resolves to "null" if courseId starts with "null"', function(done) {
-
+    it('Should resolves to "null" if courseId starts with "null"', () => {
+      // given
       sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
 
-      service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge').then(function(result) {
+      // when
+      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge');
+
+      // then
+      return promise.then(function(result) {
         expect(result).to.equal(null);
         courseRepository.get.restore();
-        done();
       });
-
     });
-
   });
 
   describe('#getScoredAssessment', () => {

--- a/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
@@ -1,0 +1,140 @@
+const { describe, it, expect } = require('../../../test-helper');
+
+const Bookshelf = require('../../../../lib/infrastructure/bookshelf');
+const assessmentAdapter = require('../../../../lib/infrastructure/adapters/assessment-adapter');
+const CatAssessment = require('../../../../lib/cat/assessment');
+const CatCourse = require('../../../../lib/cat/course');
+const CatSkill = require('../../../../lib/cat/skill');
+const CatChallenge = require('../../../../lib/cat/challenge');
+const CatAnswer = require('../../../../lib/cat/answer');
+const Answer = require('../../../../lib/domain/models/data/answer');
+
+describe('Unit | Adapter | Assessment', () => {
+
+  describe('#getAdaptedAssessment', () => {
+    it('should return an Assessment from the Cat repository', () => {
+      // given
+      const skills = [];
+      const challenges = [];
+      const answers = [];
+
+      // when
+      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+
+      // then
+      expect(adaptedAssessment).to.be.an.instanceOf(CatAssessment);
+    });
+
+    it('should add a course with a list of skills', () => {
+      // given
+      const web3Skill = { name: 'web3' };
+      const skills = [web3Skill];
+      const challenges = [];
+      const answers = [];
+
+      // when
+      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+
+      // then
+      expect(adaptedAssessment).to.have.property('course').and.to.be.an.instanceOf(CatCourse);
+
+      const { course } = adaptedAssessment;
+      expect(course).to.have.property('competenceSkills').and.to.be.an.instanceOf(Set);
+
+      const expectedSetOfSkills = new Set([new CatSkill('web3')]);
+      expect(course.competenceSkills).to.deep.equal(expectedSetOfSkills);
+    });
+
+    describe('the assessment\'s course ', () => {
+      it('should have an array of challenges', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [],
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+
+        // then
+        const { course } = adaptedAssessment;
+        expect(course).to.have.property('challenges');
+        expect(course.challenges[0]).to.deep.equal(new CatChallenge(256, 'validé', [], 26));
+      });
+
+      it('should not select challenges without skills', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+
+        // then
+        const { course } = adaptedAssessment;
+        expect(course).to.have.property('challenges');
+        expect(course.challenges).to.have.lengthOf(0);
+      });
+
+      it('should have challenges with skills', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [{ name: 'url6' }],
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+
+        // then
+        const challenge  = adaptedAssessment.course.challenges[0];
+        expect(challenge.skills).to.deep.equal([new CatSkill('url6')]);
+      });
+    });
+
+    describe('the assessment\'s answers', () => {
+
+      const AnswerCollection = Bookshelf.Collection.extend({
+        model: Answer
+      });
+
+      it('should have an array of challenges', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [],
+          timer: 26
+        }];
+
+        const answersGiven = AnswerCollection.forge([new Answer({
+          id: 42,
+          challengeId: 256,
+          result: '#ABAND#'
+        })]);
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answersGiven, challenges, skills);
+
+        // then
+        const { answers } = adaptedAssessment;
+        expect(answers).to.deep.equal([new CatAnswer(new CatChallenge(256, 'validé', [], 26), '#ABAND#')]);
+      });
+    });
+  });
+
+});

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -108,7 +108,7 @@ describe('Unit | Repository | AnswerRepository', () => {
 
     afterEach(() => knex('answers').delete());
 
-    it('should find all answers by challenge', () => {
+    it('should find all answers by challenge id', () => {
       // when
       const promise = AnswerRepository.findByChallenge('challenge_1234');
 

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -5,7 +5,7 @@ const Answer = require('../../../../lib/domain/models/data/answer');
 
 describe('Unit | Repository | AnswerRepository', () => {
 
-  describe('#getById', () => {
+  describe('#get', () => {
     let answerId;
 
     beforeEach(() => {
@@ -14,18 +14,20 @@ describe('Unit | Repository | AnswerRepository', () => {
           value: '1,2',
           result: 'ko',
           challengeId: 'challenge_1234',
-          assessmentId: 1234
+          assessmentId: 353
         })
         .then((createdAnswer) => {
           answerId = createdAnswer[0];
         });
     });
 
-    afterEach(() => knex('answers').delete());
+    afterEach(() => {
+      return knex('answers').delete();
+    });
 
     it('should retrieve an answer from its id', () => {
       // when
-      const promise = AnswerRepository.getById(answerId);
+      const promise = AnswerRepository.get(answerId);
 
       // then
       return promise.then(foundAnswer => {

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -1,11 +1,40 @@
-const { describe, it, before, after, expect, knex, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { describe, it, expect, knex, beforeEach, afterEach, sinon } = require('../../../test-helper');
 
 const AnswerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 const Answer = require('../../../../lib/domain/models/data/answer');
 
-describe('Unit | Repository | AnswerRepository', function() {
+describe('Unit | Repository | AnswerRepository', () => {
 
-  describe('findByChallengeAndAssessment', function() {
+  describe('#getById', () => {
+    let answerId;
+
+    beforeEach(() => {
+      return knex('answers')
+        .insert({
+          value: '1,2',
+          result: 'ko',
+          challengeId: 'challenge_1234',
+          assessmentId: 1234
+        })
+        .then((createdAnswer) => {
+          answerId = createdAnswer[0];
+        });
+    });
+
+    afterEach(() => knex('answers').delete());
+
+    it('should retrieve an answer from its id', () => {
+      // when
+      const promise = AnswerRepository.getById(answerId);
+
+      // then
+      return promise.then(foundAnswer => {
+        expect(foundAnswer.get('id')).to.deep.equal(answerId);
+      });
+    });
+  });
+
+  describe('#findByChallengeAndAssessment', () => {
 
     // nominal case
     const wrongAnswer = {
@@ -48,7 +77,7 @@ describe('Unit | Repository | AnswerRepository', function() {
     });
   });
 
-  describe('findByChallenge', () => {
+  describe('#findByChallenge', () => {
 
     const wrongAnswerForAssessment1234 = {
       value: '1',

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -8,7 +8,7 @@ describe('Unit | Repository | AnswerRepository', function() {
   describe('findByChallengeAndAssessment', function() {
 
     // nominal case
-    const inserted_answer_1 = {
+    const wrongAnswer = {
       value: '1,2',
       result: 'ko',
       challengeId: 'challenge_1234',
@@ -16,7 +16,7 @@ describe('Unit | Repository | AnswerRepository', function() {
     };
 
     // same assessmentId, different challengeId
-    const inserted_answer_2 = {
+    const correctAnswer = {
       value: '1,2,4',
       result: 'ok',
       challengeId: 'challenge_000',
@@ -24,39 +24,33 @@ describe('Unit | Repository | AnswerRepository', function() {
     };
 
     // different assessmentId, same challengeId
-    const inserted_answer_3 = {
+    const partiallyCorrectAnswer = {
       value: '3',
       result: 'partially',
       challengeId: 'challenge_1234',
       assessmentId: 1
     };
 
-    before((done) =>{
-      knex('answers').delete().then(() => {
-        knex('answers').insert([inserted_answer_1, inserted_answer_2, inserted_answer_3]).then(() => {
-          done();
-        });
-      });
-    });
+    beforeEach(() => knex('answers').insert([wrongAnswer, correctAnswer, partiallyCorrectAnswer]));
 
-    after(() =>{
-      knex('answers').delete();
-    });
+    afterEach(() => knex('answers').delete());
 
-    it('should find the answer by challenge and assessment and return its in an object', function(done) {
-      expect(AnswerRepository.findByChallengeAndAssessment).to.exist;
-      AnswerRepository.findByChallengeAndAssessment('challenge_1234', 1234).then(function(foundAnswers) {
+    it('should find the answer by challenge and assessment and return its in an object', () => {
+      // when
+      const promise = AnswerRepository.findByChallengeAndAssessment('challenge_1234', 1234);
+
+      // then
+      return promise.then(foundAnswers => {
         expect(foundAnswers).to.exist;
         expect(foundAnswers).to.be.an('object');
-        expect(foundAnswers.attributes.value).to.equal(inserted_answer_1.value);
-        done();
+        expect(foundAnswers.attributes.value).to.equal(wrongAnswer.value);
       });
     });
   });
 
-  describe('findByChallenge', function() {
+  describe('findByChallenge', () => {
 
-    const inserted_answer_1 = {
+    const wrongAnswerForAssessment1234 = {
       value: '1',
       result: 'ko',
       challengeId: 'challenge_1234',
@@ -64,7 +58,7 @@ describe('Unit | Repository | AnswerRepository', function() {
     };
 
     // same challenge different assessment
-    const inserted_answer_2 = {
+    const wrongAnswerForAssessment1 = {
       value: '1,2',
       result: 'ko',
       challengeId: 'challenge_1234',
@@ -72,58 +66,46 @@ describe('Unit | Repository | AnswerRepository', function() {
     };
 
     //different challenge different assessment
-    const inserted_answer_3 = {
+    const timedOutAnswerForAssessement1 = {
       value: '1,2,3',
       result: 'timedout',
       challengeId: 'challenge_000',
       assessmentId: 1
     };
 
-    before(function(done) {
-      knex('answers').delete().then(() => {
-        knex('answers').insert([inserted_answer_1, inserted_answer_2, inserted_answer_3]).then(() => {
-          done();
-        });
-      });
-    });
+    beforeEach(() => knex('answers').insert([wrongAnswerForAssessment1234, wrongAnswerForAssessment1, timedOutAnswerForAssessement1]));
 
-    after(function(done) {
-      knex('answers').delete().then(() => {
-        done();
-      });
-    });
+    afterEach(() => knex('answers').delete());
 
-    it('should find all answers by challenge', function(done) {
+    it('should find all answers by challenge', () => {
+      // when
+      const promise = AnswerRepository.findByChallenge('challenge_1234');
 
-      expect(AnswerRepository.findByChallenge).to.exist;
-
-      AnswerRepository.findByChallenge('challenge_1234').then(function(foundAnswers) {
+      // then
+      return promise.then(foundAnswers => {
 
         expect(foundAnswers).to.exist;
 
         expect(foundAnswers).to.have.length.of(2);
 
-        expect(foundAnswers[0].attributes.value).to.equal(inserted_answer_1.value);
-        expect(foundAnswers[0].attributes.challengeId).to.equal(inserted_answer_1.challengeId);
+        expect(foundAnswers[0].attributes.value).to.equal(wrongAnswerForAssessment1234.value);
+        expect(foundAnswers[0].attributes.challengeId).to.equal(wrongAnswerForAssessment1234.challengeId);
 
-        expect(foundAnswers[1].attributes.value).to.equal(inserted_answer_2.value);
-        expect(foundAnswers[1].attributes.challengeId).to.equal(inserted_answer_2.challengeId);
-
-        done();
+        expect(foundAnswers[1].attributes.value).to.equal(wrongAnswerForAssessment1.value);
+        expect(foundAnswers[1].attributes.challengeId).to.equal(wrongAnswerForAssessment1.challengeId);
       });
     });
   });
 
   describe('#findCorrectAnswersByAssessment', () => {
     let fetchAllStub;
+
     beforeEach(() => {
       sinon.stub(Answer.prototype, 'where');
       fetchAllStub = sinon.stub();
     });
 
-    afterEach(() => {
-      Answer.prototype.where.restore();
-    });
+    afterEach(() => Answer.prototype.where.restore());
 
     it('should retrieve answers with ok status from assessment id provided', () => {
       // given


### PR DESCRIPTION
Le problème de la modale grise vient du fait qu'on ouvre la modale avant d'avoir reçu les données de l'API. Quand les données ne sont pas accessible par la personne (par exemple l'API crash salement une 500), la modale reste grise.

Je n'ai corrigé que la partie API, et fait un gros réfactoring sur les endpoints concernés.

A vue de nez, cette PR corrige la majorité de nos erreurs Sentry.