### PR TITLE
[#629] [BUGFIX] Gestion les challenges qui ne sont plus valide (US-982).

### DIFF
--- a/api/lib/cat/answer.js
+++ b/api/lib/cat/answer.js
@@ -1,7 +1,15 @@
 class Answer {
   constructor(challenge, result) {
-    this.challenge = challenge;
+    this.challenge = challenge || this.emptyChallenge;
     this.result = result;
+  }
+  get emptyChallenge() {
+    return {
+      id: null,
+      status: 'archive',
+      skills: [],
+      timer: null,
+    };
   }
 
   get binaryOutcome() {

--- a/api/lib/cat/answer.js
+++ b/api/lib/cat/answer.js
@@ -1,10 +1,10 @@
 class Answer {
   constructor(challenge, result) {
-    this.challenge = challenge || this.emptyChallenge;
+    this.challenge = this._getChallenge(challenge);
     this.result = result;
   }
-  get emptyChallenge() {
-    return {
+  _getChallenge(challenge) {
+    return challenge || {
       id: null,
       status: 'archive',
       skills: [],

--- a/api/lib/cat/answer.js
+++ b/api/lib/cat/answer.js
@@ -1,9 +1,9 @@
 class Answer {
   constructor(challenge, result) {
-    this.challenge = this._getChallenge(challenge);
+    this.challenge = this._getValidChallenge(challenge);
     this.result = result;
   }
-  _getChallenge(challenge) {
+  _getValidChallenge(challenge) {
     return challenge || {
       id: null,
       status: 'archive',

--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -29,11 +29,13 @@ class Assessment {
     return this.answers
       .filter(answer => answer.result === 'ok')
       .reduce((skills, answer) => {
-        answer.challenge.skills.forEach(skill => {
-          skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
-            skills.add(validatedSkill);
+        if(answer.challenge.skills.length > 0) {
+          answer.challenge.skills.forEach(skill => {
+            skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
+              skills.add(validatedSkill);
+            });
           });
-        });
+        }
         return skills;
       }, new Set());
   }
@@ -42,9 +44,11 @@ class Assessment {
     return this.answers
       .filter(answer => answer.result !== 'ok')
       .reduce((failedSkills, answer) => {
-        answer.challenge.hardestSkill.getHarderWithin(this.course.tubes).forEach(failedSkill => {
-          failedSkills.add(failedSkill);
-        });
+        if(answer.challenge.skills.length > 0) {
+          answer.challenge.hardestSkill.getHarderWithin(this.course.tubes).forEach(failedSkill => {
+            failedSkills.add(failedSkill);
+          });
+        }
         return failedSkills;
       }, new Set());
   }

--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -29,13 +29,11 @@ class Assessment {
     return this.answers
       .filter(answer => answer.result === 'ok')
       .reduce((skills, answer) => {
-        if(answer.challenge.skills.length > 0) {
-          answer.challenge.skills.forEach(skill => {
-            skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
-              skills.add(validatedSkill);
-            });
+        answer.challenge.skills.forEach(skill => {
+          skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
+            skills.add(validatedSkill);
           });
-        }
+        });
         return skills;
       }, new Set());
   }

--- a/api/tests/unit/cat/answer_test.js
+++ b/api/tests/unit/cat/answer_test.js
@@ -29,6 +29,17 @@ describe('Unit | Model | Answer', function() {
       // then
       expect(maxDifficulty).to.equal(5);
     });
+
+    it('should return level 2 if the challenge is undefined', function() {
+      // given
+      const answer = new Answer(undefined, 'ok');
+
+      // when
+      const maxDifficulty = answer.maxDifficulty;
+
+      // then
+      expect(maxDifficulty).to.equal(2);
+    });
   });
 
   describe('#binaryOutcome', function() {

--- a/api/tests/unit/cat/answer_test.js
+++ b/api/tests/unit/cat/answer_test.js
@@ -30,7 +30,7 @@ describe('Unit | Model | Answer', function() {
       expect(maxDifficulty).to.equal(5);
     });
 
-    it('should return level 2 if the challenge is undefined', function() {
+    it('should return 2 if the challenge is undefined', function() {
       // given
       const answer = new Answer(undefined, 'ok');
 

--- a/api/tests/unit/cat/assessment_test.js
+++ b/api/tests/unit/cat/assessment_test.js
@@ -182,6 +182,19 @@ describe('Unit | Model | Assessment', function() {
       // then
       expect([...assessment.validatedSkills]).to.be.deep.equal([web3forChallengeOne, url3]);
     });
+
+    it('should not try to add skill from undefined challenge', function() {
+      // given
+      const web3forChallengeOne = new Skill('web3');
+      const ch1 = new Challenge('a', 'validé', [web3forChallengeOne]);
+      const course = new Course([ch1]);
+      const answer = new Answer(ch1, 'ok');
+      const answer2 = new Answer(undefined, 'ok');
+      const assessment = new Assessment(course, [answer, answer2]);
+
+      // then
+      expect([...assessment.validatedSkills]).to.be.deep.equal([web3forChallengeOne]);
+    });
   });
 
   describe('#failedSkills', function() {
@@ -212,6 +225,19 @@ describe('Unit | Model | Assessment', function() {
 
       // then
       expect([...assessment.failedSkills]).to.be.deep.equal([url5, url6, url8]);
+    });
+
+    it('should not try to add skill from undefined challenge', function() {
+      // given
+      const web3forChallengeOne = new Skill('web3');
+      const ch1 = new Challenge('a', 'validé', [web3forChallengeOne]);
+      const course = new Course([ch1]);
+      const answer = new Answer(ch1, 'ko');
+      const answer2 = new Answer(undefined, 'ko');
+      const assessment = new Assessment(course, [answer, answer2]);
+
+      // then
+      expect([...assessment.failedSkills]).to.be.deep.equal([web3forChallengeOne]);
     });
   });
 
@@ -421,6 +447,69 @@ describe('Unit | Model | Assessment', function() {
       // then
       expect(assessment.nextChallenge).to.equal(ch5);
     });
+    context('when one challenge (level3) has been archived', () => {
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const ch1 = new Challenge('recEasy', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch3 = new Challenge('rec3', 'archive', [web3]);
+      const ch3Bis= new Challenge('rec3bis', 'validé', [web3]);
+      const ch4 = new Challenge('rec4', 'validé', [web4]);
+      const ch5 = new Challenge('rec5', 'validé', [web5]);
+      it('should return a challenge of level 3 if user got levels 1, 2 ,3 and 4 at KO', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4, ch5]);
+        const answer1 = new Answer(ch1, 'ok');
+        const answer2 = new Answer(ch2, 'ok');
+        const answer3 = new Answer(undefined, 'ok');
+        const answer4 = new Answer(ch4, 'ko');
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch3Bis);
+      });
+
+      it('should return a challenge of level 5 if user got levels 1, 2, 3, 4 with OK', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4, ch5]);
+        const answer1 = new Answer(ch1, 'ok');
+        const answer2 = new Answer(ch2, 'ok');
+        const answer3 = new Answer(undefined, 'ok');
+        const answer4 = new Answer(ch4, 'ok');
+        const assessment = new Assessment(course, [answer1, answer2, answer3,answer4]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch5);
+      });
+      it('should return a challenge of level 4 if user got levels 1, 2 and  3 archived', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4]);
+        const answer1 = new Answer(ch1, 'ok');
+        const answer2 = new Answer(ch2, 'ok');
+        const answer3 = new Answer(undefined, 'ok');
+        const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch4);
+      });
+
+      it('should return a challenge of level 3 if user got levels 1, 2 and 3 archived', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis]);
+        const answer1 = new Answer(ch1, 'ok');
+        const answer2 = new Answer(ch2, 'ok');
+        const answer3 = new Answer(undefined, 'ok');
+        const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch3Bis);
+      });
+    });
+
+
 
     it('should return null if remaining challenges do not provide extra validated or failed skills', function() {
       // given
@@ -496,7 +585,7 @@ describe('Unit | Model | Assessment', function() {
       expect(assessment.pixScore).to.be.equal(0);
     });
 
-    it('should be 8 if validated skills are web1 among 2 (4 pix), web2 (4 pix) but not web3 among 4 (2 pix)', function() {
+    it('should be 8 if validated skills are web1 among 2 (4 pix), web2 (4 pix) but not web3 among 4 (2 pix)', () => {
       // given
       const skillNames = ['web1', 'chi1', 'web2', 'web3', 'chi3', 'fou3', 'mis3'];
       const skills = {};
@@ -513,7 +602,7 @@ describe('Unit | Model | Assessment', function() {
       expect(assessment.pixScore).to.be.equal(8);
     });
 
-    it('should be 6 if validated skills are web1 (4 pix) and fou3 among 4 (2 pix) (web2 was failed)', function() {
+    it('should be 6 if validated skills are web1 (4 pix) and fou3 among 4 (2 pix) (web2 was failed)', () => {
       // given
       const skillNames = ['web1', 'chi1', 'web2', 'web3', 'chi3', 'fou3', 'mis3'];
       const skills = {};
@@ -530,6 +619,61 @@ describe('Unit | Model | Assessment', function() {
 
       // then
       expect(assessment.pixScore).to.be.equal(6);
+    });
+
+    context('when one challenge was archived', () => {
+      it('should return maximum score even if one answer has undefined challenge and skill do not exist anymore', () => {
+
+        // given
+        const skillNames = ['web1', 'web3', 'ch1', 'ch2', 'ch3', 'truc2'];
+        const skills = {};
+        skillNames.forEach(skillName => skills[skillName] = new Skill(skillName));
+        const competenceSkills = new Set(Object.values(skills));
+        const web1Challenge = new Challenge('a', 'validé', [skills['web1']]);
+        const web3Challege = new Challenge('c', 'validé', [skills['web3']]);
+        const ch1Challenge = new Challenge('a', 'validé', [skills['ch1']]);
+        const ch2Challenge = new Challenge('b', 'archived', [skills['ch2']]);
+        const ch3Challege = new Challenge('c', 'validé', [skills['ch3']]);
+        const truc2Challege = new Challenge('c', 'validé', [skills['truc2']]);
+        const course = new Course([web1Challenge, web3Challege, ch1Challenge, ch2Challenge, ch3Challege, truc2Challege], competenceSkills);
+        const answer1 = new Answer(web1Challenge, 'ok');
+        const answer2 = new Answer(undefined, 'ok');
+        const answer3 = new Answer(web3Challege, 'ok');
+        const answer4 = new Answer(ch1Challenge, 'ok');
+        const answer5 = new Answer(ch2Challenge, 'ok');
+        const answer6 = new Answer(ch3Challege, 'ok');
+        const answer7 = new Answer(truc2Challege, 'ok');
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4, answer5, answer6, answer7]);
+
+        // then
+        expect(assessment.pixScore).to.be.equal(24);
+      });
+
+      it('should return maximum score even if one answer has undefined challenge and but skill exist', () => {
+
+        // given
+        const skillNames = ['web1', 'web2', 'web3', 'ch1', 'ch2', 'ch3'];
+        const skills = {};
+        skillNames.forEach(skillName => skills[skillName] = new Skill(skillName));
+        const competenceSkills = new Set(Object.values(skills));
+        const web1Challenge = new Challenge('a', 'validé', [skills['web1']]);
+        const web2Challenge = new Challenge('a', 'validé', [skills['web2']]);
+        const web3Challege = new Challenge('c', 'validé', [skills['web3']]);
+        const ch1Challenge = new Challenge('a', 'validé', [skills['ch1']]);
+        const ch2Challenge = new Challenge('b', 'archived', [skills['ch2']]);
+        const ch3Challege = new Challenge('c', 'validé', [skills['ch3']]);
+        const course = new Course([web1Challenge, web2Challenge, web3Challege, ch1Challenge, ch2Challenge, ch3Challege], competenceSkills);
+        const answer1 = new Answer(web1Challenge, 'ok');
+        const answer2 = new Answer(undefined, 'ok');
+        const answer3 = new Answer(web3Challege, 'ok');
+        const answer4 = new Answer(ch1Challenge, 'ok');
+        const answer5 = new Answer(ch2Challenge, 'ok');
+        const answer6 = new Answer(ch3Challege, 'ok');
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4, answer5, answer6]);
+
+        // then
+        expect(assessment.pixScore).to.be.equal(24);
+      });
     });
   });
 

--- a/api/tests/unit/cat/assessment_test.js
+++ b/api/tests/unit/cat/assessment_test.js
@@ -509,8 +509,6 @@ describe('Unit | Model | Assessment', function() {
       });
     });
 
-
-
     it('should return null if remaining challenges do not provide extra validated or failed skills', function() {
       // given
       const web1 = new Skill('web1');


### PR DESCRIPTION
Cas constaté : 
- L'utilisateur commence un test de positionnement
- Il l'arrête
- Un des challenges déjà passé est archivé
- Il reprend le test : 
  - Pour connaitre les skills validés, on récupère les challenges de la compétences et on regarde ceux qu'on a validé/failed.
  - Erreur dans le cas où le challenge n'a pas pu être remonté

Solution: 
- Vérification que le challenge a un skill avant de vérifier les skills à validé/invalidé. 
- Ajout d'un challenge vide lors de la création d'un answer
- Ajout de nombreux tests pour voir le fonctionnement de l'algo