### PR TITLE
[#702] [BUGFIX] Correction des anciens assessments avec un pixScore à 0 (US-1115).

### DIFF
--- a/api/db/batchTreatment.js
+++ b/api/db/batchTreatment.js
@@ -1,0 +1,37 @@
+const BATCH_SIZE = 10;
+
+function batch(knex, elementsToUpdate, treatment) {
+
+  function _innerTreatment(knex, remainingElementsToUpdate, countOfBatches, batchesDone) {
+
+    if (remainingElementsToUpdate.length <= 0) {
+      return Promise.resolve()
+        .then(() => {
+          console.log(`-- ENDING - ${numberOfTotalBatches} iterations done\n`);
+        });
+    }
+
+    const assessments = remainingElementsToUpdate.splice(0, BATCH_SIZE);
+    const promises = assessments.map(treatment);
+
+    return Promise
+      .all(promises)
+      .then((results) => {
+        console.log(`---- Lot ${batchesDone} : ${results.length} processed - (total: ${countOfBatches} lots, ${batchesDone / countOfBatches * 100}%)`);
+      })
+      .then(() => _innerTreatment(knex, remainingElementsToUpdate, countOfBatches, batchesDone+1));
+  }
+
+  const numberOfTotalBatches = Math.ceil(elementsToUpdate.length / BATCH_SIZE);
+
+  return Promise
+    .resolve()
+    .then(() => {
+      console.log(`\n-- STARTING - Processing the data through ${numberOfTotalBatches} iterations`);
+    })
+    .then(() => _innerTreatment(knex, elementsToUpdate, numberOfTotalBatches, 0));
+}
+
+module.exports = {
+  batch
+};

--- a/api/db/migrations/20180306151846_add_type_to_all_assessments.js
+++ b/api/db/migrations/20180306151846_add_type_to_all_assessments.js
@@ -1,0 +1,100 @@
+const { batch } = require('../batchTreatment2')
+const TABLE_NAME_ASSESSMENTS = 'assessments';
+const TABLE_NAME_CERTIFICATIONS = 'certification-courses';
+const LIST_COMPETENCES_PLACEMENT = [
+  'recRlIVstCemVM8jE',
+  'recfLYUy8fYlcyAsl',
+  'recxlkyNjuu4cJuuF',
+  'recAY0W7xurA11OLZ',
+  'recRKkLdx99wfl3qs',
+  'recVtTay20uxEqubF',
+  'recye6vmFsi8ernH4',
+  'rec43mpMIR5dUzdjh',
+  'recTMfUJzFaNiUt64',
+  'recO1qH39C0IfggLZ',
+  'recNPB7dTNt5krlMA',
+  'recrJ90Sbrotzkb7x',
+  'rec5gEPqhxYjz15eI',
+  'recHOjJHVxjD8m9bz',
+  'recR9yCEqgedB0LYQ',
+  'recyochcrrSOALQPS'];
+const TYPE_PLACEMENT = 'PLACEMENT';
+const TYPE_CERTIFICATION = 'CERTIFICATION';
+const TYPE_DEMO = 'DEMO';
+const TYPE_PREVIEW = 'PREVIEW'; //null...
+
+exports.up = function(knex, Promise) {
+
+  // XXX : Modify PREVIEW assessments
+    return knex(TABLE_NAME_ASSESSMENTS)
+      .select('id', 'courseId', 'type')
+      .whereNull('type')
+      .where('courseId', 'LIKE', 'null%')
+      .then((allAssessmentsPreview) => {
+        return batch(knex, allAssessmentsPreview, (assessment) => {
+          return knex(TABLE_NAME_ASSESSMENTS)
+            .where('id', '=', assessment.id)
+            .update({
+              type: TYPE_PREVIEW
+            });
+        });
+
+      })
+      .then(() => {
+        // XXX : Modify PLACEMENT assessments
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .select('id', 'courseId', 'type')
+          .whereNull('type')
+          .where('courseId', 'IN', LIST_COMPETENCES_PLACEMENT);
+      })
+      .then((allAssessmentsPlacement) => {
+        return batch(knex, allAssessmentsPlacement, (assessment) => {
+          return knex(TABLE_NAME_ASSESSMENTS)
+            .where('id', '=', assessment.id)
+            .update({
+              type: TYPE_PLACEMENT
+            });
+        });
+
+      }).then(() => {
+        // XXX : Modify CERTIFICATION assessments
+        return knex(TABLE_NAME_CERTIFICATIONS)
+          .select('id');
+      }).then((allCertifications) => {
+        const certificationsId = allCertifications.map(certification => certification.id.toString());
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .select('id', 'courseId', 'type')
+          .whereNull('type')
+          .where('courseId', 'IN', certificationsId);
+      })
+      .then((allAssessmentsCertifications) => {
+        return batch(knex, allAssessmentsCertifications, (assessment) => {
+          return knex(TABLE_NAME_ASSESSMENTS)
+            .where('id', '=', assessment.id)
+            .update({
+              type: TYPE_CERTIFICATION
+            });
+        });
+
+      }).then(() => {
+        // XXX : Modify DEMO assessments
+
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .select('id', 'courseId', 'type')
+          .whereNull('type');
+      })
+      .then((allAssessmentsDemo) => {
+        return batch(knex, allAssessmentsDemo, (assessment) => {
+          return knex(TABLE_NAME_ASSESSMENTS)
+            .where('id', '=', assessment.id)
+            .update({
+              type: TYPE_DEMO
+            });
+        });
+
+      });
+
+};
+
+exports.down = function(knex, Promise) {
+};

--- a/api/db/migrations/20180306151846_add_type_to_all_assessments.js
+++ b/api/db/migrations/20180306151846_add_type_to_all_assessments.js
@@ -1,4 +1,4 @@
-const { batch } = require('../batchTreatment2')
+const { batch } = require('../batchTreatment');
 const TABLE_NAME_ASSESSMENTS = 'assessments';
 const TABLE_NAME_CERTIFICATIONS = 'certification-courses';
 const LIST_COMPETENCES_PLACEMENT = [
@@ -21,7 +21,7 @@ const LIST_COMPETENCES_PLACEMENT = [
 const TYPE_PLACEMENT = 'PLACEMENT';
 const TYPE_CERTIFICATION = 'CERTIFICATION';
 const TYPE_DEMO = 'DEMO';
-const TYPE_PREVIEW = 'PREVIEW'; //null...
+const TYPE_PREVIEW = 'PREVIEW';
 
 exports.up = function(knex, Promise) {
 

--- a/api/db/migrations/20180306164441_remove-score-and-level-for-bugged-assessments.js
+++ b/api/db/migrations/20180306164441_remove-score-and-level-for-bugged-assessments.js
@@ -1,0 +1,27 @@
+const { batch } = require('../batchTreatment');
+
+const TABLE_NAME_ASSESSMENTS = 'assessments';
+
+exports.up = function(knex, Promise) {
+  return knex(TABLE_NAME_ASSESSMENTS)
+    .select('id', 'estimatedLevel', 'pixScore', 'type')
+    .where('type', '=', 'PLACEMENT')
+    .where('pixScore', '=', '0')
+    .where('estimatedLevel', '>', '0')
+
+    .then((allAssessmentsWithBuggedScore) => {
+      return batch(knex, allAssessmentsWithBuggedScore, (assessment) => {
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .where('id', '=', assessment.id)
+          .update({
+            pixScore: null,
+            estimatedLevel: null,
+            updatedAt: knex.fn.now()
+          });
+      });
+    });
+};
+
+exports.down = function(knex, Promise) {
+
+};

--- a/api/db/seeds/data/assessments.js
+++ b/api/db/seeds/data/assessments.js
@@ -1,9 +1,8 @@
 module.exports = [
-  { id:1, courseId: 'recyochcrrSOALQPS', createdAt: '2018-02-15 14:59:35', updatedAt: '2018-02-15 14:59:35', userId: 1, estimatedLevel: null, pixScore: null, type: 'PLACEMENT' },
-  { id:2, courseId: 'rec43mpMIR5dUzdjh', createdAt: '2018-02-15 15:00:34', updatedAt: '2018-02-15 15:00:34', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
-  { id:3, courseId: 'recNPB7dTNt5krlMA', createdAt: '2018-02-15 15:03:18', updatedAt: '2018-02-15 15:03:18', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
-  { id:4, courseId: 'recR9yCEqgedB0LYQ', createdAt: '2018-02-15 15:04:26', updatedAt: '2018-02-15 15:04:26', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
-  { id:5, courseId: 'rec5gEPqhxYjz15eI', createdAt: '2018-02-15 15:07:02', updatedAt: '2018-02-15 15:07:02', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
+  { id:1, courseId: 'recyochcrrSOALQPS', createdAt: '2018-02-15 14:59:35', updatedAt: '2018-02-15 14:59:35', userId: 1, estimatedLevel: 5, pixScore: 44, type: 'PLACEMENT' },
+  { id:2, courseId: 'rec43mpMIR5dUzdjh', createdAt: '2018-02-15 15:00:34', updatedAt: '2018-02-15 15:00:34', userId: 1, estimatedLevel: 2, pixScore: 23, type:'PLACEMENT' },
+  { id:3, courseId: 'recNPB7dTNt5krlMA', createdAt: '2018-02-15 15:03:18', updatedAt: '2018-02-15 15:03:18', userId: 1, estimatedLevel: 5, pixScore: 47, type:'PLACEMENT' },
+  { id:4, courseId: 'recR9yCEqgedB0LYQ', createdAt: '2018-02-15 15:04:26', updatedAt: '2018-02-15 15:04:26', userId: 1, estimatedLevel: 4, pixScore: 34, type:'PLACEMENT' },
+  { id:5, courseId: 'rec5gEPqhxYjz15eI', createdAt: '2018-02-15 15:07:02', updatedAt: '2018-02-15 15:07:02', userId: 1, estimatedLevel: 5, pixScore: 48, type:'PLACEMENT' },
   { id:6, courseId: '1', createdAt: '2018-02-15 15:14:46', updatedAt: '2018-02-15 15:14:46', userId: 1, estimatedLevel: 0, pixScore: 157 , type:'CERTIFICATION' },
 ];
-

--- a/api/db/seeds/data/assessments.js
+++ b/api/db/seeds/data/assessments.js
@@ -1,9 +1,9 @@
 module.exports = [
-  { id:1, courseId: 'recyochcrrSOALQPS', createdAt: '2018-02-15 14:59:35', updatedAt: '2018-02-15 14:59:35', userId: 1, estimatedLevel: 5, pixScore: 44, type: 'PLACEMENT' },
-  { id:2, courseId: 'rec43mpMIR5dUzdjh', createdAt: '2018-02-15 15:00:34', updatedAt: '2018-02-15 15:00:34', userId: 1, estimatedLevel: 2, pixScore: 23, type:'PLACEMENT' },
-  { id:3, courseId: 'recNPB7dTNt5krlMA', createdAt: '2018-02-15 15:03:18', updatedAt: '2018-02-15 15:03:18', userId: 1, estimatedLevel: 5, pixScore: 47, type:'PLACEMENT' },
-  { id:4, courseId: 'recR9yCEqgedB0LYQ', createdAt: '2018-02-15 15:04:26', updatedAt: '2018-02-15 15:04:26', userId: 1, estimatedLevel: 4, pixScore: 34, type:'PLACEMENT' },
-  { id:5, courseId: 'rec5gEPqhxYjz15eI', createdAt: '2018-02-15 15:07:02', updatedAt: '2018-02-15 15:07:02', userId: 1, estimatedLevel: 5, pixScore: 48, type:'PLACEMENT' },
+  { id:1, courseId: 'recyochcrrSOALQPS', createdAt: '2018-02-15 14:59:35', updatedAt: '2018-02-15 14:59:35', userId: 1, estimatedLevel: null, pixScore: null, type: 'PLACEMENT' },
+  { id:2, courseId: 'rec43mpMIR5dUzdjh', createdAt: '2018-02-15 15:00:34', updatedAt: '2018-02-15 15:00:34', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
+  { id:3, courseId: 'recNPB7dTNt5krlMA', createdAt: '2018-02-15 15:03:18', updatedAt: '2018-02-15 15:03:18', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
+  { id:4, courseId: 'recR9yCEqgedB0LYQ', createdAt: '2018-02-15 15:04:26', updatedAt: '2018-02-15 15:04:26', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
+  { id:5, courseId: 'rec5gEPqhxYjz15eI', createdAt: '2018-02-15 15:07:02', updatedAt: '2018-02-15 15:07:02', userId: 1, estimatedLevel: null, pixScore: null, type:'PLACEMENT' },
   { id:6, courseId: '1', createdAt: '2018-02-15 15:14:46', updatedAt: '2018-02-15 15:14:46', userId: 1, estimatedLevel: 0, pixScore: 157 , type:'CERTIFICATION' },
 ];
 

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -7,7 +7,7 @@ class Assessment {
 
   isCompleted() {
     return Boolean(this.estimatedLevel && this.pixScore
-      || (this.estimatedLevel === 0));
+      || (this.estimatedLevel === 0)|| (this.pixScore === 0));
   }
 }
 

--- a/api/lib/domain/services/assessment-rating-service.js
+++ b/api/lib/domain/services/assessment-rating-service.js
@@ -90,10 +90,10 @@ function evaluateFromAssessmentId(assessmentId) {
 
     })
     .then((marks) => {
-
-      const totalPix = _(marks).map((mark) => mark.score).sum();
-      assessmentWithScore.pixScore = totalPix;
-
+      if(marks.length > 0) {
+        const totalPix = _(marks).map((mark) => mark.score).sum();
+        assessmentWithScore.pixScore = totalPix;
+      }
       return Promise.all(marks.map((mark) => markRepository.save(mark)));
     })
     .then(() => skillService.saveAssessmentSkills(evaluatedSkillsInAssessment))

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -7,7 +7,6 @@ function parseArgs(argv) {
   return args;
 }
 
-
 function buildRequestObject(baseUrl, assessmentId) {
   return {
     baseUrl: baseUrl,
@@ -33,20 +32,25 @@ function buildRequestObject(baseUrl, assessmentId) {
       },
   };
 }
-function makeRequest(config) {
-  return request(config);
-}
 
 function main() {
-
   const baseUrl = process.argv[2];
   const ids = parseArgs(process.argv);
   const requests = Promise.all(
     ids.map(id => buildRequestObject(baseUrl, id))
-      .map(requestObject => makeRequest(requestObject))
+      .map(requestObject => request(requestObject))
   );
 
-  requests.then(() => {console.log('OK')});
+  requests.then(() => {
+    console.log('Update EstimatedLevel and PixScore for : '+ids);
+  });
 }
 
+
 main();
+/*=================== tests =============================*/
+
+if (process.env.NODE_ENV !== 'test') {
+  console.log('Start script : ');
+  main();
+}

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -1,0 +1,52 @@
+#! /usr/bin/env node
+
+const request = require('request-promise-native');
+
+function parseArgs(argv) {
+  const [_a, _b, _c, ...args] = argv;
+  return args;
+}
+
+
+function buildRequestObject(baseUrl, assessmentId) {
+  return {
+    baseUrl: baseUrl,
+    method: 'POST',
+    url: `/api/assessment-ratings/`,
+    json: true,
+    body: {
+        data: {
+          attributes: {
+            'estimated-level': null,
+            'pix-score': null
+          },
+          relationships: {
+            assessment: {
+              data: {
+                type: 'assessments',
+                id: assessmentId
+              }
+            }
+          },
+          type: 'assessment-ratings'
+        }
+      },
+  };
+}
+function makeRequest(config) {
+  return request(config);
+}
+
+function main() {
+
+  const baseUrl = process.argv[2];
+  const ids = parseArgs(process.argv);
+  const requests = Promise.all(
+    ids.map(id => buildRequestObject(baseUrl, id))
+      .map(requestObject => makeRequest(requestObject))
+  );
+
+  requests.then(() => {console.log('OK')});
+}
+
+main();

--- a/api/tests/unit/domain/models/assessment_test.js
+++ b/api/tests/unit/domain/models/assessment_test.js
@@ -58,5 +58,17 @@ describe('Unit | Domain | Models | Assessment', () => {
       // then
       expect(isCompleted).to.be.true;
     });
+
+    it('should return true when pixScore is 0', () => {
+      // given
+      const assessment = new Assessment({ pixScore: 0, estimatedLevel: 1 });
+
+      // when
+      const isCompleted = assessment.isCompleted();
+
+      // then
+      expect(isCompleted).to.be.true;
+    });
+
   });
 });

--- a/api/tests/unit/domain/services/assessment-rating-service_test.js
+++ b/api/tests/unit/domain/services/assessment-rating-service_test.js
@@ -183,6 +183,29 @@ describe('Unit | Domain | Services | assessment-ratings', () => {
       });
     });
 
+    it('should save all assessment information even if there is no marks to saved', () => {
+      // given
+      const assessmentWithScoreWithoutType = new Assessment({
+        id: assessmentId,
+        courseId: assessmentCourseId,
+        userId: 5,
+        estimatedLevel: 2,
+        pixScore: 13,
+      });
+      assessmentService.fetchAssessment.resolves({
+        assessmentPix: assessmentWithScoreWithoutType,
+        skills: []
+      });
+
+      // when
+      const promise = service.evaluateFromAssessmentId(assessmentId);
+
+      // then
+      return promise.then(() => {
+        expect(assessmentRepository.save).to.have.been.calledWith(assessmentWithScoreWithoutType);
+      });
+    });
+
     context('when the assessment is a PLACEMENT', () => {
 
       it('should retrieve the course', () => {


### PR DESCRIPTION
Problème : 
D'anciens assessments (sans type) ont été fini récemment (après l'apparition des marks). Pour ceux-là, le pixScore est toujours à 0 alors que l'estimatedLevel est >0 (donc bien calculé).

Dans cet US : 
- Migration pour l'ajout du Type à tous les assessments qui n'en ont pas
- Migration pour remplacer les estimatedLevel et les pixScore à null pour les assessments qui posent problèmes. On change aussi l'updatedAt pour les différencier des assessments sans problèmes qui n'ont pas d'estimatedLevel/PixScore.

- Ajout d'un script qui ne fait qu'appeler la route /api/assessment-ratings pour calculer le résultat des assessements et l'enregistrer en base.

Modification des Seeds pour tester le scripts sur la RA.

