### PR TITLE
[#613] [BUGFIX] Fix affichage des boutons "replay"/"seconde chance" des tests de positionnement

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
@@ -80,6 +80,7 @@ class ProfileSerializer extends JSONAPISerializer {
           'level': competence.level,
           'course-id': competence.courseId,
           'status': competence.status,
+          'assessment-id': null,
         },
         relationships: {
           'area': {

--- a/api/tests/acceptance/application/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users-controller-get-profile_test.js
@@ -89,6 +89,7 @@ describe('Acceptance | Controller | users-controller-get-profile', function() {
           level: -1,
           'course-id': 'recBxPAuEPlTgt72q11',
           status: 'notEvaluated',
+          'assessment-id': null,
         },
         relationships: {
           area: {
@@ -108,6 +109,7 @@ describe('Acceptance | Controller | users-controller-get-profile', function() {
           level: -1,
           'course-id': 'recBxPAuEPlTgt72q99',
           status: 'notEvaluated',
+          'assessment-id': null,
         },
         relationships: {
           area: {
@@ -135,7 +137,8 @@ describe('Acceptance | Controller | users-controller-get-profile', function() {
       areaId: 'recAreaA',
       level: -1,
       courseId: 'recBxPAuEPlTgt72q11',
-      status: 'notEvaluated'
+      status: 'notEvaluated',
+      'assessment-id': null,
     },
     {
       id: 'recCompB',
@@ -144,7 +147,8 @@ describe('Acceptance | Controller | users-controller-get-profile', function() {
       areaId: 'recAreaB',
       level: -1,
       courseId: 'recBxPAuEPlTgt72q99',
-      status: 'notEvaluated'
+      status: 'notEvaluated',
+      'assessment-id': null,
     }],
     areas: [{ id: 'recAreaA', name: 'domaine-name-1' }, { id: 'recAreaB', name: 'domaine-name-2' }],
     organizations: []

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -208,7 +208,8 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
               index: '1.3',
               level: -1,
               status: 'notEvaluated',
-              'course-id': 'courseID3'
+              'course-id': 'courseID3',
+              'assessment-id': null,
             },
             relationships: {
               area: {


### PR DESCRIPTION
Set explicitement user.competences[].assessmentId = null pour éviter à Ember de réutiliser l'ancienne valeur dans le modèle.

**GUIDELINE:** toujours mettre null dans le serializer API dans les champs obligatoires