### PR TITLE
[#619] [CLEANUP] Nettoyer les serializers JSON API pour les mettre au (nouveau) standard. (US-996)

### DIFF
--- a/api/lib/application/challenges/challenge-controller.js
+++ b/api/lib/application/challenges/challenge-controller.js
@@ -16,7 +16,7 @@ module.exports = {
 
     challengeRepository
       .list()
-      .then((challenges) => reply(challengeSerializer.serializeArray(challenges)))
+      .then((challenges) => reply(challengeSerializer.serialize(challenges)))
       .catch((err) => {
         logger.error(err);
         reply(Boom.badImplementation(err));

--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -28,7 +28,7 @@ function _extractCoursesChallenges(courses) {
 }
 
 function _buildResponse(courses, challenges) {
-  const response = courseSerializer.serializeArray(courses);
+  const response = courseSerializer.serialize(courses);
   response.included = challenges.map(challenge => challengeSerializer.serialize(challenge).data);
   return response;
 }

--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -1,8 +1,6 @@
 const Boom = require('boom');
 const courseRepository = require('../../infrastructure/repositories/course-repository');
 const courseSerializer = require('../../infrastructure/serializers/jsonapi/course-serializer');
-const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
-const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 
 const logger = require('../../infrastructure/logger');
 
@@ -16,33 +14,11 @@ function _fetchCourses(query) {
   return courseRepository.getProgressionCourses();
 }
 
-function _extractCoursesChallenges(courses) {
-  const challengeIds = courses.reduce((listOfId, course) => {
-    if (course.challenges) {
-      return listOfId.concat(course.challenges);
-    }
-    return listOfId;
-  }, []);
-  const challenges = challengeIds.map(challengeId => challengeRepository.get(challengeId));
-  return Promise.all(challenges);
-}
-
-function _buildResponse(courses, challenges) {
-  const response = courseSerializer.serialize(courses);
-  response.included = challenges.map(challenge => challengeSerializer.serialize(challenge).data);
-  return response;
-}
-
 module.exports = {
 
   list(request, reply) {
-    let courses;
     _fetchCourses(request.query)
-      .then(fetchedCourses => {
-        courses = fetchedCourses;
-        return _extractCoursesChallenges(courses);
-      })
-      .then(challenges => reply(_buildResponse(courses, challenges)))
+      .then(courses => reply(courseSerializer.serialize(courses)))
       .catch((err) => {
         logger.error(err);
         reply(Boom.badImplementation(err));

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -62,7 +62,7 @@ module.exports = {
 
     return organisationRepository
       .findBy(params)
-      .then(organizations => reply(organizationSerializer.serialize(organizations)))
+      .then(organizations => reply(organizationSerializer.serialize(organizations.models)))
       .catch(err => {
         logger.error(err);
         reply().code(500);

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -62,10 +62,7 @@ module.exports = {
 
     return organisationRepository
       .findBy(params)
-      .then((organizations) => {
-
-        reply(organizationSerializer.serialize(organizations.models));
-      })
+      .then(organizations => reply(organizationSerializer.serialize(organizations)))
       .catch(err => {
         logger.error(err);
         reply().code(500);

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -62,7 +62,7 @@ module.exports = {
 
     return organisationRepository
       .findBy(params)
-      .then(organizations => reply(organizationSerializer.serialize(organizations.models)))
+      .then(organizations => reply(organizationSerializer.serialize(organizations)))
       .catch(err => {
         logger.error(err);
         reply().code(500);

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -64,7 +64,7 @@ module.exports = {
       .findBy(params)
       .then((organizations) => {
 
-        reply(organizationSerializer.serializeArray(organizations.models));
+        reply(organizationSerializer.serialize(organizations.models));
       })
       .catch(err => {
         logger.error(err);

--- a/api/lib/domain/models/data/answer.js
+++ b/api/lib/domain/models/data/answer.js
@@ -1,14 +1,14 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
 Bookshelf.plugin('registry');
 
-const Assessment = require('./assessment');
+require('./assessment');
 
 module.exports = Bookshelf.model('Answer', {
 
   tableName: 'answers',
 
   assessment() {
-    return this.belongsTo(Assessment);
+    return this.belongsTo('Assessment');
   }
 
 });

--- a/api/lib/domain/models/data/certification-challenge.js
+++ b/api/lib/domain/models/data/certification-challenge.js
@@ -1,5 +1,6 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+module.exports = Bookshelf.model('CertificationChallenge', {
   tableName: 'certification-challenges',
 });

--- a/api/lib/domain/models/data/certification-course.js
+++ b/api/lib/domain/models/data/certification-course.js
@@ -1,5 +1,6 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+module.exports = Bookshelf.model('CertificationCourse', {
   tableName: 'certification-courses'
 });

--- a/api/lib/domain/models/data/feedback.js
+++ b/api/lib/domain/models/data/feedback.js
@@ -1,14 +1,14 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
 Bookshelf.plugin('registry');
 
-const Assessment = require('./assessment');
+require('./assessment');
 
 module.exports = Bookshelf.model('Feedback', {
 
   tableName: 'feedbacks',
 
   assessment() {
-    return this.belongsTo(Assessment);
+    return this.belongsTo('Assessment');
   }
 
 });

--- a/api/lib/domain/models/data/follower.js
+++ b/api/lib/domain/models/data/follower.js
@@ -1,5 +1,6 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+module.exports = Bookshelf.model('Follower', {
   tableName: 'followers'
 });

--- a/api/lib/domain/models/data/organization.js
+++ b/api/lib/domain/models/data/organization.js
@@ -1,7 +1,9 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
-const User = require('../../../domain/models/data/user');
 
-module.exports = Bookshelf.Model.extend({
+Bookshelf.plugin('registry');
+require('./user');
+
+module.exports = Bookshelf.model('Organization', {
   tableName: 'organizations',
 
   validations: {
@@ -25,6 +27,6 @@ module.exports = Bookshelf.Model.extend({
   },
 
   user() {
-    return this.belongsTo(User);
+    return this.belongsTo('User', 'userId');
   }
 });

--- a/api/lib/domain/models/data/organization.js
+++ b/api/lib/domain/models/data/organization.js
@@ -1,6 +1,6 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
-
 Bookshelf.plugin('registry');
+
 require('./user');
 
 module.exports = Bookshelf.model('Organization', {

--- a/api/lib/domain/models/data/reset-password-demand.js
+++ b/api/lib/domain/models/data/reset-password-demand.js
@@ -1,10 +1,12 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
-const User = require('./user');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+require('./user');
+
+module.exports = Bookshelf.model('ResetPasswordDemand', {
   tableName: 'reset-password-demands',
 
   user() {
-    return this.belongsTo(User, 'email');
+    return this.belongsTo('User', 'email');
   }
 });

--- a/api/lib/domain/models/data/scenario.js
+++ b/api/lib/domain/models/data/scenario.js
@@ -2,7 +2,5 @@ const Bookshelf = require('../../../infrastructure/bookshelf');
 Bookshelf.plugin('registry');
 
 module.exports = Bookshelf.model('Scenario', {
-
-  tableName: 'scenarios',
-
+  tableName: 'scenarios'
 });

--- a/api/lib/domain/models/data/skill.js
+++ b/api/lib/domain/models/data/skill.js
@@ -1,10 +1,12 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
-const Assessment = require('./assessment');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+require('./assessment');
+
+module.exports = Bookshelf.model('Skill', {
   tableName: 'skills',
 
   assessment() {
-    return this.belongsTo(Assessment);
+    return this.belongsTo('Assessment');
   }
 });

--- a/api/lib/domain/models/data/snapshot.js
+++ b/api/lib/domain/models/data/snapshot.js
@@ -1,15 +1,17 @@
 const Bookshelf = require('../../../infrastructure/bookshelf');
-const Organization = require('./organization');
-const User = require('./user');
+Bookshelf.plugin('registry');
 
-module.exports = Bookshelf.Model.extend({
+require('./organization');
+require('./user');
+
+module.exports = Bookshelf.model('Snapshot', {
   tableName: 'snapshots',
 
   organization() {
-    return this.belongsTo(Organization);
+    return this.belongsTo('Organization');
   },
 
   user() {
-    return this.belongsTo(User, 'userId');
+    return this.belongsTo('User', 'userId');
   }
 });

--- a/api/lib/domain/models/data/user.js
+++ b/api/lib/domain/models/data/user.js
@@ -1,6 +1,8 @@
 const validator = require('validator');
 
 const Bookshelf = require('../../../infrastructure/bookshelf');
+Bookshelf.plugin('registry');
+
 const encrypt = require('../../services/encryption-service');
 const passwordValidator = require('../../../infrastructure/validators/password-validator');
 
@@ -9,7 +11,7 @@ const Organization = require('./organization');
 
 validator.isPassword = passwordValidator;
 
-module.exports = Bookshelf.Model.extend({
+module.exports = Bookshelf.model('User', {
   tableName: 'users',
 
   initialize() {

--- a/api/lib/domain/models/data/user.js
+++ b/api/lib/domain/models/data/user.js
@@ -6,8 +6,8 @@ Bookshelf.plugin('registry');
 const encrypt = require('../../services/encryption-service');
 const passwordValidator = require('../../../infrastructure/validators/password-validator');
 
-const Assessment = require('./assessment');
-const Organization = require('./organization');
+require('./assessment');
+require('./organization');
 
 validator.isPassword = passwordValidator;
 
@@ -54,10 +54,10 @@ module.exports = Bookshelf.model('User', {
   },
 
   assessments() {
-    return this.hasMany(Assessment);
+    return this.hasMany('Assessment');
   },
 
   organizations() {
-    return this.hasMany(Organization);
+    return this.hasMany('Organization');
   }
 });

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -34,16 +34,17 @@ module.exports = {
   },
 
   findBy(filters) {
-    return Organization.where(filters).fetchAll({ withRelated: ['user'] });
+    return Organization
+      .where(filters)
+      .fetchAll({ withRelated: ['user'] })
+      .then(organizations => organizations.models);
   },
 
   getByUserId(userId) {
     return Organization
       .where({ userId })
       .fetchAll()
-      .then((organizations) => {
-        return organizations.models;
-      });
+      .then(organizations => organizations.models);
   }
 };
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   findBy(filters) {
-    return Organization.where(filters).fetchAll();
+    return Organization.where(filters).fetchAll({ withRelated: ['user'] });
   },
 
   getByUserId(userId) {

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -1,44 +1,33 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
 const Answer = require('../../../domain/models/data/answer');
 
-class AnswerSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('answer');
-  }
-
-  serializeAttributes(model, data) {
-    data.attributes.value = model.value;
-    data.attributes.timeout = model.timeout;
-    data.attributes['elapsed-time'] = model.elapsedTime;
-    data.attributes.result = model.result;
-    //data.attributes.resultDetails = model.resultDetails;
-    data.attributes['result-details'] = model.resultDetails;
-  }
-
-  serializeRelationships(model, data) {
-    data.relationships = {};
-
-    data.relationships.assessment = {
-      data: {
-        type: 'assessments',
-        id: model.assessmentId
+  serialize(snapshots) {
+    return new Serializer('answer', {
+      attributes: ['value', 'timeout', 'elapsedTime', 'result', 'resultDetails', 'assessment', 'challenge'],
+      assessment: {
+        ref: 'id',
+        includes: false
+      },
+      challenge: {
+        ref: 'id',
+        includes: false
+      },
+      transform: (snapshot) => {
+        const answer = Object.assign({}, snapshot.toJSON());
+        answer.assessment = { id: snapshot.get('assessmentId') };
+        answer.challenge = { id: snapshot.get('challengeId') };
+        return answer;
       }
-    };
-
-    data.relationships.challenge = {
-      data: {
-        type: 'challenges',
-        id: model.challengeId
-      }
-    };
-  }
+    }).serialize(snapshots);
+  },
 
   deserialize(json) {
     const answer = new Answer({
       value: json.data.attributes.value,
       result: json.data.attributes.result,
-      resultDetails : json.data.attributes['result-details'],
+      resultDetails: json.data.attributes['result-details'],
       timeout: json.data.attributes.timeout,
       elapsedTime: json.data.attributes['elapsed-time'],
       assessmentId: json.data.relationships.assessment.data.id,
@@ -52,6 +41,4 @@ class AnswerSerializer extends JSONAPISerializer {
     return answer;
   }
 
-}
-
-module.exports = new AnswerSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -3,7 +3,7 @@ const Answer = require('../../../domain/models/data/answer');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(answers) {
     return new Serializer('answer', {
       attributes: ['value', 'timeout', 'elapsedTime', 'result', 'resultDetails', 'assessment', 'challenge'],
       assessment: {
@@ -14,13 +14,13 @@ module.exports = {
         ref: 'id',
         includes: false
       },
-      transform: (snapshot) => {
-        const answer = Object.assign({}, snapshot.toJSON());
-        answer.assessment = { id: snapshot.get('assessmentId') };
-        answer.challenge = { id: snapshot.get('challengeId') };
+      transform: (model) => {
+        const answer = Object.assign({}, model.toJSON());
+        answer.assessment = { id: model.get('assessmentId') };
+        answer.challenge = { id: model.get('challengeId') };
         return answer;
       }
-    }).serialize(snapshots);
+    }).serialize(answers);
   },
 
   deserialize(json) {

--- a/api/lib/infrastructure/serializers/jsonapi/authentication-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/authentication-serializer.js
@@ -2,17 +2,18 @@ const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
 
-  serialize(authentication) {
+  serialize(authentications) {
 
     return new Serializer('authentication', {
       attributes: ['token', 'user_id', 'password'],
-      transform(record) {
-        record.user_id = record.user_id.toString();
-        record.id = record.user_id;
-        record.password = '';
-        return record;
+      transform(model) {
+        const authentication = Object.assign({}, model.toJSON());
+        authentication.user_id = model.user_id.toString();
+        authentication.id = model.user_id;
+        authentication.password = '';
+        return authentication;
       }
-    }).serialize(authentication);
+    }).serialize(authentications);
   }
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/authentication-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/authentication-serializer.js
@@ -1,10 +1,10 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { Serializer } = require('jsonapi-serializer');
 
-class AuthenticationSerializer {
+module.exports = {
 
   serialize(authentication) {
 
-    return new JSONAPISerializer('authentication', {
+    return new Serializer('authentication', {
       attributes: ['token', 'user_id', 'password'],
       transform(record) {
         record.user_id = record.user_id.toString();
@@ -14,6 +14,5 @@ class AuthenticationSerializer {
       }
     }).serialize(authentication);
   }
-}
 
-module.exports = new AuthenticationSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -1,10 +1,10 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
 
   serialize(certificationCourse) {
 
-    return new JSONAPISerializer('certification-courses', {
+    return new Serializer('certification-courses', {
       attributes : ['userId', 'assessment'],
       assessment: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -3,15 +3,15 @@ const _ = require('lodash');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(challenges) {
     return new Serializer('challenge', {
       attributes: ['type', 'instruction', 'competence', 'proposals', 'hasntInternetAllowed', 'timer', 'illustrationUrl', 'attachments'],
-      transform: (snapshot) => {
-        const challenge = Object.assign({}, snapshot);
-        challenge.competence = _.get(snapshot, 'competence[0]', 'N/A');
+      transform: (record) => {
+        const challenge = Object.assign({}, record);
+        challenge.competence = _.get(record, 'competence[0]', 'N/A');
         return challenge;
       }
-    }).serialize(snapshots);
+    }).serialize(challenges);
   }
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -1,27 +1,17 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
+const _ = require('lodash');
 
-class ChallengeSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('challenge');
+  serialize(snapshots) {
+    return new Serializer('challenge', {
+      attributes: ['type', 'instruction', 'competence', 'proposals', 'hasntInternetAllowed', 'timer', 'illustrationUrl', 'attachments'],
+      transform: (snapshot) => {
+        const challenge = Object.assign({}, snapshot);
+        challenge.competence = _.get(snapshot, 'competence[0]', 'N/A');
+        return challenge;
+      }
+    }).serialize(snapshots);
   }
 
-  serializeAttributes(model, data) {
-    data.attributes['type'] = model.type;
-    data.attributes['instruction'] = model.instruction;
-    data.attributes['competence'] = (model.competence) ? model.competence[0] : undefined;
-    data.attributes['proposals'] = model.proposals;
-    data.attributes['hasnt-internet-allowed'] = model.hasntInternetAllowed;
-    data.attributes['timer'] = model.timer;
-
-    if (model.illustrationUrl) {
-      data.attributes['illustration-url'] = model.illustrationUrl;
-    }
-
-    if (model.attachments) {
-      data.attributes['attachments'] = model.attachments;
-    }
-  }
-}
-
-module.exports = new ChallengeSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
@@ -1,9 +1,9 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
 
   serialize(courses) {
-    return new JSONAPISerializer('course', {
+    return new Serializer('course', {
       attributes: ['name', 'description', 'duration', 'isAdaptive', 'nbChallenges', 'imageUrl'],
       transform(record) {
         const course = Object.assign({}, record);

--- a/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -1,11 +1,10 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
-const JSONAPIDeserializer = require('jsonapi-serializer').Deserializer;
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 const Feedback = require('../../../domain/models/data/feedback');
 
 module.exports = {
 
   serialize(feedback) {
-    return new JSONAPISerializer('feedbacks', {
+    return new Serializer('feedbacks', {
       attributes: ['createdAt', 'content', 'assessment', 'challenge'],
       assessment: { ref: 'id' },
       challenge: { ref: 'id' },
@@ -19,7 +18,7 @@ module.exports = {
   },
 
   deserialize(json) {
-    return new JSONAPIDeserializer()
+    return new Deserializer()
       .deserialize(json, function(err, feedback) {
         feedback.assessmentId = json.data.relationships.assessment.data.id;
         feedback.challengeId = json.data.relationships.challenge.data.id;

--- a/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -3,18 +3,18 @@ const Feedback = require('../../../domain/models/data/feedback');
 
 module.exports = {
 
-  serialize(feedback) {
+  serialize(feedbacks) {
     return new Serializer('feedbacks', {
       attributes: ['createdAt', 'content', 'assessment', 'challenge'],
       assessment: { ref: 'id' },
       challenge: { ref: 'id' },
-      transform(feedback) {
-        feedback.id = feedback.id.toString();
-        feedback.assessment = { id: feedback.assessmentId };
-        feedback.challenge = { id: feedback.challengeId };
+      transform(json) {
+        const feedback = Object.assign({}, json);
+        feedback.assessment = { id: json.assessmentId };
+        feedback.challenge = { id: json.challengeId };
         return feedback;
       }
-    }).serialize(feedback);
+    }).serialize(feedbacks);
   },
 
   deserialize(json) {

--- a/api/lib/infrastructure/serializers/jsonapi/follower-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/follower-serializer.js
@@ -1,21 +1,19 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
 const Follower = require('../../../domain/models/data/follower');
 
-class FollowerSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('followers');
-  }
-
-  serializeAttributes(model, data) {
-    data.attributes.email = model.email;
-  }
+  serialize(snapshots) {
+    return new Serializer('follower', {
+      attributes: ['email'],
+      transform: (snapshot) => snapshot.toJSON()
+    }).serialize(snapshots);
+  },
 
   deserialize(jsonApi) {
     return new Follower({
       email: jsonApi.data.attributes.email
     });
   }
-}
 
-module.exports = new FollowerSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/follower-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/follower-serializer.js
@@ -3,11 +3,11 @@ const Follower = require('../../../domain/models/data/follower');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(followers) {
     return new Serializer('follower', {
       attributes: ['email'],
-      transform: (snapshot) => snapshot.toJSON()
-    }).serialize(snapshots);
+      transform: (model) => model.toJSON()
+    }).serialize(followers);
   },
 
   deserialize(jsonApi) {

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -3,19 +3,19 @@ const Organization = require('../../../domain/models/data/organization');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(organizations) {
     return new Serializer('organizations', {
       attributes: ['name', 'type', 'email', 'code', 'user'],
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName', 'email']
       },
-      transform: (snapshot) => {
-        const organization = Object.assign({}, snapshot.toJSON());
-        organization.user = snapshot.user.toJSON();
+      transform: (model) => {
+        const organization = Object.assign({}, model.toJSON());
+        organization.user = model.user.toJSON();
         return organization;
       }
-    }).serialize(snapshots);
+    }).serialize(organizations);
   },
 
   deserialize(json) {

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -10,8 +10,7 @@ module.exports = {
         ref: 'id',
         attributes: ['firstName', 'lastName', 'email'],
         included: true,
-      },
-      transform: model => Object.assign({}, model.toJSON())
+      }
     }).serialize(organizations);
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -10,6 +10,9 @@ module.exports = {
         ref: 'id',
         attributes: ['firstName', 'lastName', 'email'],
         included: true,
+      },
+      transform(record) {
+        return Object.assign({}, record.toJSON());
       }
     }).serialize(organizations);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -8,13 +8,10 @@ module.exports = {
       attributes: ['name', 'type', 'email', 'code', 'user'],
       user: {
         ref: 'id',
-        attributes: ['firstName', 'lastName', 'email']
+        attributes: ['firstName', 'lastName', 'email'],
+        included: true,
       },
-      transform: (model) => {
-        const organization = Object.assign({}, model.toJSON());
-        organization.user = model.user.toJSON();
-        return organization;
-      }
+      transform: model => Object.assign({}, model.toJSON())
     }).serialize(organizations);
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -1,53 +1,22 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
 const Organization = require('../../../domain/models/data/organization');
 
-class OrganizationSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('organization');
-  }
-
-  serialize(modelObject) {
-    const response = super.serialize(modelObject);
-
-    response.included = [];
-    response.included.push(this.serializeIncluded(modelObject.user));
-
-    return response;
-  }
-
-  serializeAttributes(model, data) {
-    data.attributes['name'] = model.name;
-    data.attributes['type'] = model.type;
-    data.attributes['email'] = model.email;
-    data.attributes['code'] = model.code;
-  }
-
-  serializeRelationships(model, data) {
-    data.relationships = {
+  serialize(snapshots) {
+    return new Serializer('organizations', {
+      attributes: ['name', 'type', 'email', 'code', 'user'],
       user: {
-        data: { type: 'users', id: model.userId }
+        ref: 'id',
+        attributes: ['firstName', 'lastName', 'email']
+      },
+      transform: (snapshot) => {
+        const organization = Object.assign({}, snapshot.toJSON());
+        organization.user = snapshot.user.toJSON();
+        return organization;
       }
-    };
-  }
-
-  serializeIncluded(model) {
-    let response = {};
-
-    if(model.attributes) {
-      response = {
-        type: 'users',
-        id: model.id,
-        attributes: {
-          email: model.attributes.email,
-          'first-name': model.attributes.firstName,
-          'last-name': model.attributes.lastName,
-        }
-      };
-    }
-
-    return response;
-  }
+    }).serialize(snapshots);
+  },
 
   deserialize(json) {
     return new Organization({
@@ -57,17 +26,4 @@ class OrganizationSerializer extends JSONAPISerializer {
     });
   }
 
-  serializeArray(modelObjects) {
-    const response = {};
-    response.data = [];
-
-    for (const modelObject of modelObjects) {
-      response.data.push(this.serializeModelObject(modelObject));
-    }
-
-    return response;
-  }
-
-}
-
-module.exports = new OrganizationSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
@@ -1,11 +1,9 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-
-  serialize(snapshots) {
+  serialize(password) {
     return new Serializer('password-reset-demand', {
       attributes: ['email', 'temporaryKey']
-    }).serialize(snapshots);
+    }).serialize(password);
   }
-
 };

--- a/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
@@ -1,8 +1,8 @@
-const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(passwordResetDemands) {
-    return new JSONAPISerializer('password-reset-demand', {
+    return new Serializer('password-reset-demand', {
       attributes: ['email', 'temporaryKey'],
       transform(passwordResetDemand) {
         passwordResetDemand.id = passwordResetDemand.id.toString();

--- a/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
@@ -1,13 +1,11 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(passwordResetDemands) {
+
+  serialize(snapshots) {
     return new Serializer('password-reset-demand', {
-      attributes: ['email', 'temporaryKey'],
-      transform(passwordResetDemand) {
-        passwordResetDemand.id = passwordResetDemand.id.toString();
-        return passwordResetDemand;
-      }
-    }).serialize(passwordResetDemands);
+      attributes: ['email', 'temporaryKey']
+    }).serialize(snapshots);
   }
+
 };

--- a/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/password-reset-serializer.js
@@ -1,9 +1,11 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(password) {
+
+  serialize(passwordResetDemands) {
     return new Serializer('password-reset-demand', {
       attributes: ['email', 'temporaryKey']
-    }).serialize(password);
+    }).serialize(passwordResetDemands);
   }
+
 };

--- a/api/lib/infrastructure/serializers/jsonapi/snapshot-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/snapshot-serializer.js
@@ -9,10 +9,10 @@ module.exports = {
         ref: 'id',
         attributes: ['firstName', 'lastName']
       },
-      transform(snapshot) {
-        snapshot.id = snapshot.id.toString();
-        snapshot.completionPercentage = snapshot.completionPercentage && snapshot.completionPercentage.toString() || null;
-        snapshot.score = snapshot.score && snapshot.score.toString() || null;
+      transform(json) {
+        const snapshot = Object.assign({}, json);
+        snapshot.completionPercentage = json.completionPercentage && json.completionPercentage.toString() || null;
+        snapshot.score = json.score && json.score.toString() || null;
         return snapshot;
       }
     }).serialize(snapshots);

--- a/api/lib/infrastructure/serializers/jsonapi/solution-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/solution-serializer.js
@@ -2,10 +2,10 @@ const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(solutions) {
     return new Serializer('solutions', {
       attributes: ['value']
-    }).serialize(snapshots);
+    }).serialize(solutions);
   }
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/solution-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/solution-serializer.js
@@ -1,14 +1,11 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
 
-class SolutionSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('solutions');
+  serialize(snapshots) {
+    return new Serializer('solutions', {
+      attributes: ['value']
+    }).serialize(snapshots);
   }
 
-  serializeAttributes(model, data) {
-    data.attributes['value'] = model.value;
-  }
-}
-
-module.exports = new SolutionSerializer();
+};

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -3,11 +3,11 @@ const User = require('../../../domain/models/data/user');
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(users) {
     return new Serializer('user', {
       attributes: ['firstName', 'lastName'],
-      transform: (snapshot) => snapshot.toJSON()
-    }).serialize(snapshots);
+      transform: (model) => model.toJSON()
+    }).serialize(users);
   },
 
   deserialize(json) {

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -1,16 +1,14 @@
-const JSONAPISerializer = require('./jsonapi-serializer');
+const { Serializer } = require('jsonapi-serializer');
 const User = require('../../../domain/models/data/user');
 
-class UserSerializer extends JSONAPISerializer {
+module.exports = {
 
-  constructor() {
-    super('user');
-  }
-
-  serializeAttributes(model, data) {
-    data.attributes['first-name'] = model.firstName;
-    data.attributes['last-name'] = model.lastName;
-  }
+  serialize(snapshots) {
+    return new Serializer('user', {
+      attributes: ['firstName', 'lastName'],
+      transform: (snapshot) => snapshot.toJSON()
+    }).serialize(snapshots);
+  },
 
   deserialize(json) {
     return new User({
@@ -23,6 +21,4 @@ class UserSerializer extends JSONAPISerializer {
     });
   }
 
-}
-
-module.exports = new UserSerializer();
+};

--- a/api/tests/acceptance/application/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answer-controller-save_test.js
@@ -106,7 +106,7 @@ describe('Acceptance | Controller | answer-controller-save', function() {
               expect(model.get('assessmentId')).to.equal(options.payload.data.relationships.assessment.data.id);
               expect(model.get('challengeId')).to.equal(options.payload.data.relationships.challenge.data.id);
 
-              expect(answer.id).to.equal(model.id);
+              expect(answer.id).to.equal(model.id.toString());
               expect(answer.id).to.equal(response.result.data.id);
               expect(answer.attributes.value).to.equal(model.get('value'));
               expect(answer.attributes.result).to.equal(model.get('result'));

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -136,7 +136,7 @@ describe('Acceptance | Controller | answer-controller', function() {
           .then(function(model) {
 
             // then
-            expect(answer.id).to.equal(model.id);
+            expect(answer.id).to.equal(model.id.toString());
             expect(answer.id).to.equal(response.result.data.id);
             expect(answer.attributes['value']).to.equal(model.get('value'));
             expect(answer.attributes['elapsed-time']).to.equal(model.get('elapsedTime'));

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -65,6 +65,7 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
       .reply(200, {
         'id': 'first_challenge',
         'fields': {
+          'competences': ['competence_id'],
           // a bunch of fields
         },
       });
@@ -74,6 +75,7 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
       .reply(200, {
         'id': 'second_challenge',
         'fields': {
+          'competences': ['competence_id'],
           // a bunch of fields
         },
       });

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -24,22 +24,22 @@ describe('Unit | Controller | challenge-controller', function() {
       new Challenge({ 'id': 'challenge_3' })
     ];
 
-    it('should fetch and return all the challenges, serialized as JSONAPI', function(done) {
+    it('should fetch and return all the challenges, serialized as JSONAPI', () => {
       // given
       sinon.stub(ChallengeRepository, 'list').resolves(challenges);
       sinon.stub(ChallengeSerializer, 'serialize').callsFake(_ => challenges);
 
       // when
-      server.inject({ method: 'GET', url: '/api/challenges' }, (res) => {
+      return server.inject({ method: 'GET', url: '/api/challenges' })
+        .then(res => {
 
         // then
-        expect(res.result).to.deep.equal(challenges);
+          expect(res.result).to.deep.equal(challenges);
 
-        // after
-        ChallengeRepository.list.restore();
-        ChallengeSerializer.serialize.restore();
-        done();
-      });
+          // after
+          ChallengeRepository.list.restore();
+          ChallengeSerializer.serialize.restore();
+        });
     });
   });
 
@@ -47,25 +47,24 @@ describe('Unit | Controller | challenge-controller', function() {
 
     const challenge = new Challenge({ 'id': 'challenge_id' });
 
-    it('should fetch and return the given challenge, serialized as JSONAPI', function(done) {
+    it('should fetch and return the given challenge, serialized as JSONAPI', () => {
       // given
       sinon.stub(ChallengeRepository, 'get').resolves(challenge);
       sinon.stub(ChallengeSerializer, 'serialize').callsFake(_ => challenge);
 
       // when
-      server.inject({ method: 'GET', url: '/api/challenges/challenge_id' }, (res) => {
+      return server.inject({ method: 'GET', url: '/api/challenges/challenge_id' })
+        .then(res => {
+          // then
+          expect(res.result).to.deep.equal(challenge);
 
-        // then
-        expect(res.result).to.deep.equal(challenge);
-
-        // after
-        ChallengeRepository.get.restore();
-        ChallengeSerializer.serialize.restore();
-        done();
-      });
+          // after
+          ChallengeRepository.get.restore();
+          ChallengeSerializer.serialize.restore();
+        });
     });
 
-    it('should reply with error status code 404 if challenge not found', function(done) {
+    it('should reply with error status code 404 if challenge not found', () => {
       // given
       const error = {
         'error': {
@@ -76,21 +75,20 @@ describe('Unit | Controller | challenge-controller', function() {
       sinon.stub(ChallengeRepository, 'get').rejects(error);
 
       // when
-      server.inject({ method: 'GET', url: '/api/challenges/unknown_id' }, (res) => {
+      return server.inject({ method: 'GET', url: '/api/challenges/unknown_id' })
+        .then(res => {
+          // then
+          expect(res.statusCode).to.equal(404);
 
-        // then
-        expect(res.statusCode).to.equal(404);
-
-        // after
-        ChallengeRepository.get.restore();
-        done();
-      });
+          // after
+          ChallengeRepository.get.restore();
+        });
     });
   });
 
   describe('#refreshSolution', function() {
 
-    it('should refresh all the given challenge solutions', function(done) {
+    it('should refresh all the given challenge solutions', () => {
       // given
       const solution = new Solution({
         id: 1,
@@ -101,16 +99,15 @@ describe('Unit | Controller | challenge-controller', function() {
       sinon.stub(SolutionRepository, 'refresh').resolves(solution);
 
       // when
-      server.inject({ method: 'POST', url: '/api/challenges/challenge_id/solution' }, (res) => {
+      return server.inject({ method: 'POST', url: '/api/challenges/challenge_id/solution' })
+        .then(res => {
+          // then
+          expect(res.result).to.equal('ok');
+          sinon.assert.calledOnce(SolutionRepository.refresh);
 
-        // then
-        expect(res.result).to.equal('ok');
-        sinon.assert.calledOnce(SolutionRepository.refresh);
-
-        // after
-        SolutionRepository.refresh.restore();
-        done();
-      });
+          // after
+          SolutionRepository.refresh.restore();
+        });
     });
 
   });

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -27,7 +27,7 @@ describe('Unit | Controller | challenge-controller', function() {
     it('should fetch and return all the challenges, serialized as JSONAPI', function(done) {
       // given
       sinon.stub(ChallengeRepository, 'list').resolves(challenges);
-      sinon.stub(ChallengeSerializer, 'serializeArray').callsFake(_ => challenges);
+      sinon.stub(ChallengeSerializer, 'serialize').callsFake(_ => challenges);
 
       // when
       server.inject({ method: 'GET', url: '/api/challenges' }, (res) => {
@@ -37,7 +37,7 @@ describe('Unit | Controller | challenge-controller', function() {
 
         // after
         ChallengeRepository.list.restore();
-        ChallengeSerializer.serializeArray.restore();
+        ChallengeSerializer.serialize.restore();
         done();
       });
     });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -303,7 +303,7 @@ describe('Unit | Controller | organizationController', () => {
 
       sandbox.stub(logger, 'error');
       sandbox.stub(organisationRepository, 'findBy').resolves(arrayOfOrganizations);
-      sandbox.stub(organizationSerializer, 'serializeArray').returns(arrayOfSerializedOrganization);
+      sandbox.stub(organizationSerializer, 'serialize').returns(arrayOfSerializedOrganization);
     });
 
     afterEach(() => {
@@ -383,7 +383,7 @@ describe('Unit | Controller | organizationController', () => {
 
         // then
         return promise.then(() => {
-          sinon.assert.calledWith(organizationSerializer.serializeArray, arrayOfOrganizations.models);
+          sinon.assert.calledWith(organizationSerializer.serialize, arrayOfOrganizations.models);
           sinon.assert.calledWith(replyStub, arrayOfSerializedOrganization);
         });
       });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -294,7 +294,7 @@ describe('Unit | Controller | organizationController', () => {
     let replyStub;
     let codeStub;
     const arrayOfSerializedOrganization = [{}, {}];
-    const arrayOfOrganizations = { models: [new Organisation(), new Organisation()] };
+    const arrayOfOrganizations = [new Organisation(), new Organisation()];
 
     beforeEach(() => {
       codeStub = sinon.stub();
@@ -383,7 +383,7 @@ describe('Unit | Controller | organizationController', () => {
 
         // then
         return promise.then(() => {
-          sinon.assert.calledWith(organizationSerializer.serialize, arrayOfOrganizations.models);
+          sinon.assert.calledWith(organizationSerializer.serialize, arrayOfOrganizations);
           sinon.assert.calledWith(replyStub, arrayOfSerializedOrganization);
         });
       });

--- a/api/tests/unit/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/organization-repository_test.js
@@ -18,11 +18,11 @@ describe('Unit | Repository | OrganizationRepository', function() {
       cgu: true
     };
 
-    before(() => {
+    beforeEach(() => {
       return knex('users').insert(inserted_user);
     });
 
-    after(() => {
+    afterEach(() => {
       return knex('users').delete();
     });
 
@@ -299,7 +299,7 @@ describe('Unit | Repository | OrganizationRepository', function() {
     it('should return Organization that matches filters', function() {
       // given
       const fetchStub = sinon.stub().resolves();
-      sinon.stub(Organization, 'where').returns({ fetchAll: fetchStub });
+      sinon.stub(Organization.prototype, 'where').returns({ fetchAll: fetchStub });
 
       // when
       const filters = { code: 1234 };
@@ -307,9 +307,61 @@ describe('Unit | Repository | OrganizationRepository', function() {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledWith(Organization.where, filters);
-        sinon.assert.callOrder(Organization.where, fetchStub);
+        sinon.assert.calledWith(Organization.prototype.where, filters);
+        sinon.assert.callOrder(Organization.prototype.where, fetchStub);
+        Organization.prototype.where.restore();
       });
     });
+
+    describe('should return associated user with organization', function() {
+
+      const userPassword = bcrypt.hashSync('A124B2C3#!', 1);
+      const associatedUser = {
+        firstName: faker.name.firstName(),
+        lastName: faker.name.lastName(),
+        email: faker.internet.email(),
+        password: userPassword,
+        cgu: true
+      };
+      const insertedOrganization = {
+        email: faker.internet.email(),
+        type: 'PRO',
+        name: faker.name.firstName(),
+        code: 'ABCD01',
+      };
+
+      beforeEach(() => {
+        return knex('users').returning('id').insert(associatedUser)
+          .then(userIdArray => {
+            insertedOrganization.userId = userIdArray[0];
+            return knex('organizations').insert(insertedOrganization);
+          });
+      });
+
+      afterEach(() => {
+        return knex('users').delete()
+          .then(() => {
+            return knex('organizations').delete();
+          });
+      });
+
+      it('should return found Organization with associated user', function() {
+        // given
+        const filters = { code: 'ABCD01' };
+
+        // when
+        const promise = OrganizationRepository.findBy(filters);
+
+        // then
+        return promise.then(organizations => {
+          const organization = organizations.models[0];
+
+          expect(organization.get('email')).to.equal(insertedOrganization.email);
+          expect(organization.related('user').get('email')).to.equal(associatedUser.email);
+        });
+      });
+
+    });
+
   });
 });

--- a/api/tests/unit/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/organization-repository_test.js
@@ -298,7 +298,7 @@ describe('Unit | Repository | OrganizationRepository', function() {
 
     it('should return Organization that matches filters', function() {
       // given
-      const fetchStub = sinon.stub().resolves();
+      const fetchStub = sinon.stub().resolves({ models: {} });
       sinon.stub(Organization.prototype, 'where').returns({ fetchAll: fetchStub });
 
       // when
@@ -354,7 +354,7 @@ describe('Unit | Repository | OrganizationRepository', function() {
 
         // then
         return promise.then(organizations => {
-          const organization = organizations.models[0];
+          const organization = organizations[0];
 
           expect(organization.get('email')).to.equal(insertedOrganization.email);
           expect(organization.related('user').get('email')).to.equal(associatedUser.email);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -15,7 +15,6 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
     challengeId: 'challenge_id'
   });
 
-
   const jsonAnswer = {
     data: {
       type: 'answers',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -15,9 +15,10 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
     challengeId: 'challenge_id'
   });
 
+
   const jsonAnswer = {
     data: {
-      type: 'answer',
+      type: 'answers',
       id: 'answer_id',
       attributes: {
         value: 'answer_value',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
     challengeId: 'challenge_id'
   });
 
+
   const jsonAnswer = {
     data: {
       type: 'answers',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -10,11 +10,10 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
     timeout: 8,
     elapsedTime: 30,
     result: 'result_value',
-    resultDetails : 'resultDetails_value',
+    resultDetails: 'resultDetails_value',
     assessmentId: 'assessment_id',
     challengeId: 'challenge_id'
   });
-
 
   const jsonAnswer = {
     data: {
@@ -22,7 +21,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
       id: 'answer_id',
       attributes: {
         value: 'answer_value',
-        'result-details' : 'resultDetails_value',
+        'result-details': 'resultDetails_value',
         timeout: 8,
         'elapsed-time': 30,
         result: 'result_value'

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -7,7 +7,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
   describe('#serialize()', function() {
 
     it('should convert a Challenge model object into JSON API data', function() {
-
+      // given
       const challenge = new Challenge();
       challenge.id = 'challenge_id';
       challenge.instruction = 'Que peut-on dire des œufs de catégorie A ?';
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
       // then
       expect(json).to.deep.equal({
         data: {
-          type: 'challenge',
+          type: 'challenges',
           id: challenge.id,
           attributes: {
             instruction: challenge.instruction,
@@ -47,6 +47,51 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
           }
         }
       });
+    });
+
+    describe('field "competence"', () => {
+
+      it('should be the the first associated to the challenge when it exists', () => {
+        // given
+        const challenge = new Challenge();
+        challenge.id = 1;
+        challenge.competence = ['competence_id'];
+
+        // when
+        const json = serializer.serialize(challenge);
+
+        // then
+        expect(json).to.deep.equal({
+          data: {
+            type: 'challenges',
+            id: '1',
+            attributes: {
+              competence: 'competence_id',
+            }
+          }
+        });
+      });
+
+      it('should be null when no competence is associated to the challenge (ex: DEMO course)', () => {
+        // given
+        const challenge = new Challenge();
+        challenge.id = 1;
+
+        // when
+        const json = serializer.serialize(challenge);
+
+        // then
+        expect(json).to.deep.equal({
+          data: {
+            type: 'challenges',
+            id: '1',
+            attributes: {
+              competence: 'N/A',
+            }
+          }
+        });
+      });
+
     });
 
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -1,7 +1,6 @@
 const { describe, it, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
 const Organization = require('../../../../../lib/domain/models/data/organization');
-const User = require('../../../../../lib/domain/models/data/user');
 
 const faker = require('faker');
 
@@ -11,12 +10,6 @@ describe('Unit | Serializer | organization-serializer', () => {
     context('when user is defined', () => {
       it('should serialize organization with included user', () => {
         // Given
-        const jsonUser = {
-          'id': 42157,
-          'firstName': 'Alexander',
-          'lastName': 'Luthor',
-          'email': 'lex@lexcorp.com'
-        };
         const jsonOrganization = {
           id: 12,
           name: 'LexCorp',
@@ -24,7 +17,12 @@ describe('Unit | Serializer | organization-serializer', () => {
           email: 'lex@lexcorp.com',
           code: 'ABCD66',
           userId: '42157',
-          user: jsonUser
+          user: {
+            id: 42157,
+            firstName: 'Alexander',
+            lastName: 'Luthor',
+            email: 'lex@lexcorp.com'
+          }
         };
         const organization = new Organization(jsonOrganization);
 
@@ -69,15 +67,14 @@ describe('Unit | Serializer | organization-serializer', () => {
         email: faker.internet.email(),
         type: 'PRO',
         code: 'ABCD12',
-        userId: 3
+        userId: 3,
+        user: {
+          id: 3,
+          firstName: 'Ezzio',
+          lastName: 'Auditore',
+          email: 'ezzio@firenze.it'
+        }
       });
-      const userFromOrganizationOne = new User({
-        'firstName': 'Ezzio',
-        'lastName': 'Auditore',
-        'email': 'ezzio@firenze.it'
-      });
-      userFromOrganizationOne.set('id', 3);
-      organizationOne.relations.user = userFromOrganizationOne;
 
       const organizationTwo = new Organization({
         id: 2,
@@ -85,15 +82,14 @@ describe('Unit | Serializer | organization-serializer', () => {
         email: faker.internet.email(),
         type: 'PRO',
         code: 'EFGH54',
-        userId: 4
+        userId: 4,
+        user: {
+          id: 4,
+          firstName: 'Bayek',
+          lastName: 'Siwa',
+          email: 'bayek@siwa.eg'
+        }
       });
-      const userFromOrganizationTwo = new User({
-        'firstName': 'Bayek',
-        'lastName': 'Siwa',
-        'email': 'bayek@siwa.eg'
-      });
-      userFromOrganizationTwo.set('id', 4);
-      organizationTwo.relations.user = userFromOrganizationTwo;
 
       const expectedJsonApi = {
         data: [{
@@ -134,7 +130,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         }],
         included: [{
           attributes: {
-            'email': 'ezzio@firenze.it',
+            email: 'ezzio@firenze.it',
             'first-name': 'Ezzio',
             'last-name': 'Auditore'
           },
@@ -142,7 +138,7 @@ describe('Unit | Serializer | organization-serializer', () => {
           type: 'users'
         }, {
           attributes: {
-            'email': 'bayek@siwa.eg',
+            email: 'bayek@siwa.eg',
             'first-name': 'Bayek',
             'last-name': 'Siwa'
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -8,53 +8,56 @@ const faker = require('faker');
 describe('Unit | Serializer | organization-serializer', () => {
 
   describe('#serialize', () => {
-    it('should turn an object to JSON', () => {
-      // Given
-      const user = new User({
-        'firstName': 'Alexander',
-        'lastName': 'Luthor',
-        'email': 'lex@lexcorp.com'
-      });
-      user.set('id', 42157);
-      const organization = new Organization({
-        id: 12,
-        name: 'LexCorp',
-        type: 'PRO',
-        email: 'lex@lexcorp.com',
-        code: 'ABCD66',
-        userId: '42157'
-      });
-      organization.user = user;
+    context('when user is defined', () => {
+      it('should serialize organization with included user', () => {
+        // Given
+        const jsonUser = {
+          'id': 42157,
+          'firstName': 'Alexander',
+          'lastName': 'Luthor',
+          'email': 'lex@lexcorp.com'
+        };
+        const jsonOrganization = {
+          id: 12,
+          name: 'LexCorp',
+          type: 'PRO',
+          email: 'lex@lexcorp.com',
+          code: 'ABCD66',
+          userId: '42157',
+          user: jsonUser
+        };
+        const organization = new Organization(jsonOrganization);
 
-      // When
-      const jsonOrganization = serializer.serialize(organization);
+        // When
+        const serializedOrganization = serializer.serialize(organization);
 
-      // Then
-      expect(jsonOrganization).to.deep.equal({
-        data: {
-          type: 'organizations',
-          id: '12',
-          attributes: {
-            name: 'LexCorp',
-            email: 'lex@lexcorp.com',
-            type: 'PRO',
-            code: 'ABCD66'
-          },
-          relationships: {
-            user: {
-              data: { type: 'users', id: '42157' }
+        // Then
+        expect(serializedOrganization).to.deep.equal({
+          data: {
+            type: 'organizations',
+            id: '12',
+            attributes: {
+              name: 'LexCorp',
+              email: 'lex@lexcorp.com',
+              type: 'PRO',
+              code: 'ABCD66'
             },
-          }
-        },
-        included: [{
-          id: '42157',
-          type: 'users',
-          attributes: {
-            'first-name': 'Alexander',
-            'last-name': 'Luthor',
-            email: 'lex@lexcorp.com'
-          }
-        }]
+            relationships: {
+              user: {
+                data: { type: 'users', id: '42157' }
+              },
+            }
+          },
+          included: [{
+            id: '42157',
+            type: 'users',
+            attributes: {
+              'first-name': 'Alexander',
+              'last-name': 'Luthor',
+              email: 'lex@lexcorp.com'
+            }
+          }]
+        });
       });
     });
 
@@ -74,7 +77,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         'email': 'ezzio@firenze.it'
       });
       userFromOrganizationOne.set('id', 3);
-      organizationOne.user = userFromOrganizationOne;
+      organizationOne.relations.user = userFromOrganizationOne;
 
       const organizationTwo = new Organization({
         id: 2,
@@ -90,7 +93,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         'email': 'bayek@siwa.eg'
       });
       userFromOrganizationTwo.set('id', 4);
-      organizationTwo.user = userFromOrganizationTwo;
+      organizationTwo.relations.user = userFromOrganizationTwo;
 
       const expectedJsonApi = {
         data: [{

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -32,8 +32,8 @@ describe('Unit | Serializer | organization-serializer', () => {
       // Then
       expect(jsonOrganization).to.deep.equal({
         data: {
-          type: 'organization',
-          id: 12,
+          type: 'organizations',
+          id: '12',
           attributes: {
             name: 'LexCorp',
             email: 'lex@lexcorp.com',
@@ -47,7 +47,7 @@ describe('Unit | Serializer | organization-serializer', () => {
           }
         },
         included: [{
-          id: 42157,
+          id: '42157',
           type: 'users',
           attributes: {
             'first-name': 'Alexander',
@@ -57,6 +57,104 @@ describe('Unit | Serializer | organization-serializer', () => {
         }]
       });
     });
+
+    it('should serialize an array of organization', () => {
+      // given
+      const organizationOne = new Organization({
+        id: 1,
+        name: faker.name.firstName(),
+        email: faker.internet.email(),
+        type: 'PRO',
+        code: 'ABCD12',
+        userId: 3
+      });
+      const userFromOrganizationOne = new User({
+        'firstName': 'Ezzio',
+        'lastName': 'Auditore',
+        'email': 'ezzio@firenze.it'
+      });
+      userFromOrganizationOne.set('id', 3);
+      organizationOne.user = userFromOrganizationOne;
+
+      const organizationTwo = new Organization({
+        id: 2,
+        name: faker.name.firstName(),
+        email: faker.internet.email(),
+        type: 'PRO',
+        code: 'EFGH54',
+        userId: 4
+      });
+      const userFromOrganizationTwo = new User({
+        'firstName': 'Bayek',
+        'lastName': 'Siwa',
+        'email': 'bayek@siwa.eg'
+      });
+      userFromOrganizationTwo.set('id', 4);
+      organizationTwo.user = userFromOrganizationTwo;
+
+      const expectedJsonApi = {
+        data: [{
+          type: 'organizations',
+          id: '1',
+          attributes: {
+            name: organizationOne.get('name'),
+            type: organizationOne.get('type'),
+            email: organizationOne.get('email'),
+            code: organizationOne.get('code'),
+          },
+          relationships: {
+            user: {
+              data: {
+                id: '3',
+                type: 'users'
+              }
+            }
+          }
+        }, {
+          type: 'organizations',
+          id: '2',
+          attributes: {
+            name: organizationTwo.get('name'),
+            type: organizationTwo.get('type'),
+            email: organizationTwo.get('email'),
+            code: organizationTwo.get('code'),
+          },
+          relationships: {
+            user: {
+              data: {
+                id: '4',
+                type: 'users'
+              }
+            }
+          }
+
+        }],
+        included: [{
+          attributes: {
+            'email': 'ezzio@firenze.it',
+            'first-name': 'Ezzio',
+            'last-name': 'Auditore'
+          },
+          id: '3',
+          type: 'users'
+        }, {
+          attributes: {
+            'email': 'bayek@siwa.eg',
+            'first-name': 'Bayek',
+            'last-name': 'Siwa'
+          },
+          id: '4',
+          type: 'users'
+        }]
+      };
+
+      // when
+      const serializedArray = serializer.serialize([organizationOne, organizationTwo]);
+
+      // then
+      expect(serializedArray).to.deep.equal(expectedJsonApi);
+    });
+
   });
 
   describe('#deserialize', () => {
@@ -85,76 +183,6 @@ describe('Unit | Serializer | organization-serializer', () => {
 
       // then
       expect(deserializedObject.toJSON()).to.deep.equal(expectedModelObject.toJSON());
-    });
-
-  });
-
-  describe('#serializeArray', () => {
-
-    it('should serialize an array of organization', () => {
-      // given
-      const organizationOne = new Organization({
-        id: 1,
-        name: faker.name.firstName(),
-        email: faker.internet.email(),
-        type: 'PRO',
-        code: 'ABCD12',
-        userId: 3
-      });
-
-      const organizationTwo = new Organization({
-        id: 2,
-        name: faker.name.firstName(),
-        email: faker.internet.email(),
-        type: 'PRO',
-        code: 'EFGH54',
-        userId: 4
-      });
-
-      const expectedJsonApi = {
-        data: [{
-          type: 'organization',
-          id: 1,
-          attributes: {
-            name: organizationOne.get('name'),
-            type: organizationOne.get('type'),
-            email: organizationOne.get('email'),
-            code: organizationOne.get('code'),
-          },
-          relationships: {
-            user: {
-              data: {
-                id: 3,
-                type: 'users'
-              }
-            }
-          }
-        }, {
-          type: 'organization',
-          id: 2,
-          attributes: {
-            name: organizationTwo.get('name'),
-            type: organizationTwo.get('type'),
-            email: organizationTwo.get('email'),
-            code: organizationTwo.get('code'),
-          },
-          relationships: {
-            user: {
-              data: {
-                id: 4,
-                type: 'users'
-              }
-            }
-          }
-
-        }]
-      };
-
-      // when
-      const serializedArray = serializer.serializeArray([organizationOne, organizationTwo]);
-
-      // then
-      expect(serializedArray).to.deep.equal(expectedJsonApi);
     });
 
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -42,7 +42,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'last-name': 'Skywalker',
           },
           id: '234567',
-          type: 'user'
+          type: 'users'
         }
       });
     });


### PR DESCRIPTION
Cette PR ne concerne que les serializers JSON API de l'API.

**Nettoyage effectué pour chacun des serializers :** 
- utilisation de la classe `Serializer` de la lib jsonapi-serializer
- transformation de la classe en module
- suppression de la méthode `serializeArray` si existante (remplacée magiquement par la méthode `serialize`)
- correction dans les tests du type attendu (la spec exige un "s" à la fin de la ressource, ce que suit parfaitement la lib)

**Les serializers remis au standard :** 
- UserSerializer
- SolutionSerializer
- PasswordResetSerializer
- OrganizationSerializer
- AuthenticationSerializer
- CertificationCourseSerializer
- AnswerSerializer
- FollowerSerializer
- FeedbackSerializer
- CourseSerializer
- ChallengeSerializer

**Les serializers restant :**
- AssessmentSerializer (facile)
- CourseGroupSerializer (compliqué)
- JSONAPISerializer à supprimer
- ProfileSerializer (très compliqué)
- ValidationErrorSerializer (compliqué)