### PR TITLE
[#688] [CLEANUP] Suppression des imports de fonctions Mocha inutiles dans les tests de l'API (US-1096).

### DIFF
--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -156,7 +156,7 @@ class ScriptQueryBuilder {
 if (process.env.NODE_ENV !== 'test') {
   main();
 } else {
-  const { describe, it, beforeEach } = require('mocha');
+  const { beforeEach } = require('mocha');
   const { expect } = require('chai');
   describe('Delete User Script', () => {
     describe('ScriptQueryBuilder', () => {

--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -156,7 +156,6 @@ class ScriptQueryBuilder {
 if (process.env.NODE_ENV !== 'test') {
   main();
 } else {
-  const { beforeEach } = require('mocha');
   const { expect } = require('chai');
   describe('Delete User Script', () => {
     describe('ScriptQueryBuilder', () => {

--- a/api/tests/acceptance/application/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answer-controller-find_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Controller | answer-controller', function() {

--- a/api/tests/acceptance/application/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answer-controller-get_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Controller | answer-controller', function() {

--- a/api/tests/acceptance/application/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answer-controller-save_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 const Answer = require('../../../lib/infrastructure/data/answer');
 

--- a/api/tests/acceptance/application/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answer-controller-update_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const server = require('../../../server');
 const Answer = require('../../../lib/infrastructure/data/answer');
 

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive-correct_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 

--- a/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-adaptive_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 

--- a/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-nonadaptive_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 

--- a/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get-solutions_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, before, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 

--- a/api/tests/acceptance/application/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessment-controller-get_test.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const { describe, it, after, before, beforeEach, afterEach, expect, knex, nock } = require('../../test-helper');
+const { expect, knex, nock } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/cache');
 const server = require('../../../server');
 const settings = require('../../../lib/settings');

--- a/api/tests/acceptance/application/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessment-controller-post_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 const BookshelfAssessment = require('../../../lib/infrastructure/data/assessment');
 

--- a/api/tests/acceptance/application/assessment-rating-controller_test.js
+++ b/api/tests/acceptance/application/assessment-rating-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
 const _ = require('lodash');

--- a/api/tests/acceptance/application/authentication-controller-save_test.js
+++ b/api/tests/acceptance/application/authentication-controller-save_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, before, after, knex, expect } = require('../../test-helper');
+const { knex, expect } = require('../../test-helper');
 
 const faker = require('faker');
 const jsonwebtoken = require('jsonwebtoken');

--- a/api/tests/acceptance/application/challenge-controller_test.js
+++ b/api/tests/acceptance/application/challenge-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, nock } = require('../../test-helper');
+const { expect, nock } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | API | ChallengeController', function() {

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, nock } = require('../../test-helper');
+const { expect, nock } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | API | Courses', function() {

--- a/api/tests/acceptance/application/error-controller_test.js
+++ b/api/tests/acceptance/application/error-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, expect } = require('../../test-helper');
+const { expect } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Controller | error-controller', function() {

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 const Feedback = require('../../../lib/infrastructure/data/feedback');
 

--- a/api/tests/acceptance/application/follower-controller_test.js
+++ b/api/tests/acceptance/application/follower-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, knex, sinon } = require('../../test-helper');
+const { expect, knex, sinon } = require('../../test-helper');
 const server = require('../../../server');
 const mailService = require('../../../lib/domain/services/mail-service');
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const { describe, it, after, expect, afterEach, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 const settings = require('../../../lib/settings');
 

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -1,5 +1,5 @@
 const faker = require('faker');
-const { describe, it, before, after, expect, afterEach, beforeEach, knex, sinon } = require('../../test-helper');
+const { expect, knex, sinon } = require('../../test-helper');
 const mailjetService = require('../../../lib/domain/services/mail-service');
 const resetPasswordService = require('../../../lib/domain/services/reset-password-service');
 const resetPasswordDemandRepository = require('../../../lib/infrastructure/repositories/reset-password-demands-repository');

--- a/api/tests/acceptance/application/session-controller_test.js
+++ b/api/tests/acceptance/application/session-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, afterEach, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Controller | session-controller', function() {

--- a/api/tests/acceptance/application/snapshot-controller_test.js
+++ b/api/tests/acceptance/application/snapshot-controller_test.js
@@ -1,6 +1,6 @@
 const faker = require('faker');
 const bcrypt = require('bcrypt');
-const { describe, it, after, before, expect, afterEach, beforeEach, knex, sinon } = require('../../test-helper');
+const { expect, knex, sinon } = require('../../test-helper');
 const authorizationToken = require('../../../lib/infrastructure/validators/jsonwebtoken-verify');
 const profileService = require('../../../lib/domain/services/profile-service');
 const User = require('../../../lib/infrastructure/data/user');

--- a/api/tests/acceptance/application/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users-controller-get-profile_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../test-helper');
+const { expect, sinon } = require('../../test-helper');
 const faker = require('faker');
 const server = require('../../../server');
 const authorizationToken = require('../../../lib/infrastructure/validators/jsonwebtoken-verify');

--- a/api/tests/acceptance/application/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users-controller-save_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, before, expect, sinon } = require('../../test-helper');
+const { expect, sinon } = require('../../test-helper');
 const faker = require('faker');
 
 const server = require('../../../server');

--- a/api/tests/acceptance/application/users-controller-update-password_test.js
+++ b/api/tests/acceptance/application/users-controller-update-password_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, afterEach, before, expect, knex } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 const faker = require('faker');
 
 const server = require('../../../server');

--- a/api/tests/acceptance/infrastructure/repositories/feedback-repository_test.js
+++ b/api/tests/acceptance/infrastructure/repositories/feedback-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, knex } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 const feedbackRepository = require('../../../../lib/infrastructure/repositories/feedback-repository');
 
 describe('Acceptance | Infrastructure | Repositories | feedback-repository', () => {

--- a/api/tests/acceptance/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/acceptance/infrastructure/repositories/skill-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, knex, afterEach } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 
 const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
 

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, knex, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, beforeEach, afterEach, it, knex } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 
 const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, beforeEach, afterEach, it, knex } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 

--- a/api/tests/integration/infrastructure/repositories/mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mark-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, afterEach, it, knex } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 
 const Mark = require('../../../../lib/domain/models/Mark');
 const MarkRepository = require('../../../../lib/infrastructure/repositories/mark-repository');

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, afterEach, it, knex } = require('../../../test-helper');
+const { expect, knex } = require('../../../test-helper');
 
 const Session = require('../../../../lib/domain/models/Session');
 const SessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,6 +1,3 @@
-// Mocha
-const { describe, it, before, after, beforeEach, afterEach } = require('mocha');
-
 // Chai
 const chai = require('chai');
 const expect = chai.expect;
@@ -19,13 +16,6 @@ const nock = require('nock');
 nock.disableNetConnect();
 
 module.exports = {
-  describe,
-  context:describe,
-  it,
-  before,
-  after,
-  beforeEach,
-  afterEach,
   expect,
   sinon,
   knex,

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, afterEach, expect, knex, sinon } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const Answer = require('../../../../lib/infrastructure/data/answer');
 const solutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const AnswerController = require('../../../../lib/application/answers/answer-controller');
 

--- a/api/tests/unit/application/assessment-ratings/assessment-ratings-controller_test.js
+++ b/api/tests/unit/application/assessment-ratings/assessment-ratings-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 
 const Boom = require('boom');
 

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const Boom = require('boom');
 
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');

--- a/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-solution_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 
 const Boom = require('boom');
 const logger = require('../../../../lib/infrastructure/logger');

--- a/api/tests/unit/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 const Boom = require('boom');
 

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const Boom = require('boom');
 
 const controller = require('../../../../lib/application/assessments/assessment-controller');

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, expect, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
 

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const AssessmentController = require('../../../../lib/application/assessments/assessment-controller');
 const AssessmentAuthorization = require('../../../../lib/application/preHandlers/assessment-authorization');

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, after, beforeEach, before, knex, sinon, expect } = require('../../../test-helper');
+const { knex, sinon, expect } = require('../../../test-helper');
 
 const faker = require('faker');
 const server = require('../../../../server');

--- a/api/tests/unit/application/authentication/index_test.js
+++ b/api/tests/unit/application/authentication/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const AuthenticationController = require('../../../../lib/application/authentication/authentication-controller');
 

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const CertificationCourseController = require('../../../../lib/application/certificationCourses/certification-course-controller');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');

--- a/api/tests/unit/application/certificationCourses/index_test.js
+++ b/api/tests/unit/application/certificationCourses/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const certificationCoursesController = require('../../../../lib/application/certificationCourses/certification-course-controller');
 

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 const ChallengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');

--- a/api/tests/unit/application/challenges/index_test.js
+++ b/api/tests/unit/application/challenges/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const ChallengeController = require('../../../../lib/application/challenges/challenge-controller');
 

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, afterEach, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const Boom = require('boom');
 const Course = require('../../../../lib/domain/models/Course');

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const CourseController = require('../../../../lib/application/courses/course-controller');
 

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const _ = require('lodash');
 const Feedback = require('../../../../lib/infrastructure/data/feedback');

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, before, after, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const feedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
 

--- a/api/tests/unit/application/followers/follower-controller_test.js
+++ b/api/tests/unit/application/followers/follower-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const EmailValidator = require('../../../../lib/domain/services/email-validator');
 const Follower = require('../../../../lib/infrastructure/data/follower');
 const followerSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/follower-serializer');

--- a/api/tests/unit/application/followers/index_test.js
+++ b/api/tests/unit/application/followers/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, before, after, beforeEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const FollowerController = require('../../../../lib/application/followers/follower-controller');
 

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const healthcheckRepository = require('../../../../lib/infrastructure/repositories/healthcheck-repository');
 
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, before, beforeEach, after, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');
 

--- a/api/tests/unit/application/metrics/index_test.js
+++ b/api/tests/unit/application/metrics/index_test.js
@@ -1,6 +1,6 @@
 const PROJECT_ROOT = '../../../..';
 
-const { describe, it, expect, before, beforeEach, after, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const metricController = require(`${PROJECT_ROOT}/lib/application/metrics/metric-controller`);
 

--- a/api/tests/unit/application/metrics/metric-controller_test.js
+++ b/api/tests/unit/application/metrics/metric-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const metricController = require('../../../../lib/application/metrics/metric-controller');
 

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 
 const organisationController = require('../../../../lib/application/organizations/organization-controller');

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 const User = require('../../../../lib/infrastructure/data/user');
 const Organisation = require('../../../../lib/infrastructure/data/organization');

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const passwordController = require('../../../../lib/application/passwords/password-controller');
 

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const User = require('../../../../lib/infrastructure/data/user');
 const passwordController = require('../../../../lib/application/passwords/password-controller');
 const userService = require('../../../../lib/domain/services/user-service');

--- a/api/tests/unit/application/preHandlers/access-session_test.js
+++ b/api/tests/unit/application/preHandlers/access-session_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const AccessSession = require('../../../../lib/application/preHandlers/access-session');
 const SessionService = require('../../../../lib/domain/services/session-service');
 

--- a/api/tests/unit/application/preHandlers/assessment-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-authorization_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const AssessmentAuhorization = require('../../../../lib/application/preHandlers/assessment-authorization');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');

--- a/api/tests/unit/application/preHandlers/connected-user-verification_test.js
+++ b/api/tests/unit/application/preHandlers/connected-user-verification_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const ConnectedUserVerification = require('../../../../lib/application/preHandlers/connected-user-verification');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');

--- a/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const snapshotAuthorization = require('../../../../lib/application/preHandlers/snapshot-authorization');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');

--- a/api/tests/unit/application/preHandlers/user-existence-verification_test.js
+++ b/api/tests/unit/application/preHandlers/user-existence-verification_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const User = require('../../../../lib/infrastructure/data/user');
 const userVerification = require('../../../../lib/application/preHandlers/user-existence-verification');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');

--- a/api/tests/unit/application/qmail/qmail-controller_test.js
+++ b/api/tests/unit/application/qmail/qmail-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const AnswerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 const SolutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');
 const Answer = require('../../../../lib/infrastructure/data/answer');

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, expect, sinon, before, after } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const SessionController = require('../../../../lib/application/sessions/session-controller');
 

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1,5 +1,5 @@
 const Boom = require('boom');
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const logger = require('../../../../lib/infrastructure/logger');
 
 const sessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-serializer');

--- a/api/tests/unit/application/snapshots/index_test.js
+++ b/api/tests/unit/application/snapshots/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 
 const snapshotController = require('../../../../lib/application/snapshots/snapshot-controller');

--- a/api/tests/unit/application/snapshots/snapshot-controller_test.js
+++ b/api/tests/unit/application/snapshots/snapshot-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const profileService = require('../../../../lib/domain/services/profile-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const snapshotService = require('../../../../lib/domain/services/snapshot-service');

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const UserController = require('../../../../lib/application/users/user-controller');
 const userVerification = require('../../../../lib/application/preHandlers/user-existence-verification');

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -1,4 +1,4 @@
-const { describe, it, afterEach, beforeEach, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 
 const faker = require('faker');
 const User = require('../../../../lib/infrastructure/data/user');

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../test-helper');
+const { expect } = require('../../test-helper');
 const errors = require('../../../lib/domain/errors');
 
 describe('Unit | Domain | Errors', () => {

--- a/api/tests/unit/domain/models/assessment_test.js
+++ b/api/tests/unit/domain/models/assessment_test.js
@@ -1,5 +1,5 @@
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | Assessment', () => {
 

--- a/api/tests/unit/domain/models/challenge_test.js
+++ b/api/tests/unit/domain/models/challenge_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 const Skill = require('../../../../lib/domain/models/Skill');
 

--- a/api/tests/unit/domain/models/competence_test.js
+++ b/api/tests/unit/domain/models/competence_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const Competence = require('../../../../lib/domain/models/Competence');
 
 describe('Unit | Domain | Models | Competence', () => {

--- a/api/tests/unit/domain/models/course_test.js
+++ b/api/tests/unit/domain/models/course_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 const Course = require('../../../../lib/domain/models/Course');
 

--- a/api/tests/unit/domain/models/mark_test.js
+++ b/api/tests/unit/domain/models/mark_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const Mark = require('../../../../lib/domain/models/Mark');
 
 describe('Unit | Domain | Models | Mark', () => {

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const User = require('../../../../lib/infrastructure/data/user');
 const Profile = require('../../../../lib/domain/models/Profile');
 

--- a/api/tests/unit/domain/services/answer-service_test.js
+++ b/api/tests/unit/domain/services/answer-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const answerService = require('../../../../lib/domain/services/answer-service');
 
 const Bookshelf = require('../../../../lib/infrastructure/bookshelf');

--- a/api/tests/unit/domain/services/assessment-rating-service_test.js
+++ b/api/tests/unit/domain/services/assessment-rating-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const faker = require('faker');
 
 const service = require('../../../../lib/domain/services/assessment-rating-service');

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/assessment-service');
 const assessmentAdapter = require('../../../../lib/infrastructure/adapters/assessment-adapter');

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, beforeEach, afterEach, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const certificationChallengesService = require('../../../../lib/domain/services/certification-challenges-service');
 const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
 

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const certificationService = require('../../../../lib/domain/services/certification-service');
 const Answer = require('../../../../lib/infrastructure/data/answer');
 const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');

--- a/api/tests/unit/domain/services/challenge-service_test.js
+++ b/api/tests/unit/domain/services/challenge-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/challenge-service');
 const Answer = require('../../../../lib/infrastructure/data/answer');

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -5,7 +5,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 describe('Unit | Service | Course Service', () => {
 

--- a/api/tests/unit/domain/services/deactivations-service_test.js
+++ b/api/tests/unit/domain/services/deactivations-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/deactivations-service');
 

--- a/api/tests/unit/domain/services/email-validator_test.js
+++ b/api/tests/unit/domain/services/email-validator_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const service = require('../../../../lib/domain/services/email-validator');
 
 describe('Unit | Service | email-validator', function() {

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 
 const bcrypt = require('bcrypt');
 const encryptionService = require('../../../../lib/domain/services/encryption-service');

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const _ = require('lodash');
 const mailJet = require('../../../../lib/infrastructure/mailjet');
 const mailService = require('../../../../lib/domain/services/mail-service');

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const organizationService = require('../../../../lib/domain/services/organization-service');
 

--- a/api/tests/unit/domain/services/profile-completion-service_test.js
+++ b/api/tests/unit/domain/services/profile-completion-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const { getNumberOfFinishedTests } = require('../../../../lib/domain/services/profile-completion-service');
 
 describe('Unit | Service | profile number of finished tests service', function() {

--- a/api/tests/unit/domain/services/profile-service_test.js
+++ b/api/tests/unit/domain/services/profile-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 const faker = require('faker');
 

--- a/api/tests/unit/domain/services/qmail-validation-service_test.js
+++ b/api/tests/unit/domain/services/qmail-validation-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const qmailValidationService = require('../../../../lib/domain/services/qmail-validation-service');
 
 describe('Unit | Service | QMail Validation', function() {

--- a/api/tests/unit/domain/services/reset-password-service_test.js
+++ b/api/tests/unit/domain/services/reset-password-service_test.js
@@ -1,5 +1,5 @@
 const jsonwebtoken = require('jsonwebtoken');
-const { describe, it, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { sinon } = require('../../../test-helper');
 const settings = require('../../../../lib/settings');
 const resetPasswordService = require('../../../../lib/domain/services/reset-password-service');
 const resetPasswordRepository = require('../../../../lib/infrastructure/repositories/reset-password-demands-repository');

--- a/api/tests/unit/domain/services/session-service_test.js
+++ b/api/tests/unit/domain/services/session-service_test.js
@@ -1,4 +1,4 @@
-const { describe, context, it, expect, sinon, afterEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const session = require('../../../../lib/domain/services/session-service');
 
 describe('Unit | Service | session', () => {

--- a/api/tests/unit/domain/services/skills-service_test.js
+++ b/api/tests/unit/domain/services/skills-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Skill = require('../../../../lib/cat/skill');
 const skillsService = require('../../../../lib/domain/services/skills-service');
 const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');

--- a/api/tests/unit/domain/services/snapshot-service_test.js
+++ b/api/tests/unit/domain/services/snapshot-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const snapshotService = require('../../../../lib/domain/services/snapshot-service');
 const Snapshot = require('../../../../lib/infrastructure/data/snapshot');
 const snapshotRepository = require('../../../../lib/infrastructure/repositories/snapshot-repository');

--- a/api/tests/unit/domain/services/solution-service-function-match_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-match_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const service = require('../../../../lib/domain/services/solution-service');
 const serviceQcu = require('../../../../lib/domain/services/solution-service-qcu');
 const serviceQcm = require('../../../../lib/domain/services/solution-service-qcm');

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, knex, sinon } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service');
 const Answer = require('../../../../lib/infrastructure/data/answer');

--- a/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service');

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const service = require('../../../../lib/domain/services/solution-service-qcm');
 const Answer = require('../../../../lib/infrastructure/data/answer');

--- a/api/tests/unit/domain/services/solution-service-qcu_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcu_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qcu');

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qroc');

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qrocm-dep');

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qrocm-ind');

--- a/api/tests/unit/domain/services/solutions-service-utils_tests.js
+++ b/api/tests/unit/domain/services/solutions-service-utils_tests.js
@@ -1,4 +1,3 @@
-const { describe, it } = require('mocha');
 const { expect } = require('chai');
 const service = require('../../../../lib/domain/services/solution-service-utils');
 

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const User = require('../../../../lib/infrastructure/data/user');
 const { InvalidTemporaryKeyError } = require('../../../../lib/domain/errors');

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const Bookshelf = require('../../../../lib/infrastructure/bookshelf');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');

--- a/api/tests/unit/domain/services/validation-comparison_test.js
+++ b/api/tests/unit/domain/services/validation-comparison_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const { _getSmallestLevenshteinDistance, t3 } = require('../../../../lib/domain/services/validation-comparison');
 
 describe('Unit | Service | Validation Comparison', function() {

--- a/api/tests/unit/domain/services/validation-treatments_test.js
+++ b/api/tests/unit/domain/services/validation-treatments_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const { t1, t2, applyPreTreatments, applyTreatments } = require('../../../../lib/domain/services/validation-treatments');
 
 describe('Unit | Service | Validation Treatments', function() {

--- a/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 
 const Bookshelf = require('../../../../lib/infrastructure/bookshelf');
 const assessmentAdapter = require('../../../../lib/infrastructure/adapters/assessment-adapter');

--- a/api/tests/unit/infrastructure/converter/snapshots-csv-converter_test.js
+++ b/api/tests/unit/infrastructure/converter/snapshots-csv-converter_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const snapshotsConverter = require('../../../../lib/infrastructure/converter/snapshots-csv-converter');
 
 describe('Unit | Serializer | CSV | snapshots-converter', () => {

--- a/api/tests/unit/infrastructure/mailjet_test.js
+++ b/api/tests/unit/infrastructure/mailjet_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../test-helper');
+const { sinon, expect } = require('../../test-helper');
 const Mailjet = require('../../../lib/infrastructure/mailjet');
 
 const nodeMailjet = require('node-mailjet');

--- a/api/tests/unit/infrastructure/models/certification-course_test.js
+++ b/api/tests/unit/infrastructure/models/certification-course_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const BookshelfCertificationCourse = require('../../../../lib/infrastructure/data/certification-course');
 
 describe('Unit | Infrastructure | Models | BookshelfCertificationCourse', () => {

--- a/api/tests/unit/infrastructure/models/organization_test.js
+++ b/api/tests/unit/infrastructure/models/organization_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, knex } = require('../../../test-helper');
+const { expect, sinon, knex } = require('../../../test-helper');
 const faker = require('faker');
 
 const BookshelfOrganization = require('../../../../lib/infrastructure/data/organization');

--- a/api/tests/unit/infrastructure/models/session_test.js
+++ b/api/tests/unit/infrastructure/models/session_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 const BookshelfSession = require('../../../../lib/infrastructure/data/session');
 

--- a/api/tests/unit/infrastructure/models/user_test.js
+++ b/api/tests/unit/infrastructure/models/user_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const faker = require('faker');
 
 const BookshelfUser = require('../../../../lib/infrastructure/data/user');

--- a/api/tests/unit/infrastructure/plugins/metrics_test.js
+++ b/api/tests/unit/infrastructure/plugins/metrics_test.js
@@ -1,7 +1,7 @@
 const PROJECT_ROOT = '../../../..';
 const TESTS_ROOT = `${PROJECT_ROOT}/tests`;
 
-const { describe, it, expect } = require(`${TESTS_ROOT}/test-helper`);
+const { expect } = require(`${TESTS_ROOT}/test-helper`);
 const { EventEmitter } = require('events');
 const Metrics = require(`${PROJECT_ROOT}/lib/infrastructure/plugins/metrics`);
 

--- a/api/tests/unit/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/answer-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, knex, beforeEach, afterEach, sinon } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 
 const AnswerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
 const Answer = require('../../../../lib/infrastructure/data/answer');

--- a/api/tests/unit/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/area-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 

--- a/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, before, after, knex, sinon, beforeEach, afterEach } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const BookshelfAssessment = require('../../../../lib/infrastructure/data/assessment');

--- a/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach, knex } = require('../../../test-helper');
+const { expect, sinon, knex } = require('../../../test-helper');
 
 const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
 const CertificationChallengeBookshelf = require('../../../../lib/infrastructure/data/certification-challenge');

--- a/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, beforeEach, afterEach, it, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const CertificationCourseBookshelf = require('../../../../lib/infrastructure/data/certification-course');
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const cache = require('../../../../lib/infrastructure/cache');
 const airtable = require('../../../../lib/infrastructure/airtable');
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');

--- a/api/tests/unit/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/organization-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, knex, sinon } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 const faker = require('faker');
 const bcrypt = require('bcrypt');
 

--- a/api/tests/unit/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, beforeEach, afterEach, it, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const ResetPasswordDemandRepository = require('../../../../lib/infrastructure/repositories/reset-password-demands-repository');
 const ResetPasswordDemand = require('../../../../lib/infrastructure/data/reset-password-demand');
 const { PasswordResetDemandNotFoundError } = require('../../../../lib/domain/errors');

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const cache = require('../../../../lib/infrastructure/cache');
 const Bookshelf = require('../../../../lib/infrastructure/bookshelf');
 const DomainSkill = require('../../../../lib/domain/models/Skill');

--- a/api/tests/unit/infrastructure/repositories/snapshot-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/snapshot-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, beforeEach, afterEach, it, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const snapshotRepository = require('../../../../lib/infrastructure/repositories/snapshot-repository');
 const Snapshot = require('../../../../lib/infrastructure/data/snapshot');
 

--- a/api/tests/unit/infrastructure/repositories/solution-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/solution-repository_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, expect, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const airtable = require('../../../../lib/infrastructure/airtable');
 const cache = require('../../../../lib/infrastructure/cache');
 const solutionRepository = require('../../../../lib/infrastructure/repositories/solution-repository');

--- a/api/tests/unit/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/user-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, knex, describe, before, beforeEach, afterEach, sinon, after, it } = require('../../../test-helper');
+const { expect, knex, sinon } = require('../../../test-helper');
 const faker = require('faker');
 const bcrypt = require('bcrypt');
 

--- a/api/tests/unit/infrastructure/serializers/airtable/area-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/area-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/area-serializer');
 const Area = require('../../../../../lib/domain/models/Area');
 

--- a/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/challenge-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/challenge-serializer');
 
 describe('Unit | Serializer | challenge-serializer', function() {

--- a/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/competence-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/competence-serializer');
 const Area = require('../../../../../lib/domain/models/Area');
 

--- a/api/tests/unit/infrastructure/serializers/airtable/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/course-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/course-serializer');
 
 describe('Unit | Serializer | course-serializer', function() {

--- a/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable/solution-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/airtable/solution-serializer');
 
 describe('Unit | Serializer | solution-serializer', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/answer-serializer');
 const Answer = require('../../../../../lib/infrastructure/data/answer');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-rating-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-rating-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const AssessmentRating = require('../../../../../lib/domain/models/AssessmentRating');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/assessment-rating-serializer');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const Assessment = require('../../../../../lib/infrastructure/data/assessment');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/authentication-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/authentication-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/authentication-serializer');
 const Authentication = require('../../../../../lib/domain/models/Authentication');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-course-serializer');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
 const CertificationCourse = require('../../../../../lib/domain/models/CertificationCourse');

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
 const Challenge = require('../../../../../lib/domain/models/Challenge');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/course-serializer');
 const Course = require('../../../../../lib/domain/models/Course');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/feedback-serializer');
 
 describe('Unit | Serializer | JSONAPI | feedback-serializer', function() {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/follower-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/follower-serializer');
 const Follower = require('../../../../../lib/infrastructure/data/follower');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
 const Organization = require('../../../../../lib/infrastructure/data/organization');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/password-reset-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/password-reset-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/password-reset-serializer');
 
 describe('Unit | Serializer | JSONAPI | password-reset-serializer', function() {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/profile-serializer');
 const Profile = require('../../../../../lib/domain/models/Profile');
 const User = require('../../../../../lib/infrastructure/data/user');

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 
 const Session = require('../../../../../lib/domain/models/Session');

--- a/api/tests/unit/infrastructure/serializers/jsonapi/snapshot-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/snapshot-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/snapshot-serializer');
 
 describe('Unit | Serializer | JSONAPI | snapshot-serializer', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/solution-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/solution-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/solution-serializer');
 const Solution = require('../../../../../lib/domain/models/referential/solution');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const User = require('../../../../../lib/infrastructure/data/user');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/validation-error-serializer_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, before } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 
 const Bookshelf = require('../../../../../lib/infrastructure/bookshelf');

--- a/api/tests/unit/infrastructure/utils/bookshelf-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/bookshelf-utils_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, it, sinon } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const bookShelfUtils = require('../../../../lib/infrastructure/utils/bookshelf-utils');
 
 describe('Unit | Utils | Bookhelf utils', function() {

--- a/api/tests/unit/infrastructure/utils/lodash-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/lodash-utils_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const original_lodash = require('lodash');
 const _ = require('../../../../lib/infrastructure/utils/lodash-utils');
 

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -1,4 +1,4 @@
-const { expect, describe, it } = require('../../../test-helper');
+const { expect,  } = require('../../../test-helper');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 
 describe('Unit | Utils | Query Params Utils', function() {

--- a/api/tests/unit/infrastructure/validators/error_test.js
+++ b/api/tests/unit/infrastructure/validators/error_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const error = require('../../../../lib/infrastructure/validators/errors');
 
 describe('Unit | Validator | Errors', () => {

--- a/api/tests/unit/infrastructure/validators/grecaptcha-validator_test.js
+++ b/api/tests/unit/infrastructure/validators/grecaptcha-validator_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, sinon, beforeEach, afterEach, before, after } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const gRecaptcha = require('../../../../lib/infrastructure/validators/grecaptcha-validator');
 const { InvalidRecaptchaTokenError } = require('../../../../lib/infrastructure/validators/errors');
 const request = require('request');

--- a/api/tests/unit/infrastructure/validators/jsonwebtoken-verify_test.js
+++ b/api/tests/unit/infrastructure/validators/jsonwebtoken-verify_test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach, afterEach, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const jsonwebtoken = require('jsonwebtoken');
 const settings = require('../../../../lib/settings');
 const { InvalidTokenError } = require('../../../../lib/domain/errors');

--- a/api/tests/unit/infrastructure/validators/password-validator_test.js
+++ b/api/tests/unit/infrastructure/validators/password-validator_test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const isPasswordvalid = require('../../../../lib/infrastructure/validators/password-validator');
 
 describe('Unit | Validator | password-validator', function() {


### PR DESCRIPTION
L'objet de cette PR est de supprimer tous les imports de fonctions telles que `describe`, `it`, `beforeEach` etc. dans les tests de l'API car : 

- que ce soit dans NPM ou pour debugger dans l'IDE, on utilise forcément le binaire Mocha
- Mocha est déclaré en tant que dépendance d'environnement dans la config ESLint

À noter qu'il fallait penser à supprimer les exports "passe-plat" dans le module `api/tests/test-helper.js`