### PR TITLE
[#612] [BUGFIX] Réparation du lancement des tests de positionnement (US-1002).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
@@ -1,14 +1,18 @@
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
 module.exports = {
-  serialize(course) {
+
+  serialize(snapshots) {
     return new JSONAPISerializer('course', {
       attributes: ['name', 'description', 'duration', 'isAdaptive', 'nbChallenges', 'imageUrl'],
-      transform(course) {
-        course.id = course.id.toString();
-        course.nbChallenges = course.challenges.length;
+      transform(snapshot) {
+        const course = Object.assign({}, snapshot);
+        if (snapshot.challenges) {
+          course.nbChallenges = snapshot.challenges.length;
+        }
         return course;
       }
-    }).serialize(course);
+    }).serialize(snapshots);
   }
+
 };

--- a/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
@@ -2,17 +2,17 @@ const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
 module.exports = {
 
-  serialize(snapshots) {
+  serialize(courses) {
     return new JSONAPISerializer('course', {
       attributes: ['name', 'description', 'duration', 'isAdaptive', 'nbChallenges', 'imageUrl'],
-      transform(snapshot) {
-        const course = Object.assign({}, snapshot);
-        if (snapshot.challenges) {
-          course.nbChallenges = snapshot.challenges.length;
+      transform(record) {
+        const course = Object.assign({}, record);
+        if (record.challenges) {
+          course.nbChallenges = record.challenges.length;
         }
         return course;
       }
-    }).serialize(snapshots);
+    }).serialize(courses);
   }
 
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -42,6 +42,54 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function() {
       });
     });
 
+    describe('field "nbChallenges"', () => {
+
+      it('should be length of challenges associated to the course where they exist', () => {
+        // given
+        const course = new Course();
+        course.id = 'course_id';
+        course.challenges = [
+          'rec_challenge_1',
+          'rec_challenge_2',
+          'rec_challenge_3',
+          'rec_challenge_4',
+          'rec_challenge_5'
+        ];
+
+        // when
+        const json = serializer.serialize(course);
+
+        // then
+        expect(json).to.deep.equal({
+          'data': {
+            'type': 'courses',
+            'id': course.id,
+            'attributes': {
+              'nb-challenges': 5
+            }
+          }
+        });
+      });
+
+      it('should be undefined when there is no challenges associated to the course', () => {
+        // given
+        const course = new Course();
+        course.id = 'course_id';
+        course.challenges = undefined;
+
+        // when
+        const json = serializer.serialize(course);
+
+        // then
+        expect(json).to.deep.equal({
+          'data': {
+            'type': 'courses',
+            'id': course.id
+          }
+        });
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
**Scénario :** 
- on se connecte
- on lance un test de positionnement du domaine 2 (qui n'ont pas d'épreuves associées dans Airtable)
- l'API plante

**Correction :**
- lors de la sérialization d'un course, on vérifie qu'il a des épreuves associées avant d'accéder à la longueur de ces challenges