### PR TITLE
[#631] [FEATURE] Ajout du statut de la certification dans l'endpoint /api/certification-courses (US-961)

### DIFF
--- a/api/db/migrations/20171212144653_add_status_to_certification_course.js
+++ b/api/db/migrations/20171212144653_add_status_to_certification_course.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'certification-courses';
+
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table(TABLE_NAME, function(table){
+      table.string('status');
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table(TABLE_NAME, function(table){
+      table.dropColumn('status');
+    })
+  ]);
+};

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -112,9 +112,9 @@ module.exports = {
 
               let promise;
               if (assessmentService.isCertificationAssessment(assessmentPix)) {
-                promise = certificationCourseRepository.updateStatus('completed', assessmentPix.get('courseId'))
+                promise = certificationCourseRepository.updateStatus('completed', assessmentPix.get('courseId'));
               } else {
-                promise = Promise.resolve()
+                promise = Promise.resolve();
               }
 
               // XXX: successRate should not be saved in DB.
@@ -122,9 +122,9 @@ module.exports = {
 
               return promise
                 .then(() => assessmentPix.save())
-                .then(() => skillsService.saveAssessmentSkills(skills))
+                .then(() => skillsService.saveAssessmentSkills(skills));
             })
-            .then(() => { throw err });
+            .then(() => { throw err; });
         } else {
           throw err;
         }

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -129,11 +129,9 @@ module.exports = {
           throw err;
         }
       })
-      .then((nextChallengeId) => {
-        return challengeRepository.get(nextChallengeId);
-      })
+      .then(challengeRepository.get)
       .then((challenge) => {
-        return reply(challengeSerializer.serialize(challenge));
+        reply(challengeSerializer.serialize(challenge));
       })
       .catch((err) => {
         if(err instanceof AssessmentEndedError) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -18,12 +18,12 @@ const logger = require('../../infrastructure/logger');
 const { NotFoundError, NotCompletedAssessmentError, AssessmentEndedError } = require('../../domain/errors');
 
 function _doesAssessmentExistsAndIsCompleted(assessment) {
-  if(!assessment)
+  if (!assessment)
     throw new NotFoundError();
 
   const isAssessmentNotCompleted = !assessmentService.isAssessmentCompleted(assessment);
 
-  if(isAssessmentNotCompleted)
+  if (isAssessmentNotCompleted)
     throw new NotCompletedAssessmentError();
 }
 
@@ -110,11 +110,9 @@ module.exports = {
             .fetchAssessment(request.params.id)
             .then(({ assessmentPix, skills }) => {
 
-              let promise;
+              let promise = Promise.resolve();
               if (assessmentService.isCertificationAssessment(assessmentPix)) {
                 promise = certificationCourseRepository.updateStatus('completed', assessmentPix.get('courseId'));
-              } else {
-                promise = Promise.resolve();
               }
 
               // XXX: successRate should not be saved in DB.
@@ -124,7 +122,9 @@ module.exports = {
                 .then(() => assessmentPix.save())
                 .then(() => skillsService.saveAssessmentSkills(skills));
             })
-            .then(() => { throw err; });
+            .then(() => {
+              throw err;
+            });
         } else {
           throw err;
         }
@@ -134,7 +134,7 @@ module.exports = {
         reply(challengeSerializer.serialize(challenge));
       })
       .catch((err) => {
-        if(err instanceof AssessmentEndedError) {
+        if (err instanceof AssessmentEndedError) {
           return reply(Boom.notFound());
         }
 

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -115,6 +115,8 @@ module.exports = {
                 .then(() => skillsService.saveAssessmentSkills(skills))
             })
             .then(() => { throw err });
+        } else {
+          throw err;
         }
       })
       .then((nextChallengeId) => {

--- a/api/lib/application/certificationCourses/certification-course-controller.js
+++ b/api/lib/application/certificationCourses/certification-course-controller.js
@@ -62,9 +62,9 @@ module.exports = {
 
   get(request, reply) {
     const certificationCourseId = request.params.id;
-    return assessmentRepository.getByCertificationCourseId(certificationCourseId)
-      .then((assessment) => {
-        reply(certificationCourseSerializer.serialize({ id: certificationCourseId, assessment: assessment.toJSON(), userId: '' }));
+    return CertificationCourseRepository.get(certificationCourseId)
+      .then((certificationCourse) => {
+        reply(certificationCourseSerializer.serialize(certificationCourse));
       })
       .catch((err) => {
         logger.error(err);

--- a/api/lib/application/certificationCourses/certification-course-controller.js
+++ b/api/lib/application/certificationCourses/certification-course-controller.js
@@ -14,7 +14,7 @@ const CertificationCourse = require('../../../lib/domain/models/CertificationCou
 module.exports = {
   save(request, reply) {
     const userId = request.pre.userId;
-    let certificationCourse = new CertificationCourse({ userId });
+    let certificationCourse = new CertificationCourse({ userId, status: 'started' });
 
     return CertificationCourseRepository.save(certificationCourse)
       .then((savedCertificationCourse) => {

--- a/api/lib/application/preHandlers/access-session.js
+++ b/api/lib/application/preHandlers/access-session.js
@@ -1,12 +1,10 @@
-const Boom = require('boom');
-
 const SessionService = require('../../domain/services/session-service');
 
 module.exports = {
   sessionIsOpened(request, reply) {
 
     if (SessionService.getCurrentCode() !== request.payload.data.attributes['session-code']) {
-      return reply(Boom.unauthorized()).takeover();
+      return reply().code(401).takeover();
     }
 
     delete request.payload.data.attributes['session-code'];

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -110,6 +110,20 @@ class UserNotAuthorizedToCertifyError extends Error {
   }
 }
 
+class AssessmentEndedError extends Error {
+  constructor() {
+    super();
+  }
+
+  getErrorMessage() {
+    return {
+      data: {
+        error: ['L\'évaluation est terminée. Nous n\'avons plus de questions à vous poser.']
+      }
+    };
+  }
+}
+
 module.exports = {
   NotFoundError,
   PasswordNotMatching,
@@ -122,5 +136,6 @@ module.exports = {
   InvalidTemporaryKeyError,
   NotElligibleToQmailError,
   UserNotAuthorizedToCertifyError,
-  NotCompletedAssessmentError
+  NotCompletedAssessmentError,
+  AssessmentEndedError
 };

--- a/api/lib/domain/models/data/certification-course.js
+++ b/api/lib/domain/models/data/certification-course.js
@@ -2,5 +2,12 @@ const Bookshelf = require('../../../infrastructure/bookshelf');
 Bookshelf.plugin('registry');
 
 module.exports = Bookshelf.model('CertificationCourse', {
-  tableName: 'certification-courses'
+  tableName: 'certification-courses',
+
+  validations: {
+    status: [
+      { method: 'isRequired', error: 'Le champ status doit être renseigné.' },
+      { method: 'isIn', error: 'Le status de la certification n\'est pas valide', args: ['started', 'completed', 'validated', 'rejected'] },
+    ]
+  }
 });

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -56,19 +56,16 @@ function _selectNextChallengeId(course, currentChallengeId, assessment) {
 
 function getAssessmentNextChallengeId(assessment, currentChallengeId) {
 
-  return Promise.resolve()
-    .then(() => {
-      const courseId = assessment.get('courseId');
+  if (isPreviewAssessment(assessment)) {
+    return Promise.reject(new AssessmentEndedError());
+  }
 
-      if (isPreviewAssessment(assessment)) {
-        throw new AssessmentEndedError();
-      }
+  const courseId = assessment.get('courseId');
 
-      return courseRepository.get(courseId);
-    })
+  return courseRepository.get(courseId)
     .then(course => _selectNextChallengeId(course, currentChallengeId, assessment))
     .then((nextChallenge) => {
-      if(nextChallenge) {
+      if (nextChallenge) {
         return nextChallenge;
       }
 
@@ -113,7 +110,7 @@ async function fetchAssessment(assessmentId) {
     })
     .then((skillsAndChallenges) => {
 
-      if(skillsAndChallenges) {
+      if (skillsAndChallenges) {
         const [skillNames, challengesPix] = skillsAndChallenges;
         const catAssessment = assessmentAdapter.getAdaptedAssessment(answers, challengesPix, skillNames);
 
@@ -132,7 +129,7 @@ async function fetchAssessment(assessmentId) {
 }
 
 function _isNonScoredAssessment(assessment) {
-  return isPreviewAssessment(assessment)  || isCertificationAssessment(assessment);
+  return isPreviewAssessment(assessment) || isCertificationAssessment(assessment);
 }
 
 function isPreviewAssessment(assessment) {

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -1,6 +1,6 @@
 const CertificationChallengeBookshelf = require('../../domain/models/data/certification-challenge');
 const CertificationChallenge = require('../../domain/models/CertificationChallenge');
-const { NotFoundError } = require('../../domain/errors');
+const { AssessmentEndedError } = require('../../domain/errors');
 const Bookshelf = require('../bookshelf');
 
 function _toDomain(model) {
@@ -48,7 +48,7 @@ module.exports = {
       .fetch()
       .then((certificationChallenge) => {
         if(certificationChallenge === null) {
-          throw new NotFoundError();
+          throw new AssessmentEndedError();
         }
 
         return _toDomain(certificationChallenge);

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -28,9 +28,7 @@ module.exports = {
     const getCertificationCoursePromise = CertificationCourseBookshelf
       .where({ id })
       .fetch()
-      .then((certificationCourse) => {
-        return _toDomain(certificationCourse);
-      });
+      .then(_toDomain);
 
     return getCertificationCoursePromise
       .then((foundCertificationCourse) => {

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -14,5 +14,11 @@ module.exports = {
     const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourseDomainModel);
     return certificationCourseBookshelf.save()
       .then(_toDomain);
+  },
+
+  updateStatus(status, certificationCourseId) {
+    const certificationCourseBookshelf = new CertificationCourseBookshelf({id: certificationCourseId, status});
+    return certificationCourseBookshelf.save();
   }
+
 };

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -1,10 +1,12 @@
 const CertificationCourseBookshelf = require('../../domain/models/data/certification-course');
+const AssessmentBookshelf = require('../../domain/models/data/assessment');
 const CertificationCourse = require('../../domain/models/CertificationCourse');
 
 function _toDomain(model) {
   return new CertificationCourse({
     id: model.get('id'),
-    userId: model.get('userId')
+    userId: model.get('userId'),
+    status: model.get('status')
   });
 }
 
@@ -17,8 +19,27 @@ module.exports = {
   },
 
   updateStatus(status, certificationCourseId) {
-    const certificationCourseBookshelf = new CertificationCourseBookshelf({id: certificationCourseId, status});
+    const certificationCourseBookshelf = new CertificationCourseBookshelf({ id: certificationCourseId, status });
     return certificationCourseBookshelf.save();
+  },
+
+  get(id) {
+    let certificationCourse;
+    const getCertificationCoursePromise = CertificationCourseBookshelf
+      .where({ id })
+      .fetch()
+      .then((certificationCourse) => {
+        return _toDomain(certificationCourse);
+      });
+
+    return getCertificationCoursePromise
+      .then((foundCertificationCourse) => {
+        certificationCourse = foundCertificationCourse;
+        return AssessmentBookshelf.where({ courseId: id, userId: certificationCourse.userId }).fetch();
+      }).then((assessment) => {
+        certificationCourse.assessment = assessment.toJSON();
+        return certificationCourse;
+      });
   }
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -5,7 +5,7 @@ module.exports = {
   serialize(certificationCourse) {
 
     return new Serializer('certification-courses', {
-      attributes : ['userId', 'assessment'],
+      attributes : ['userId', 'assessment', 'status'],
       assessment: {
         ref: 'id',
       },

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -236,7 +236,12 @@ describe('Acceptance | API | assessment-controller-get-adaptive-correct', () => 
 
       // then
       return promise.then((response) => {
-        expect(response.result).to.be.null;
+        expect(response.statusCode).to.equal(404);
+        expect(response.result).to.deep.equal({
+          error: 'Not Found',
+          message: 'Not Found',
+          statusCode: 404
+        });
       });
     });
   });

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -120,21 +120,14 @@ describe('Acceptance | API | assessment-controller-get-adaptive', function() {
       return knex('assessments').delete();
     });
 
-    it('should return HTTP status code 204 when there is not next challenge', (done) => {
+    it('should return HTTP status code 204 when there is not next challenge', () => {
       // given
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
 
       // when
-      server.inject(options, (response) => {
-
-        // then
-        expect(response.statusCode).to.equal(204);
-        done();
+      return server.injectThen(options).then((response) => {
+        expect(response.statusCode).to.equal(404);
       });
     });
-
   });
-
-})
-;
-
+});

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -120,7 +120,7 @@ describe('Acceptance | API | assessment-controller-get-adaptive', function() {
       return knex('assessments').delete();
     });
 
-    it('should return HTTP status code 204 when there is not next challenge', () => {
+    it('should return HTTP status code 404 when there is not next challenge', () => {
       // given
       const options = { method: 'GET', url: '/api/assessments/' + insertedAssessmentId + '/next' };
 

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -169,8 +169,12 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
 
       // When
       return server.injectThen(options).then((response) => {
-        expect(response.result).to.be.null;
-        expect(response.statusCode).to.equal(204);
+        expect(response.statusCode).to.equal(404);
+        expect(response.result).to.deep.equal({
+          error: 'Not Found',
+          message: 'Not Found',
+          statusCode: 404
+        });
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -18,15 +18,11 @@ describe('Integration | Repository | Certification Course', function() {
   describe('#updateStatus', () => {
 
     beforeEach(() => {
-      return Promise.all([
-        knex('certification-courses').insert(certificationCourse),
-      ]);
+      return knex('certification-courses').insert(certificationCourse);
     });
 
     afterEach(() => {
-      return Promise.all([
-        knex('certification-courses').delete(),
-      ]);
+      return knex('certification-courses').delete();
     });
 
     it('should update status of the certificationCourse', () => {

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,28 +1,37 @@
 const { expect, describe, beforeEach, afterEach, it, knex } = require('../../../test-helper');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
-const CertificationCourseBookshelf = require('../../../../lib/domain/models/data/certification-course');
-const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 
 describe('Integration | Repository | Certification Course', function() {
 
-  const certificationCourse = {
-    id: 1,
-    status: 'started'
+  const associatedAssessment = {
+    id: 7,
+    courseId: 20,
+    userId : 1
   };
 
-  beforeEach(() => {
-    return knex('certification-courses').insert(certificationCourse);
-  });
-
-  afterEach(() => {
-    return knex('certification-courses').delete();
-  });
+  const certificationCourse = {
+    id: 20,
+    status: 'started',
+    userId: 1
+  };
 
   describe('#updateStatus', () => {
 
+    beforeEach(() => {
+      return Promise.all([
+        knex('certification-courses').insert(certificationCourse),
+      ])
+    });
+
+    afterEach(() => {
+      return Promise.all([
+        knex('certification-courses').delete(),
+      ])
+    });
+
     it('should update status of the certificationCourse', () => {
       // when
-      const promise = CertificationCourseRepository.updateStatus('completed', 1);
+      const promise = CertificationCourseRepository.updateStatus('completed', 20);
 
       // then
       return promise.then(() => knex('certification-courses').first('id', 'status'))
@@ -30,6 +39,36 @@ describe('Integration | Repository | Certification Course', function() {
           expect(certificationCourse.status).to.equal('completed')
         });
     });
+  });
+
+  describe('#get', function() {
+
+    beforeEach(() => {
+      return Promise.all([
+        knex('certification-courses').insert(certificationCourse),
+        knex('assessments').insert(associatedAssessment),
+      ])
+    });
+
+    afterEach(() => {
+      return Promise.all([
+        knex('certification-courses').delete(),
+        knex('assessments').delete(),
+      ])
+    });
+
+    it('should retrieve associated assessment with the certification course', function() {
+      // when
+      const promise = CertificationCourseRepository.get(20);
+
+      // then
+      return promise.then((certificationCourse) => {
+          expect(certificationCourse.id).to.equal(20);
+          expect(certificationCourse.status).to.equal('started');
+          expect(certificationCourse.assessment.id).to.equal(7);
+        });
+    });
+
   });
 });
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,0 +1,35 @@
+const { expect, describe, beforeEach, afterEach, it, knex } = require('../../../test-helper');
+const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
+const CertificationCourseBookshelf = require('../../../../lib/domain/models/data/certification-course');
+const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+
+describe('Integration | Repository | Certification Course', function() {
+
+  const certificationCourse = {
+    id: 1,
+    status: 'started'
+  };
+
+  beforeEach(() => {
+    return knex('certification-courses').insert(certificationCourse);
+  });
+
+  afterEach(() => {
+    return knex('certification-courses').delete();
+  });
+
+  describe('#updateStatus', () => {
+
+    it('should update status of the certificationCourse', () => {
+      // when
+      const promise = CertificationCourseRepository.updateStatus('completed', 1);
+
+      // then
+      return promise.then(() => knex('certification-courses').first('id', 'status'))
+        .then((certificationCourse) => {
+          expect(certificationCourse.status).to.equal('completed')
+        });
+    });
+  });
+});
+

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -6,7 +6,7 @@ describe('Integration | Repository | Certification Course', function() {
   const associatedAssessment = {
     id: 7,
     courseId: 20,
-    userId : 1
+    userId: 1
   };
 
   const certificationCourse = {
@@ -20,13 +20,13 @@ describe('Integration | Repository | Certification Course', function() {
     beforeEach(() => {
       return Promise.all([
         knex('certification-courses').insert(certificationCourse),
-      ])
+      ]);
     });
 
     afterEach(() => {
       return Promise.all([
         knex('certification-courses').delete(),
-      ])
+      ]);
     });
 
     it('should update status of the certificationCourse', () => {
@@ -36,7 +36,7 @@ describe('Integration | Repository | Certification Course', function() {
       // then
       return promise.then(() => knex('certification-courses').first('id', 'status'))
         .then((certificationCourse) => {
-          expect(certificationCourse.status).to.equal('completed')
+          expect(certificationCourse.status).to.equal('completed');
         });
     });
   });
@@ -47,14 +47,14 @@ describe('Integration | Repository | Certification Course', function() {
       return Promise.all([
         knex('certification-courses').insert(certificationCourse),
         knex('assessments').insert(associatedAssessment),
-      ])
+      ]);
     });
 
     afterEach(() => {
       return Promise.all([
         knex('certification-courses').delete(),
         knex('assessments').delete(),
-      ])
+      ]);
     });
 
     it('should retrieve associated assessment with the certification course', function() {
@@ -63,10 +63,10 @@ describe('Integration | Repository | Certification Course', function() {
 
       // then
       return promise.then((certificationCourse) => {
-          expect(certificationCourse.id).to.equal(20);
-          expect(certificationCourse.status).to.equal('started');
-          expect(certificationCourse.assessment.id).to.equal(7);
-        });
+        expect(certificationCourse.id).to.equal(20);
+        expect(certificationCourse.status).to.equal('started');
+        expect(certificationCourse.assessment.id).to.equal(7);
+      });
     });
 
   });

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -61,6 +61,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       sandbox.stub(assessmentService, 'getAssessmentNextChallengeId');
       sandbox.stub(assessmentRepository, 'get');
       sandbox.stub(Boom, 'notFound').returns({ message: 'NotFoundError' });
+      sandbox.stub(Boom, 'badImplementation').returns({});
     });
 
     afterEach(() => {
@@ -97,6 +98,29 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
           expect(Boom.notFound).to.have.been.calledOnce;
         });
       });
+    });
+
+    describe('when retrieving the next challenge is failing', () => {
+
+      beforeEach(() => {
+        assessmentRepository.get.resolves(assessmentWithoutScore);
+      });
+
+      it('should call fetchAssessment', () => {
+        // given
+        const error = new Error();
+        assessmentService.getAssessmentNextChallengeId.rejects(error);
+
+        // When
+        const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
+
+        // Then
+        return promise.then(() => {
+          expect(Boom.badImplementation).to.have.been.calledWith(error);
+          expect(replyStub).to.have.been.calledWith(Boom.badImplementation(error));
+        });
+      });
+
     });
 
     describe('when the assessment is over', () => {
@@ -157,16 +181,10 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       describe('when saving level and score is failing', () => {
 
-        let badImplementationSpy;
         let replyStub;
 
         beforeEach(() => {
-          badImplementationSpy = sinon.stub(Boom, 'badImplementation').returns({});
           replyStub = sinon.stub();
-        });
-
-        afterEach(() => {
-          badImplementationSpy.restore();
         });
 
         it('should return a badImplementation error when evaluating is an error', () => {
@@ -179,7 +197,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
           // Then
           return promise.then(() => {
-            expect(badImplementationSpy).to.have.been.calledWith(error);
+            expect(Boom.badImplementation).to.have.been.calledWith(error);
             expect(replyStub).to.have.been.calledWith(Boom.badImplementation(error));
           });
         });
@@ -194,7 +212,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
           // Then
           return promise.then(() => {
-            expect(badImplementationSpy).to.have.been.calledWith(error);
+            expect(Boom.badImplementation).to.have.been.calledWith(error);
             expect(replyStub).to.have.been.calledWith(Boom.badImplementation(error));
           });
 

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -146,7 +146,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
             type: 'CERTIFICATION'
           });
           assessmentRepository.get.resolves(certificationAssessment);
-          assessmentService.fetchAssessment.resolves({assessmentPix: certificationAssessment});
+          assessmentService.fetchAssessment.resolves({ assessmentPix: certificationAssessment });
 
           // when
           const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
@@ -168,7 +168,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
             type: 'CERTIFICATION'
           });
           assessmentRepository.get.resolves(certificationAssessment);
-          assessmentService.fetchAssessment.resolves({assessmentPix: certificationAssessment});
+          assessmentService.fetchAssessment.resolves({ assessmentPix: certificationAssessment });
 
           // when
           const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);
@@ -192,7 +192,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
             type: 'PLACEMENT'
           });
           assessmentRepository.get.resolves(certificationAssessment);
-          assessmentService.fetchAssessment.resolves({assessmentPix: certificationAssessment});
+          assessmentService.fetchAssessment.resolves({ assessmentPix: certificationAssessment });
 
           // when
           const promise = assessmentController.getNextChallenge({ params: { id: 7531 } }, replyStub);

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, sinon } = require('../../../test-helper');
+const { describe, it, before, sinon, expect } = require('../../../test-helper');
 const Hapi = require('hapi');
 const CertificationCourseController = require('../../../../lib/application/certificationCourses/certification-course-controller');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
@@ -234,8 +234,8 @@ describe('Unit | Controller | certification-course-controller', function() {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(CertificationCourseRepository.get);
-        sinon.assert.calledWithExactly(CertificationCourseRepository.get, certificationId);
+        expect(CertificationCourseRepository.get).to.have.been.calledOnce;
+        expect(CertificationCourseRepository.get).to.have.been.calledWith(certificationId);
       });
     });
 
@@ -245,8 +245,8 @@ describe('Unit | Controller | certification-course-controller', function() {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(reply);
-        sinon.assert.calledWithExactly(reply, certificationSerialized);
+        expect(reply).to.have.been.calledOnce;
+        expect(reply).to.have.been.calledWith(certificationSerialized);
       });
     });
   });

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -96,6 +96,7 @@ describe('Unit | Controller | certification-course-controller', function() {
     });
 
   });
+
   describe('#getResult', () => {
     const answersByAssessments = [{ challenge: 'challenge1', result: 'ok' }];
     const challengesByCertificationId = [{ challenge: 'challenge1', courseId: '2' }];
@@ -200,10 +201,16 @@ describe('Unit | Controller | certification-course-controller', function() {
     let sandbox;
 
     const certificationId = 12;
-    const assessment = new Assessment({ id: 'assessment_id' });
-    const reply = sinon.stub();
+    const assessment = { id: 'assessment_id', courseId: 1 };
+    const certificationCourse = {
+      id: 1,
+      userId: 7,
+      completed: 'started',
+      assessment
+    };
 
     let request;
+    let reply;
     const certificationSerialized = { id: certificationId, assessment: { id: 'assessment_id' } };
 
     beforeEach(() => {
@@ -211,7 +218,9 @@ describe('Unit | Controller | certification-course-controller', function() {
 
       sandbox = sinon.sandbox.create();
 
+      reply = sandbox.stub();
       sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(assessment);
+      sandbox.stub(CertificationCourseRepository, 'get').resolves(certificationCourse);
       sandbox.stub(certificationCourseSerializer, 'serialize').returns(certificationSerialized);
     });
 
@@ -221,19 +230,24 @@ describe('Unit | Controller | certification-course-controller', function() {
 
     it('should call assessmentRepository#getByCertificationCourseId with request param', () => {
       // when
-      CertificationCourseController.get(request, reply);
+      const promise = CertificationCourseController.get(request, reply);
 
       // then
-      sinon.assert.calledOnce(assessmentRepository.getByCertificationCourseId);
-      sinon.assert.calledWithExactly(assessmentRepository.getByCertificationCourseId, certificationId);
+      return promise.then(() => {
+        sinon.assert.calledOnce(CertificationCourseRepository.get);
+        sinon.assert.calledWithExactly(CertificationCourseRepository.get, certificationId);
+      });
     });
 
     it('should reply the certification course serialized', () => {
       // when
-      CertificationCourseController.get(request, reply);
+      const promise = CertificationCourseController.get(request, reply);
 
       // then
-      sinon.assert.calledWithExactly(reply, certificationSerialized);
+      return promise.then(() => {
+        sinon.assert.calledOnce(reply);
+        sinon.assert.calledWithExactly(reply, certificationSerialized);
+      });
     });
   });
 });

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -49,14 +49,14 @@ describe('Unit | Controller | certification-course-controller', function() {
       sandbox.restore();
     });
 
-    it('should call repository to create certification-course', function() {
+    it('should call repository to create certification-course with status "started"', function() {
       // when
       const promise = CertificationCourseController.save(request, replyStub);
 
       // then
       return promise.then(() => {
         sinon.assert.calledOnce(CertificationCourseRepository.save);
-        sinon.assert.calledWith(CertificationCourseRepository.save, { userId: 'userId' });
+        sinon.assert.calledWith(CertificationCourseRepository.save, { userId: 'userId', status: 'started' });
       });
     });
 

--- a/api/tests/unit/application/preHandlers/access-session_test.js
+++ b/api/tests/unit/application/preHandlers/access-session_test.js
@@ -6,19 +6,14 @@ describe('Unit | Pre-handler | Session Access', () => {
 
   describe('#sessionIsOpened', () => {
 
-    let replyStub;
-    let takeoverStub;
-    let codeStub;
+    let reply;
+    let takeover;
+    let code;
 
     beforeEach(() => {
-      takeoverStub = sinon.stub();
-      codeStub = sinon.stub();
-      replyStub = sinon.stub().returns({
-        code: codeStub.returns({
-          takeover: takeoverStub
-        })
-      });
-
+      takeover = sinon.stub();
+      code = sinon.stub().returns({ takeover });
+      reply = sinon.stub().returns({ code });
       sinon.stub(SessionService, 'getCurrentCode').returns('e24d32');
     });
 
@@ -37,12 +32,12 @@ describe('Unit | Pre-handler | Session Access', () => {
         const request = { payload: { data: { attributes: {} } } };
 
         // when
-        AccessSession.sessionIsOpened(request, replyStub);
+        AccessSession.sessionIsOpened(request, reply);
 
         // then
-        expect(replyStub).to.have.been.called;
-        expect(codeStub).to.have.been.called;
-        expect(takeoverStub).to.have.been.called;
+        expect(reply).to.have.been.called;
+        expect(code).to.have.been.called;
+        expect(takeover).to.have.been.called;
       });
     });
 
@@ -52,11 +47,11 @@ describe('Unit | Pre-handler | Session Access', () => {
         const request = { payload: { data: { attributes: { id: '1245', 'session-code': 'WrongCode' } } } };
 
         // when
-        AccessSession.sessionIsOpened(request, replyStub);
+        AccessSession.sessionIsOpened(request, reply);
 
         // then
-        expect(replyStub).to.have.been.called;
-        expect(takeoverStub).to.have.been.called;
+        expect(reply).to.have.been.called;
+        expect(takeover).to.have.been.called;
       });
     });
 
@@ -75,11 +70,11 @@ describe('Unit | Pre-handler | Session Access', () => {
         };
 
         // when
-        AccessSession.sessionIsOpened(request, replyStub);
+        AccessSession.sessionIsOpened(request, reply);
 
         // then
-        expect(replyStub).to.have.been.calledWith(requestWithoutSessionCode);
-        expect(takeoverStub).not.to.have.been.called;
+        expect(reply).to.have.been.calledWith(requestWithoutSessionCode);
+        expect(takeover).not.to.have.been.called;
       });
     });
   });

--- a/api/tests/unit/application/preHandlers/access-session_test.js
+++ b/api/tests/unit/application/preHandlers/access-session_test.js
@@ -1,7 +1,6 @@
 const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
 const AccessSession = require('../../../../lib/application/preHandlers/access-session');
 const SessionService = require('../../../../lib/domain/services/session-service');
-const Boom = require('boom');
 
 describe('Unit | Pre-handler | Session Access', () => {
 
@@ -9,19 +8,21 @@ describe('Unit | Pre-handler | Session Access', () => {
 
     let replyStub;
     let takeoverStub;
+    let codeStub;
 
     beforeEach(() => {
       takeoverStub = sinon.stub();
+      codeStub = sinon.stub();
       replyStub = sinon.stub().returns({
-        takeover: takeoverStub
+        code: codeStub.returns({
+          takeover: takeoverStub
+        })
       });
 
-      sinon.stub(Boom, 'unauthorized').returns({ message: 'Not authenticated for session' });
       sinon.stub(SessionService, 'getCurrentCode').returns('e24d32');
     });
 
     afterEach(() => {
-      Boom.unauthorized.restore();
       SessionService.getCurrentCode.restore();
     });
 
@@ -39,7 +40,8 @@ describe('Unit | Pre-handler | Session Access', () => {
         AccessSession.sessionIsOpened(request, replyStub);
 
         // then
-        expect(replyStub).to.have.been.calledWith(Boom.unauthorized());
+        expect(replyStub).to.have.been.called;
+        expect(codeStub).to.have.been.called;
         expect(takeoverStub).to.have.been.called;
       });
     });
@@ -53,7 +55,7 @@ describe('Unit | Pre-handler | Session Access', () => {
         AccessSession.sessionIsOpened(request, replyStub);
 
         // then
-        expect(replyStub).to.have.been.calledWith(Boom.unauthorized());
+        expect(replyStub).to.have.been.called;
         expect(takeoverStub).to.have.been.called;
       });
     });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -115,4 +115,24 @@ describe('Unit | Domain | Errors', () => {
     });
   });
 
+  describe('#AssessmentEndedError', () => {
+    it('should export a AssessmentEndedError', () => {
+      expect(errors.AssessmentEndedError).to.exist;
+    });
+
+    it('should have a getErrorMessage method', () => {
+      // given
+      const expectedErrorMessage = {
+        data: {
+          error: ['L\'évaluation est terminée. Nous n\'avons plus de questions à vous poser.']
+        }
+      };
+
+      // then
+      const userNotFoundError = new errors.AssessmentEndedError();
+      expect(userNotFoundError.getErrorMessage).to.be.a('function');
+      expect(userNotFoundError.getErrorMessage()).to.eql(expectedErrorMessage);
+    });
+  });
+
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -116,7 +116,7 @@ describe('Unit | Domain | Errors', () => {
   });
 
   describe('#AssessmentEndedError', () => {
-    it('should export a AssessmentEndedError', () => {
+    it('should export an AssessmentEndedError', () => {
       expect(errors.AssessmentEndedError).to.exist;
     });
 
@@ -129,9 +129,9 @@ describe('Unit | Domain | Errors', () => {
       };
 
       // then
-      const userNotFoundError = new errors.AssessmentEndedError();
-      expect(userNotFoundError.getErrorMessage).to.be.a('function');
-      expect(userNotFoundError.getErrorMessage()).to.eql(expectedErrorMessage);
+      const AssessmentEndedError = new errors.AssessmentEndedError();
+      expect(AssessmentEndedError.getErrorMessage).to.be.a('function');
+      expect(AssessmentEndedError.getErrorMessage()).to.eql(expectedErrorMessage);
     });
   });
 

--- a/api/tests/unit/domain/models/certification-cours_test.js
+++ b/api/tests/unit/domain/models/certification-cours_test.js
@@ -1,0 +1,72 @@
+const { describe, it, expect, sinon, beforeEach } = require('../../../test-helper');
+const CertificationChallenge = require('../../../../lib/domain/models/data/certification-course');
+
+describe('Unit | Domain | Models | CertificationChallenge', () => {
+
+  describe('validation', () => {
+
+    let rawData;
+
+    beforeEach(() => {
+      rawData = {
+        status: null
+      };
+    });
+
+    describe('the status field', () => {
+      it('is required', () => {
+        // Given
+        const certification = new CertificationChallenge(rawData);
+
+        // When
+        const promise = certification.save();
+
+        // Then
+        return promise
+          .then(() => {
+            sinon.assert.fail('Cannot succeed');
+          })
+          .catch((err) => {
+            const status = err.data['status'];
+            expect(status).to.deep.equal(['Le champ status doit être renseigné.']);
+          });
+      });
+
+      it('should only accept specific values', () => {
+        // Given
+        rawData.status = 'not_a_correct_status';
+        const certification = new CertificationChallenge(rawData);
+
+        // When
+        const promise = certification.save();
+
+        // Then
+        return promise
+          .then(() => {
+            sinon.assert.fail('Cannot succeed');
+          })
+          .catch((err) => {
+            const status = err.data['status'];
+            expect(status).to.exist.and.to.deep.equal(['Le status de la certification n\'est pas valide']);
+          });
+      });
+
+      ['started', 'completed', 'validated', 'rejected'].forEach((organizationType) => {
+        it(`should be saved when organisation type is ${organizationType}`, () => {
+          // Given
+          rawData.status = organizationType;
+          const certification = new CertificationChallenge(rawData);
+
+          // When
+          const promise = certification.save();
+
+          // Then
+          return promise
+            .catch(_ => {
+              sinon.assert.fail(new Error(`Should not fail with ${organizationType} type`));
+            });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/certification-course_test.js
+++ b/api/tests/unit/domain/models/certification-course_test.js
@@ -1,7 +1,7 @@
 const { describe, it, expect, sinon, beforeEach } = require('../../../test-helper');
-const CertificationChallenge = require('../../../../lib/domain/models/data/certification-course');
+const CertificationCourse = require('../../../../lib/domain/models/data/certification-course');
 
-describe('Unit | Domain | Models | CertificationChallenge', () => {
+describe('Unit | Domain | Models | CertificationCourse', () => {
 
   describe('validation', () => {
 
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | CertificationChallenge', () => {
     describe('the status field', () => {
       it('is required', () => {
         // Given
-        const certification = new CertificationChallenge(rawData);
+        const certification = new CertificationCourse(rawData);
 
         // When
         const promise = certification.save();
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | CertificationChallenge', () => {
       it('should only accept specific values', () => {
         // Given
         rawData.status = 'not_a_correct_status';
-        const certification = new CertificationChallenge(rawData);
+        const certification = new CertificationCourse(rawData);
 
         // When
         const promise = certification.save();
@@ -55,7 +55,7 @@ describe('Unit | Domain | Models | CertificationChallenge', () => {
         it(`should be saved when organisation type is ${organizationType}`, () => {
           // Given
           rawData.status = organizationType;
-          const certification = new CertificationChallenge(rawData);
+          const certification = new CertificationCourse(rawData);
 
           // When
           const promise = certification.save();

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -100,7 +100,6 @@ describe('Unit | Domain | Services | assessment-service', () => {
       return expect(promise).to.be.rejectedWith(AssessmentEndedError);
     });
 
-
     it('Should reject with a AssessmentEndedError when the course is a preview', () => {
       // given
       const assessment = _buildAssessmentForCourse('null22');

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -17,6 +17,7 @@ const CertificationChallenge = require('../../../../lib/domain/models/Certificat
 
 const Answer = require('../../../../lib/domain/models/data/answer');
 const Skill = require('../../../../lib/cat/skill');
+const { AssessmentEndedError } = require('../../../../lib/domain/errors');
 
 function _buildChallenge(challengeId, skills) {
   const challenge = new Challenge();
@@ -53,9 +54,17 @@ describe('Unit | Domain | Services | assessment-service', () => {
 
   describe('#getAssessmentNextChallengeId', () => {
 
+    beforeEach(() => {
+      sinon.stub(courseRepository, 'get').resolves();
+    });
+
+    afterEach(() => {
+      courseRepository.get.restore();
+    });
+
     it('Should return the first challenge if no currentChallengeId is given', () => {
       // given
-      sinon.stub(courseRepository, 'get').resolves({ challenges: ['the_first_challenge'] });
+      courseRepository.get.resolves({ challenges: ['the_first_challenge'] });
 
       // when
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), null);
@@ -63,13 +72,12 @@ describe('Unit | Domain | Services | assessment-service', () => {
       // then
       return promise.then((result) => {
         expect(result).to.equal('the_first_challenge');
-        courseRepository.get.restore();
       });
     });
 
     it('Should return the next challenge if currentChallengeId is given', () => {
       // given
-      sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
+      courseRepository.get.resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
 
       // when
       const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '1st_challenge');
@@ -77,48 +85,33 @@ describe('Unit | Domain | Services | assessment-service', () => {
       // then
       return promise.then((result) => {
         expect(result).to.equal('2nd_challenge');
-        courseRepository.get.restore();
       });
 
     });
 
-    it('Should resolves to "null" if no assessment is given', () => {
-      // when
-      const promise = service.getAssessmentNextChallengeId();
-
-      // then
-      return promise.then((result) => {
-        expect(result).to.equal(null);
-      });
-    });
-
-    it('Should resolves to "null" if no courseId is given', () => {
+    it('Should throw a AssessmentEndedError when there are no more challenges to ask', () => {
       // given
-      sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
+      courseRepository.get.resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
 
       // when
-      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse(), '1st_challenge');
+      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('22'), '2nd_challenge');
 
       // then
-      return promise.then((result) => {
-        expect(result).to.equal(null);
-        courseRepository.get.restore();
-      });
-
+      return expect(promise).to.be.rejectedWith(AssessmentEndedError);
     });
 
-    it('Should resolves to "null" if courseId starts with "null"', () => {
+
+    it('Should reject with a AssessmentEndedError when the course is a preview', () => {
       // given
-      sinon.stub(courseRepository, 'get').resolves({ challenges: ['1st_challenge', '2nd_challenge'] });
+      const assessment = _buildAssessmentForCourse('null22');
+      assessment.set('type', 'PREVIEW');
 
       // when
-      const promise = service.getAssessmentNextChallengeId(_buildAssessmentForCourse('null22'), '1st_challenge');
+      const promise = service.getAssessmentNextChallengeId(assessment, '1st_challenge');
 
       // then
-      return promise.then((result) => {
-        expect(result).to.equal(null);
-        courseRepository.get.restore();
-      });
+      expect(courseRepository.get).not.to.have.been.called;
+      return expect(promise).to.be.rejectedWith(AssessmentEndedError);
     });
   });
 

--- a/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
@@ -3,7 +3,7 @@ const { describe, it, expect, sinon, beforeEach, afterEach, knex } = require('..
 const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
 const CertificationChallengeBookshelf = require('../../../../lib/domain/models/data/certification-challenge');
 const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');
-const { NotFoundError } = require('../../../../lib/domain/errors');
+const { AssessmentEndedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Repository | certification-challenge-repository', () => {
 
@@ -247,8 +247,7 @@ describe('Unit | Repository | certification-challenge-repository', () => {
         );
 
         // then
-        //return expect(promise).to.be.rejectedWith('EmptyResponse');
-        return expect(promise).to.be.rejectedWith(NotFoundError);
+        return expect(promise).to.be.rejectedWith(AssessmentEndedError);
       });
 
     });

--- a/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
@@ -10,7 +10,7 @@ describe('Unit | Repository | Certification Course', function() {
     let certificationCourse;
 
     beforeEach(() => {
-      certificationCourse = new CertificationCourse({ id: 'certifId', userId: 1, status : 'completed' });
+      certificationCourse = new CertificationCourse({ id: 'certifId', userId: 1, status: 'completed' });
       const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourse);
       sinon.stub(CertificationCourseBookshelf.prototype, 'save').resolves(certificationCourseBookshelf);
     });
@@ -19,7 +19,7 @@ describe('Unit | Repository | Certification Course', function() {
       CertificationCourseBookshelf.prototype.save.restore();
     });
 
-    it('should save the certification-course', function() {
+    it('should save the certification-course', () => {
       // when
       const promise = CertificationCourseRepository.save(certificationCourse);
 
@@ -30,7 +30,7 @@ describe('Unit | Repository | Certification Course', function() {
 
     });
 
-    it('return the saved certification course in JSON ', function() {
+    it('return the saved certification course in JSON ', () => {
       // when
       const promise = CertificationCourseRepository.save(certificationCourse);
 

--- a/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
@@ -10,7 +10,7 @@ describe('Unit | Repository | Certification Course', function() {
     let certificationCourse;
 
     beforeEach(() => {
-      certificationCourse = new CertificationCourse({ id: 'certifId', userId: 1 });
+      certificationCourse = new CertificationCourse({ id: 'certifId', userId: 1, status : 'completed' });
       const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourse);
       sinon.stub(CertificationCourseBookshelf.prototype, 'save').resolves(certificationCourseBookshelf);
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -13,6 +13,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
     const certificationCourse = new CertificationCourse({
       id: 'certification_id',
       userId : 2,
+      status : 'completed',
       assessment: assessment
     });
 
@@ -21,7 +22,8 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         type: 'certification-courses',
         id: 'certification_id',
         attributes : {
-          'user-id': '2'
+          'user-id': '2',
+          'status' : 'completed'
         },
         relationships: {
           assessment: {


### PR DESCRIPTION
Hello, petit brief sur ce qu'il s'est fait : 

**Pour l'ajout du statut :** 
- Ajout d'un champs sur la table certif-course 
- Récupérer le statut et le transmettre dans /certification-courses (repo, controller, serializer ...)

**Un BSR qui a dérapé (refacto du controller get-next-challenge, pas parfait mais qui se conduit proprement maintenant) :**

- On a refacto en faisant en sorte que l'endpoint ne renvoie plus jamais `null` mais plutot un code 404 adapté (à challenger avec 204 à votre guise).
- Création de l'erreur AssessmentEnded plus parlante et qu'on utilise dans le controller.