### PR TITLE
[#665] [TECH] Migrer le serializer JSON:API pour les groupe de tests

### DIFF
--- a/api/lib/application/courseGroups/course-group-controller.js
+++ b/api/lib/application/courseGroups/course-group-controller.js
@@ -18,7 +18,7 @@ module.exports = {
         const coursesMappedById = _mapCourseById(courses);
         const extendedlistOfCourseGroupWithCourse = _addCourseDetailsToCourseGroups(courseGroups, coursesMappedById);
 
-        reply(courseGroupSerializer.serializeArray(extendedlistOfCourseGroupWithCourse));
+        reply(courseGroupSerializer.serialize(extendedlistOfCourseGroupWithCourse));
       });
 
   }

--- a/api/tests/unit/application/courseGroups/course-group-controller_test.js
+++ b/api/tests/unit/application/courseGroups/course-group-controller_test.js
@@ -46,7 +46,7 @@ describe('Unit | Controller | course-group-controller', function() {
 
       // Then
       return promise.then((res) => {
-        expect(res.result).to.deep.equal(courseGroupSerializer.serializeArray(courseGroups));
+        expect(res.result).to.deep.equal(courseGroupSerializer.serialize(courseGroups));
       });
 
     });
@@ -97,7 +97,7 @@ describe('Unit | Controller | course-group-controller', function() {
           {
             'data': [
               {
-                'type': 'course-group',
+                'type': 'course-groups',
                 'id': 'serie1',
                 'attributes': {
                   'name': 'OTTO'
@@ -159,7 +159,7 @@ describe('Unit | Controller | course-group-controller', function() {
           {
             'data': [
               {
-                'type': 'course-group',
+                'type': 'course-groups',
                 'id': 'serie1',
                 'attributes': {
                   'name': 'OTTO'

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-group-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-group-serializer_test.js
@@ -6,29 +6,97 @@ describe('Unit | Serializer | JSONAPI | course-group-serializer', function() {
 
   describe('#serialize', function() {
 
-    it('should convert courseGroup model Object to JSON API', function() {
+    context('Single object', function() {
+
+      it('should convert courseGroup model Object to JSON API', function() {
 
       //given
-      const courseGroup = new CourseGroup();
-      courseGroup.id = 'fakeId';
-      courseGroup.name = 'name of courseGroup';
-      courseGroup.courses = [{
-        id: 'courseId1',
-        name: 'first course',
-        description: 'first course description',
-        imageUrl: 'urlImage',
-        challenges: ['challenge1', 'challenge2', 'challenge3']
-      }, {
-        id: 'courseId2',
-        name: 'second course',
-        description: 'second course description',
-        imageUrl: 'urlImage'
-      }];
+        const courseGroup = new CourseGroup();
+        courseGroup.id = 'fakeId';
+        courseGroup.name = 'name of courseGroup';
+        courseGroup.courses = [{
+          id: 'courseId1',
+          name: 'first course',
+          description: 'first course description',
+          imageUrl: 'urlImage',
+          challenges: ['challenge1', 'challenge2', 'challenge3']
+        }, {
+          id: 'courseId2',
+          name: 'second course',
+          description: 'second course description',
+          imageUrl: 'urlImage'
+        }];
 
-      const expectedJsonApicourseGroup = {
-        data: {
-          type: 'course-group',
-          id: 'fakeId',
+        const expectedJsonApicourseGroup = {
+          data: {
+            type: 'course-groups',
+            id: 'fakeId',
+            attributes: {
+              name: 'name of courseGroup'
+            },
+            relationships: {
+              courses: {
+                data: [
+                  { type: 'courses', id: 'courseId1' },
+                  { type: 'courses', id: 'courseId2' }
+                ]
+              }
+            }
+          },
+          included: [{
+            type: 'courses',
+            id: 'courseId1',
+            attributes: {
+              name: 'first course',
+              description: 'first course description',
+              'image-url': 'urlImage',
+              'nb-challenges': 3
+            }
+          }, {
+            type: 'courses',
+            id: 'courseId2',
+            attributes: {
+              name: 'second course',
+              description: 'second course description',
+              'image-url': 'urlImage',
+              'nb-challenges': 0
+            }
+          }]
+        };
+
+        // when
+        const jsonApicourseGroup = serializer.serialize(courseGroup);
+
+        // then
+        expect(jsonApicourseGroup).to.deep.equal(expectedJsonApicourseGroup);
+      });
+    });
+
+    context('Array', function() {
+
+      //given
+      const courseGroup1 = new CourseGroup();
+      courseGroup1.id = 'fakeId1';
+      courseGroup1.name = 'name of courseGroup';
+      courseGroup1.courses = [
+        { id: 'courseId1', name: 'first course', description: 'first course description', imageUrl: 'urlImage', challenges: ['challenge1', 'challenge2'] },
+        { id: 'courseId2', name: 'second course', description: 'second course description', imageUrl: 'urlImage' }
+      ];
+
+      const courseGroup2 = new CourseGroup();
+      courseGroup2.id = 'fakeId2';
+      courseGroup2.name = 'name of courseGroup';
+      courseGroup2.courses = [
+        { id: 'courseId3', name: 'third course', description: 'third course description', imageUrl: 'urlImage' },
+        { id: 'courseId4', name: 'fourth course', description: 'fourth course description', imageUrl: 'urlImage' }
+      ];
+
+      const courseGroupsArray = [courseGroup1, courseGroup2];
+
+      const expectedJsonApicourseGroups = {
+        data: [{
+          type: 'course-groups',
+          id: 'fakeId1',
           attributes: {
             name: 'name of courseGroup'
           },
@@ -40,7 +108,21 @@ describe('Unit | Serializer | JSONAPI | course-group-serializer', function() {
               ]
             }
           }
-        },
+        }, {
+          type: 'course-groups',
+          id: 'fakeId2',
+          attributes: {
+            name: 'name of courseGroup'
+          },
+          relationships: {
+            courses: {
+              data: [
+                { type: 'courses', id: 'courseId3' },
+                { type: 'courses', id: 'courseId4' }
+              ]
+            }
+          }
+        }],
         included: [{
           type: 'courses',
           id: 'courseId1',
@@ -48,7 +130,7 @@ describe('Unit | Serializer | JSONAPI | course-group-serializer', function() {
             name: 'first course',
             description: 'first course description',
             'image-url': 'urlImage',
-            'nb-challenges': 3
+            'nb-challenges': 2
           }
         }, {
           type: 'courses',
@@ -59,115 +141,35 @@ describe('Unit | Serializer | JSONAPI | course-group-serializer', function() {
             'image-url': 'urlImage',
             'nb-challenges': 0
           }
+        }, {
+          type: 'courses',
+          id: 'courseId3',
+          attributes: {
+            name: 'third course',
+            description: 'third course description',
+            'image-url': 'urlImage',
+            'nb-challenges': 0
+          }
+        }, {
+          type: 'courses',
+          id: 'courseId4',
+          attributes: {
+            name: 'fourth course',
+            description: 'fourth course description',
+            'image-url': 'urlImage',
+            'nb-challenges': 0
+          }
         }]
       };
 
-      // when
-      const jsonApicourseGroup = serializer.serialize(courseGroup);
+      it('should convert an array of courseGroup model to JSON API', function() {
+        // when
+        const jsonApicourseGroup = serializer.serialize(courseGroupsArray);
 
-      // then
-      expect(jsonApicourseGroup).to.deep.equal(expectedJsonApicourseGroup);
+        // then
+        expect(jsonApicourseGroup).to.deep.equal(expectedJsonApicourseGroups);
+      });
     });
   });
 
-  describe('#serializeArray', function() {
-
-    //given
-    const courseGroup1 = new CourseGroup();
-    courseGroup1.id = 'fakeId1';
-    courseGroup1.name = 'name of courseGroup';
-    courseGroup1.courses = [
-      { id: 'courseId1', name: 'first course', description: 'first course description', imageUrl: 'urlImage', challenges: ['challenge1', 'challenge2'] },
-      { id: 'courseId2', name: 'second course', description: 'second course description', imageUrl: 'urlImage' }
-    ];
-
-    const courseGroup2 = new CourseGroup();
-    courseGroup2.id = 'fakeId2';
-    courseGroup2.name = 'name of courseGroup';
-    courseGroup2.courses = [
-      { id: 'courseId3', name: 'third course', description: 'third course description', imageUrl: 'urlImage' },
-      { id: 'courseId4', name: 'fourth course', description: 'fourth course description', imageUrl: 'urlImage' }
-    ];
-
-    const courseGroupsArray = [courseGroup1, courseGroup2];
-
-    const expectedJsonApicourseGroups = {
-      data: [{
-        type: 'course-group',
-        id: 'fakeId1',
-        attributes: {
-          name: 'name of courseGroup'
-        },
-        relationships: {
-          courses: {
-            data: [
-              { type: 'courses', id: 'courseId1' },
-              { type: 'courses', id: 'courseId2' }
-            ]
-          }
-        }
-      }, {
-        type: 'course-group',
-        id: 'fakeId2',
-        attributes: {
-          name: 'name of courseGroup'
-        },
-        relationships: {
-          courses: {
-            data: [
-              { type: 'courses', id: 'courseId3' },
-              { type: 'courses', id: 'courseId4' }
-            ]
-          }
-        }
-      }],
-      included: [{
-        type: 'courses',
-        id: 'courseId1',
-        attributes: {
-          name: 'first course',
-          description: 'first course description',
-          'image-url': 'urlImage',
-          'nb-challenges': 2
-        }
-      }, {
-        type: 'courses',
-        id: 'courseId2',
-        attributes: {
-          name: 'second course',
-          description: 'second course description',
-          'image-url': 'urlImage',
-          'nb-challenges': 0
-        }
-      }, {
-        type: 'courses',
-        id: 'courseId3',
-        attributes: {
-          name: 'third course',
-          description: 'third course description',
-          'image-url': 'urlImage',
-          'nb-challenges': 0
-        }
-      }, {
-        type: 'courses',
-        id: 'courseId4',
-        attributes: {
-          name: 'fourth course',
-          description: 'fourth course description',
-          'image-url': 'urlImage',
-          'nb-challenges': 0
-        }
-      }]
-    };
-
-    it('should convert an array of courseGroup model to JSON API', function() {
-      // when
-      const jsonApicourseGroup = serializer.serializeArray(courseGroupsArray);
-
-      // then
-      expect(jsonApicourseGroup).to.deep.equal(expectedJsonApicourseGroups);
-    });
-  });
-
-})
-;
+});


### PR DESCRIPTION
- [x] Utiliser le module jsonapi-serializer#Serializer à la place de l'ancienne implémentation custom
- [x] Supprimer la méthode `#serializeArray` qui est désormais couverte par `#serialize`