### PR TITLE
[#656] [TECH] Normalisation des URLs coté API (US-1037). 

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -11,11 +11,15 @@ const config = require('./lib/settings');
 const logger = require('./lib/infrastructure/logger');
 
 const server = new Hapi.Server({
-  'connections': {
-    'routes': {
-      'cors': true
+  connections: {
+    routes: {
+      cors: true
+    },
+    router: {
+      isCaseSensitive: false,
+      stripTrailingSlash: true
     }
-  }
+  },
 });
 
 server.connection({ port: config.port });


### PR DESCRIPTION
C'est un papercut rapide. Avec ce changement, les URLs suivantes fonctionnent :
- `GET /api/healthcheck`
- `GET /api/healthcheck/`
- `GET /api/HealthCheck` 

Ça simplifie ma vie, je propose, et je pense pas être le seul à m'être tapé un 404 à cause d'un `/` en fin d'URL. :/

Ref de la doc: https://hapijs.com/api#-serveroptionsrouter