### PR TITLE
[#672] [BUGFIX] Vérification que l'on trouve bien un Test d'après le courseId dans le profil (US-1047).

### DIFF
--- a/api/lib/domain/models/data/profile.js
+++ b/api/lib/domain/models/data/profile.js
@@ -65,8 +65,10 @@ class Profile {
     assessments.forEach(assessment => {
       const courseIdFromAssessment = assessment.courseId;
       const course = this._getCourseById(courses, courseIdFromAssessment);
-      const competence = this.competences.find(competence => course.competences.includes(competence.id));
-      competence.assessmentId = assessment.id;
+      if(course) {
+        const competence = this.competences.find(competence => course.competences.includes(competence.id));
+        competence.assessmentId = assessment.id;
+      }
     });
   }
 
@@ -74,7 +76,7 @@ class Profile {
     return assessments.filter((assessment) => {
       const courseIdFromAssessment = assessment.courseId;
       const course = this._getCourseById(courses, courseIdFromAssessment);
-      return course.competences.indexOf(competenceId) > -1;
+      return course ? course.competences.indexOf(competenceId) > -1 : false;
     });
   }
 

--- a/api/lib/domain/models/data/profile.js
+++ b/api/lib/domain/models/data/profile.js
@@ -76,7 +76,7 @@ class Profile {
     return assessments.filter((assessment) => {
       const courseIdFromAssessment = assessment.courseId;
       const course = this._getCourseById(courses, courseIdFromAssessment);
-      return course ? course.competences.indexOf(competenceId) > -1 : false;
+      return course ? course.competences.includes(competenceId) : false;
     });
   }
 

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -360,7 +360,7 @@ describe('Unit | Domain | Models | Profile', () => {
     });
 
     context('when user has one assessment without existing courseId', () => {
-      it('should', () => {
+      it('should return the profile without only assessment of placement in competences', () => {
         // Given
         courses[0].competences = ['competenceId1'];
         assessmentsCompleted = [new Assessment({

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -359,8 +359,8 @@ describe('Unit | Domain | Models | Profile', () => {
 
     });
 
-    context('when user has one assessment without existing courseId', () => {
-      it('should return the profile without only assessment of placement in competences', () => {
+    context('when user has one assessment without competence linked to the courseId', () => {
+      it('should return the profile only with competences linked to Competences', () => {
         // Given
         courses[0].competences = ['competenceId1'];
         assessmentsCompleted = [new Assessment({

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -407,9 +407,9 @@ describe('Unit | Domain | Models | Profile', () => {
         expect(profile.competences).to.be.deep.equal(expectedCompetences);
         expect(profile.areas).to.be.equal(areas);
 
-      })
+      });
 
-    })
+    });
 
     describe('when calculating score', () => {
 

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -359,6 +359,58 @@ describe('Unit | Domain | Models | Profile', () => {
 
     });
 
+    context('when user has one assessment without existing courseId', () => {
+      it('should', () => {
+        // Given
+        courses[0].competences = ['competenceId1'];
+        assessmentsCompleted = [new Assessment({
+          id: 'assessmentId1',
+          pixScore: 10,
+          estimatedLevel: 1,
+          courseId: 'courseId8'
+        }), new Assessment({
+          id: 'assessmentId2',
+          pixScore: null,
+          estimatedLevel: null,
+          courseId: 'DemoCourse'
+        })];
+
+        const expectedCompetences = [
+          {
+            id: 'competenceId1',
+            name: '1.1 Mener une recherche d’information',
+            index: '1.1',
+            areaId: 'areaId1',
+            level: 1,
+            pixScore: 10,
+            assessmentId: 'assessmentId1',
+            status: 'evaluated',
+            courseId: 'courseId8'
+          },
+          {
+            id: 'competenceId2',
+            name: '1.2 Gérer des données',
+            index: '1.2',
+            areaId: 'areaId2',
+            level: -1,
+            status: 'notEvaluated',
+            courseId: 'courseId9'
+          }
+        ];
+
+        // When
+        const profile = new Profile(user, competences, areas, assessmentsCompleted, assessmentsCompleted, courses);
+
+        // Then
+        expect(profile).to.be.an.instanceof(Profile);
+        expect(profile.user).to.be.equal(user);
+        expect(profile.competences).to.be.deep.equal(expectedCompetences);
+        expect(profile.areas).to.be.equal(areas);
+
+      })
+
+    })
+
     describe('when calculating score', () => {
 
       beforeEach(() => {

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -403,9 +403,9 @@ describe('Unit | Domain | Models | Profile', () => {
 
         // Then
         expect(profile).to.be.an.instanceof(Profile);
-        expect(profile.user).to.be.equal(user);
-        expect(profile.competences).to.be.deep.equal(expectedCompetences);
-        expect(profile.areas).to.be.equal(areas);
+        expect(profile.user).to.equal(user);
+        expect(profile.competences).to.deep.equal(expectedCompetences);
+        expect(profile.areas).to.equal(areas);
 
       });
 


### PR DESCRIPTION
Le bug de connexion de benoit venait d'un test de DEMO passé par lui et enregistré dans ses assessments.

Au moment de récupérer le profile (users/me) à la connexion, on tentait d'ajouter la compétence lié, sauf que le courseId ne correspond à aucune compétence. 

Correction: lors de la création du profile, si on a besoin du course (de la compétence), on filtre ou on n'ajoute pas de compétence à l'assessment.